### PR TITLE
specfiles: Quote filenames

### DIFF
--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -343,15 +343,21 @@ class TestSpecfileWrite(unittest.TestCase):
         """
         test write_files base test.
         """
-        self.specfile.packages["main"] = ["mainfile1", "mainfile2", "mainfile3"]
+        self.specfile.packages["main"] = ["mainfile1", "/mainfile2", "/mainfile3",
+                "/mainfile 4", "mainfile\t5", "%foo /mainfile6", "%bar /mainfile 7"]
         self.specfile.packages["ignore"] = ["ignorepkg"]
         self.specfile.packages["other"] = ["other2", "other1"]
         self.specfile.write_files()
+        # Note the special sorting
         expect = ["\n%files\n",
                   "%defattr(-,root,root,-)\n",
+                  '%bar "/mainfile 7"\n',
+                  "%foo /mainfile6\n",
+                  '"/mainfile 4"\n',
+                  "/mainfile2\n",
+                  "/mainfile3\n",
+                  '"mainfile\t5"\n',
                   "mainfile1\n",
-                  "mainfile2\n",
-                  "mainfile3\n",
                   "\n%files other\n",
                   "%defattr(-,root,root,-)\n",
                   "other1\n",


### PR DESCRIPTION
In `%files` sections, double-quote all filenames. Use assumption that all
filenames have a leading slash to detect and separate any macro
prefixes.

This should permit filenames with spaces or other special characters
that otherwise trip up rpmbuild

Fixes #32.

Signed-off-by: Brett T. Warden <brett.t.warden@intel.com>