### PR TITLE
Change how to decide whether use sudo or not with mock

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -35,7 +35,6 @@ must_restart = 0
 base_path = None
 output_path = None
 download_path = None
-mock_cmd = '/usr/bin/mock'
 uniqueext = ''
 
 
@@ -195,19 +194,19 @@ def get_uniqueext(dirn, dist, name):
     return "{}-{}".format(name, seq)
 
 
-def set_mock():
-    global mock_cmd
+def get_mock_cmd():
     # Some distributions (e.g. Fedora) use consolehelper to run mock,
     # while others (e.g. Clear Linux) expect the user run it via sudo.
-    if not (os.path.basename(os.path.realpath('/usr/bin/mock')) == 'consolehelper'):
-        mock_cmd = 'sudo /usr/bin/mock'
+    if os.path.basename(os.path.realpath('/usr/bin/mock')) == 'consolehelper':
+        return '/usr/bin/mock'
+    return 'sudo /usr/bin/mock'
 
 
 def package(filemanager, cleanup=False):
     global round
     global uniqueext
     round = round + 1
-    set_mock()
+    mock_cmd = get_mock_cmd()
     print("Building package " + tarball.name + " round", round)
 
     # determine uniqueext only once

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -23,7 +23,6 @@ import buildreq
 import re
 import tarball
 import os
-import grp
 import shutil
 import subprocess
 
@@ -198,11 +197,10 @@ def get_uniqueext(dirn, dist, name):
 
 def set_mock():
     global mock_cmd
-    # get group list of current user
-    user_grps = [grp.getgrgid(g).gr_name for g in os.getgroups()]
-    if os.path.exists('/usr/bin/mock'):
-        if 'mock' not in user_grps:
-            mock_cmd = 'sudo /usr/bin/mock'
+    # Some distributions (e.g. Fedora) use consolehelper to run mock,
+    # while others (e.g. Clear Linux) expect the user run it via sudo.
+    if not (os.path.basename(os.path.realpath('/usr/bin/mock')) == 'consolehelper'):
+        mock_cmd = 'sudo /usr/bin/mock'
 
 
 def package(filemanager, cleanup=False):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,7 +25,6 @@ class TestBuildpattern(unittest.TestCase):
         build.base_path = None
         build.output_path = None
         build.download_path = None
-        build.mock_cmd = '/usr/bin/mock'
         build.buildreq.buildreqs = set()
         build.config.config_opts['32bit'] = False
 
@@ -318,9 +317,9 @@ class TestBuildpattern(unittest.TestCase):
         self.assertIn('testpkg-python', build.buildreq.buildreqs)
         self.assertEqual(build.must_restart, 1)
 
-    def test_set_mock_without_consolehelper(self):
+    def test_get_mock_cmd_without_consolehelper(self):
         """
-        Test set_mock when /usr/bin/mock doesn't point to consolehelper
+        Test get_mock_cmd when /usr/bin/mock doesn't point to consolehelper
         """
         def mock_realpath(path):
             return path
@@ -329,15 +328,15 @@ class TestBuildpattern(unittest.TestCase):
 
         build.os.path.realpath = mock_realpath
 
-        build.set_mock()
+        mock_cmd = build.get_mock_cmd()
 
         build.os.path.realpath = realpath_backup
 
-        self.assertEqual(build.mock_cmd, 'sudo /usr/bin/mock')
+        self.assertEqual(mock_cmd, 'sudo /usr/bin/mock')
 
-    def test_set_mock_with_consolehelper(self):
+    def test_get_mock_cmd_with_consolehelper(self):
         """
-        Test set_mock when /usr/bin/mock points to consolehelper
+        Test get_mock_cmd when /usr/bin/mock points to consolehelper
         """
         def mock_realpath(path):
             return '/usr/bin/consolehelper'
@@ -346,11 +345,11 @@ class TestBuildpattern(unittest.TestCase):
 
         build.os.path.realpath = mock_realpath
 
-        build.set_mock()
+        mock_cmd = build.get_mock_cmd()
 
         build.os.path.realpath = realpath_backup
 
-        self.assertEqual(build.mock_cmd, '/usr/bin/mock')
+        self.assertEqual(mock_cmd, '/usr/bin/mock')
 
     def test_get_uniqueext_first(self):
         """

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -318,63 +318,37 @@ class TestBuildpattern(unittest.TestCase):
         self.assertIn('testpkg-python', build.buildreq.buildreqs)
         self.assertEqual(build.must_restart, 1)
 
-    def test_set_mock(self):
+    def test_set_mock_without_consolehelper(self):
         """
-        Test set_mock when user is not in the mock group
+        Test set_mock when /usr/bin/mock doesn't point to consolehelper
         """
-        class mock_getgrgid(object):
-            def __init__(self, g):
-                self.gr_name = 'not_mock'
+        def mock_realpath(path):
+            return path
 
-        def mock_getgroups():
-            return ['gr1', 'gr2', 'gr3']
+        realpath_backup = build.os.path.realpath
 
-        def mock_exists(path):
-            return True
-
-        getgrgid_backup = build.grp.getgrgid
-        getgroups_backup = build.os.getgroups
-        exists_backup = build.os.path.exists
-
-        build.grp.getgrgid = mock_getgrgid
-        build.os.getgroups = mock_getgroups
-        build.os.path.exists = mock_exists
+        build.os.path.realpath = mock_realpath
 
         build.set_mock()
 
-        build.grp.getgrgid = getgrgid_backup
-        build.os.getgroups = getgroups_backup
-        build.os.path.exists = exists_backup
+        build.os.path.realpath = realpath_backup
 
         self.assertEqual(build.mock_cmd, 'sudo /usr/bin/mock')
 
-    def test_set_mock_user_in_mock_group(self):
+    def test_set_mock_with_consolehelper(self):
         """
-        Test set_mock when user is in the mock group
+        Test set_mock when /usr/bin/mock points to consolehelper
         """
-        class mock_getgrgid(object):
-            def __init__(self, g):
-                self.gr_name = 'mock'
+        def mock_realpath(path):
+            return '/usr/bin/consolehelper'
 
-        def mock_getgroups():
-            return ['gr1', 'gr2', 'gr3']
+        realpath_backup = build.os.path.realpath
 
-        def mock_exists(path):
-            return True
-
-        getgrgid_backup = build.grp.getgrgid
-        getgroups_backup = build.os.getgroups
-        exists_backup = build.os.path.exists
-
-        build.grp.getgrgid = mock_getgrgid
-        build.os.getgroups = mock_getgroups
-        build.os.path.exists = mock_exists
+        build.os.path.realpath = mock_realpath
 
         build.set_mock()
 
-        build.grp.getgrgid = getgrgid_backup
-        build.os.getgroups = getgroups_backup
-        build.os.path.exists = exists_backup
+        build.os.path.realpath = realpath_backup
 
         self.assertEqual(build.mock_cmd, '/usr/bin/mock')
 


### PR DESCRIPTION
Instead of peeking at group membership, check if /usr/bin/mock points to consolehelper.

I've kept the "refactor" change in a separate patch, so it is easy to drop it if not desired.