### PR TITLE
Add "Dual" to license_blacklist

### DIFF
--- a/autospec/license_blacklist
+++ b/autospec/license_blacklist
@@ -82,3 +82,4 @@ Two-clause
 MIT/Expat
 Expat/MIT
 gpl
+Dual GPL/BSD/CPL


### PR DESCRIPTION
For "Dual GPL/BSD/CPL" in DAPL package.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>