### PR TITLE
pkg_integrity: handle domain verification for ftp.gnome.org

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -235,7 +235,7 @@ def get_signature_url(package_url):
 
 
 def get_hash_url(package_url):
-    if 'download.gnome.org' in package_url:
+    if 'download.gnome.org' in package_url or 'ftp.gnome.org' in package_url:
         return package_url.replace('.tar.xz', '.sha256sum')
     return None
 
@@ -715,7 +715,7 @@ def attempt_verification_per_domain(package_path, url):
     netloc = urlparse(url).netloc
     if 'pypi' in netloc:
         domain = 'pypi'
-    elif 'download.gnome.org' in netloc:
+    elif 'download.gnome.org' in netloc or 'ftp.gnome.org' in netloc:
         domain = 'gnome.org'
     else:
         domain = 'unknown'


### PR DESCRIPTION
Some gnome integrity verification (sha256sum based) do the following
format: `<project>-<version>.sha256sum`. This verification is handled
correctly by autospec for the download.gnome.org domain, but it misses
the ftp.gnome.org domain, failing the verification when using ftp
subdomain.

This commit adds the handling of the ftp.gnome.org subdomain into the
gnome pattern.

Fixes #37.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>