### PR TITLE
font-adobe name and version detection

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -232,6 +232,8 @@ def name_and_version(name_arg, version_arg, filemanager):
     pattern_options = [
         r"(.*?)[\-_](v*[0-9]+[a-zalpha\+_spbfourcesigedsvstableP0-9\.\-\~]*)\.orig\.tar",
         r"(.*?)[\-_](v*[0-9]+[alpha\+_spbfourcesigedsvstableP0-9\.\-\~]*)\.src\.(tgz|tar|zip)",
+        # handle font packages with names ending in -nnndpi
+        r"(.*-[0-9]+dpi)[\-_](v*[0-9]+[alpha\+_sbpfourcesigedsvstableP0-9\.\-\~]*)\.(tgz|tar|zip)",
         r"(.*?)[\-_](v*[0-9]+[alpha\+_sbpfourcesigedsvstableP0-9\.\-\~]*)\.(tgz|tar|zip)",
         r"(.*?)[\-_](v*[0-9]+[\+_spbfourcesigedsvstableP0-9\.\~]*)(-.*?)?\.tar",
     ]

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -179,3 +179,5 @@ https://github.com/ocaml/ocamlbuild/archive/0.11.0.tar.gz,ocamlbuild,0.11.0
 https://github.com/kubernetes/kubernetes/archive/v1.7.0-alpha.0.tar.gz,kubernetes,1.7.0.alpha.0
 https://github.com/commercialhaskell/stack/releases/download/v1.4.0/stack-1.4.0-sdist-4.tar.gz,stack,1.4.0.sdist.4
 https://github.com/commercialhaskell/stack/releases/download/v1.5.0/stack-1.5.0-linux-x86_64.tar.gz,stack,1.5.0
+https://www.x.org/releases/individual/font/font-adobe-75dpi-1.0.3.tar.bz2,font-adobe-75dpi,1.0.3
+https://www.x.org/releases/individual/font/font-adobe-100dpi-1.0.3.tar.bz2,font-adobe-100dpi,1.0.3


### PR DESCRIPTION
Adobe font packages have -nndpi as part of the name. Add tests and a
regular expression to capture these.

Skip some debian pkg_integrity tests since debian is down and we shouldn't be relying on network for unit tests anyways.

Fixes #28 