### PR TITLE
Remove asciidoc from failed_commands

### DIFF
--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -84,7 +84,6 @@ less, less
 pam_authenticate, Linux-PAM-dev
 vim, vim
 CLUTTER, clutter-dev
-asciidoc, asciidoc
 webp/decode.h, libwebp-dev
 inkscape, inkscape
 desktop-file-validate, desktop-file-utils


### PR DESCRIPTION
Asciidoc being in the configure log should not cause it to be added to
the build requires automatically. This is also intended to enable
asciidoc to be removed from use entirely.