### PR TITLE
Update unittests to run all from one command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,4 @@ python:
 # command to run tests
 script:
   - make check
-  - make test_pkg_integrity
-  - make test_tarball
-  - make test_specfile
-  - make test_abireport
-  - make test_commitmessage
-  - make test_files
-  - make test_license
-  - make test_buildpattern
-  - make test_build
-  - make test_buildreq
-  - make test_specdescription
-  - make test_count
-  - make test_test
-  - make test_util
+  - make unittests

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,4 @@ test_autospec:
 	python3 tests/test_autospec.py -c ${CASES}
 
 unittests:
-	for f in `ls tests/test_*.py | grep -v tests/test_autospec.py`; do \
-		echo ; echo $$f ; \
-		PYTHONPATH=${CURDIR}/autospec python3 $$f ; \
-	done
+	PYTHONPATH=${CURDIR}/autospec python3 -m unittest discover -b -s tests -p 'test_*.py'

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -463,10 +463,16 @@ def test_generator(line, expected):
     return test_parse_log
 
 
-if __name__ == "__main__":
+def test_setup():
     for i, pat in enumerate(pats):
         test_name = 'test_pat{}'.format(pat[0])
         test = test_generator(pat[0], pat[1])
         setattr(TestCount, test_name, test)
 
+
+# Run test_setup() to generate tests
+test_setup()
+
+
+if __name__ == "__main__":
     unittest.main(buffer=True)

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -35,6 +35,21 @@ def test_generator(url, name, version):
     return test_packageurl
 
 
+def test_setup():
+    global TestTarballVersionName
+    with open('tests/packageurls', 'r') as pkgurls:
+        for urlline in pkgurls.read().split('\n'):
+            if not urlline or urlline.startswith('#'):
+                continue
+
+            tarball.name = ''
+            tarball.version = ''
+            (url, name, version) = urlline.split(',')
+            test_name = 'test_pat_{}'.format(url)
+            test = test_generator(url, name, version)
+            setattr(TestTarballVersionName, test_name, test)
+
+
 class TestTarballVersionName(unittest.TestCase):
 
     def test_version_configuration_override(self):
@@ -201,17 +216,9 @@ GEM_OUT = '/path/to/dir/file1\n'                           \
           'Unpacked gem: \'/path/to/gem/test-prefix\''
 
 
+# Run test_setup to generate tests
+test_setup()
+
+
 if __name__ == '__main__':
-    with open('tests/packageurls', 'r') as pkgurls:
-        for urlline in pkgurls.read().split('\n'):
-            if not urlline or urlline.startswith('#'):
-                continue
-
-            tarball.name = ''
-            tarball.version = ''
-            (url, name, version) = urlline.split(',')
-            test_name = 'test_pat_{}'.format(url)
-            test = test_generator(url, name, version)
-            setattr(TestTarballVersionName, test_name, test)
-
     unittest.main(buffer=True)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -25,6 +25,7 @@ class TestTest(unittest.TestCase):
         test.tests_config = ''
         test.tarball.name = ''
         test.buildreq.buildreqs = set()
+        test.buildpattern.default_pattern = "make"
 
     def test_check_regression(self):
         """


### PR DESCRIPTION
This allows python3 unittest to properly generate the tests when running
all the tests in the tests directory.

Also adds a fix to test_test.py to reset buildpattern.default_pattern
every test. This was a bug introduced by running all tests at once -
this was not being cleared correctly.

Modifies .travis.yml to call make unittests instead of each test target individually.