### PR TITLE
Allow manual override of requires

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -72,7 +72,7 @@ def add_buildreq(req):
     return new
 
 
-def add_requires(req):
+def add_requires(req, override=False):
     """
     Add req to the global requires set if it is present in buildreqs and
     os_packages and is not banned.
@@ -84,7 +84,7 @@ def add_requires(req):
         new = False
     if req in banned_requires:
         return False
-    if req not in buildreqs and req not in config.os_packages:
+    if req not in buildreqs and req not in config.os_packages and not override:
         if req:
             print("requirement '{}' not found is buildreqs or os_packages, skipping".format(req))
         return False

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -577,7 +577,7 @@ def parse_config_files(path, bump, filemanager):
     content = read_conf_file(os.path.join(path, "requires_add"))
     for extra in content:
         print("Adding additional runtime requirement: %s." % extra)
-        buildreq.add_requires(extra)
+        buildreq.add_requires(extra, override=True)
 
     content = read_conf_file(os.path.join(path, "excludes"))
     for exclude in content:


### PR DESCRIPTION
Allow developers to specify Requres that will not be dropped during
existence detection normally done for auto-detecting runtime
requirements.