### PR TITLE
Metadata

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -268,11 +268,27 @@ failed_pats = [
      r"available", 0, 'maven')]
 
 
+def get_metadata_conf():
+    """
+    gather package metadata from the tarball module
+    """
+    metadata = {}
+    metadata['name'] = tarball.name
+    metadata['url'] = tarball.url
+    metadata['archives'] = ' '.join(tarball.archives)
+    return metadata
+
+
 def create_conf(path):
     """
     Create options.conf file. Use deprecated configuration files or defaults to populate
     """
     config_f = configparser.ConfigParser(allow_no_value=True)
+
+    # first the metadata
+    config_f['package'] = get_metadata_conf()
+
+    # next the options
     config_f['autospec'] = {}
     for fname, comment in sorted(config_options.items()):
         config_f.set('autospec', '# {}'.format(comment))
@@ -326,6 +342,7 @@ def rewrite_config_opts(path):
     Rewrite options.conf file when an option has changed (verify_required for example)
     """
     config_f = configparser.ConfigParser(allow_no_value=True)
+    config_f['package'] = get_metadata_conf()
     config_f['autospec'] = {}
 
     # Populate missing configuration options

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import pycurl
+import configparser
 
 import build
 import buildpattern
@@ -175,11 +176,28 @@ def print_header():
 def download_tarball(target_dir):
     """
     Download tarball at url (global) to target_dir
-    """
-    global gcov_file
 
+    priority for target directory:
+    - target_dir set from args
+    - current directory if options.conf['package'] exists and
+      any of the options match what has been detected.
+    - curdir/name
+    """
     tarfile = os.path.basename(url)
-    build.download_path = target_dir if target_dir else os.path.join(os.getcwd(), name)
+    target = os.path.join(os.getcwd(), name)
+    if os.path.exists(os.path.join(os.getcwd(), 'options.conf')):
+        config_f = configparser.ConfigParser()
+        config_f.read('options.conf')
+        if "package" in config_f.sections():
+            if (config_f["package"].get("name") == name or
+                    config_f["package"].get("url") == url or
+                    config_f["package"].get("archives") == " ".join(archives)):
+                target = os.getcwd()
+
+    if target_dir:
+        target = target_dir
+
+    build.download_path = target
     call("mkdir -p {}".format(build.download_path))
 
     # locate the tarball locally or download
@@ -451,10 +469,12 @@ def process(url_arg, name_arg, ver_arg, target, archives_arg, filemanager):
     version = ver_arg
     archives = archives_arg
     tarfile = os.path.basename(url_arg)
-    # set gcov file information
-    set_gcov()
     # determine name and version of package
     name_and_version(name_arg, ver_arg, filemanager)
+    # set gcov file information, must be done after name is set since the gcov
+    # name is created by adding ".gcov" to the package name (if a gcov file
+    # exists)
+    set_gcov()
     # download the tarball to tar_path
     tar_path = download_tarball(target)
     # write the sha of the upstream tarfile to the "upstream" file

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -38,6 +38,7 @@ url = ""
 path = ""
 tarball_prefix = ""
 gcov_file = ""
+archives = []
 
 
 def get_sha1sum(filename):
@@ -435,7 +436,7 @@ def process_archives(archives):
         write_upstream(sha1, os.path.basename(archive), mode="a")
 
 
-def process(url_arg, name_arg, ver_arg, target, archives, filemanager):
+def process(url_arg, name_arg, ver_arg, target, archives_arg, filemanager):
     """
     Download and process the tarball at url_arg
     """
@@ -444,9 +445,11 @@ def process(url_arg, name_arg, ver_arg, target, archives, filemanager):
     global version
     global path
     global tarball_prefix
+    global archives
     url = url_arg
     name = name_arg
     version = ver_arg
+    archives = archives_arg
     tarfile = os.path.basename(url_arg)
     # set gcov file information
     set_gcov()
@@ -463,11 +466,12 @@ def process(url_arg, name_arg, ver_arg, target, archives, filemanager):
     # Now that the metadata has been collected print the header
     print_header()
     # write out the Makefile with the name, url, and archives we found
-    write_makefile(archives)
+    # DEPRECATED, this will be removed in a future version
+    write_makefile(archives_arg)
     # prepare directory and extract tarball
     prepare_and_extract(extract_cmd)
     # locate or download archives and move them into the right spot
-    process_archives(archives)
+    process_archives(archives_arg)
 
 
 def load_specfile(specfile):


### PR DESCRIPTION
Deprecate writing to a Makefile in the package directory and write to
the options.conf file instead. Any other infrastructure that needs a
Makefile should write it itself.

Instead of requiring the url argument and guessing where to put the
results from an autospec run, read metadata from options.conf. The
'package' section in options.conf defines the package name, url, and
archives when available.

If options.conf is present and there is at least one match between
detected metadata from the source tarball and the metadata in the
configuration, assume that the target directory is the current
directory. This is overridable with the -t/--target option. If nothing
matches the target directory is <current_dir>/<package_name>.

This functionality allows user to run autospec within the target
directory without passing any arguments, including the previously
required "url" argument if the metadata is present.