### PR TITLE
Remove config from lib dependencies

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -233,8 +233,8 @@ class Specfile(object):
         deps["dev"] = ["lib", "bin", "data"]
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
         deps["bin"] = ["data", "config", "setuid", "attr"]
-        deps["lib"] = ["data", "config"]
-        deps["lib32"] = ["data", "config"]
+        deps["lib"] = ["data"]
+        deps["lib32"] = ["data"]
         deps["python"] = ["legacypython"]
 
         provides = {}


### PR DESCRIPTION
The lib submodule requiring the config submodule was an artifact of
how autospec used to work before the stateless implementation in Clear
Linux. config is now mostly used for systemd configuration and unit
files which do not need to be pulled in for library use cases. So to
avoid having lib pull in systemd units that need the bin submodule,
stop having lib require config.