### PR TITLE
Fix prefix detection when tarball has ./ as first entry

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -79,7 +79,7 @@ def build_untar(tarball_path):
     if tarball_contents:
         tarball_prefix = tarball_contents.splitlines()[0].rsplit("/")[0]
         if tarball_prefix == ".":
-            tarball_prefix = tarball_contents.splitlines()[0].rsplit("/")[1]
+            tarball_prefix = tarball_contents.splitlines()[1].rsplit("/")[1]
     return extract_cmd, tarball_prefix
 
 


### PR DESCRIPTION
whan a tarball's first entry is ./ e.g:

tar -tf open-vm-tools-10.1.0-4449150.tar.gz
	./
	./open-vm-tools-10.1.0-4449150/
	./open-vm-tools-10.1.0-4449150/README.md
	./open-vm-tools-10.1.0-4449150/ReleaseNotes.md
	./open-vm-tools-10.1.0-4449150/open-vm-tools/

autospec  can not detect the tarball prefix and
fails with this error (mock build.log)

	Bad %setup option -n: missing argument

This patch fix this by using the second line
and the second split result