### PR TITLE
Deprecate use of Python 3.6 style format strings

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -62,7 +62,7 @@ def really_download(upstream_url, destination):
         try:
             c.perform()
         except pycurl.error:
-            print_fatal(f"unable to download {upstream_url}")
+            print_fatal("unable to download {}".format(upstream_url))
             exit(1)
         finally:
             c.close()
@@ -89,8 +89,7 @@ def build_untar(tarball_path):
     except subprocess.CalledProcessError as cpe:
         file_type = subprocess.check_output(["file", tarball_path]).decode("utf-8").strip()
         print_fatal("tarball inspection failed, unable to determine tarball contents:\n"
-                    f"{file_type}\n"
-                    f"{cpe}\n")
+                    "{}\n{}\n".format(file_type, cpe))
         exit(1)
 
     extract_cmd = "tar --directory={0} -xf {1}".format(build.base_path, tarball_path)


### PR DESCRIPTION
Several platforms are using Python 3.5 or lower. Replace the new f"..."
style strings with the traditional "...".format() style strings.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

Fixes #22 