### PR TITLE
Add --prep-only option to run preparatory work only

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -116,6 +116,28 @@ def read_old_metadata():
             archives)
 
 
+def write_prep(workingdir):
+    """
+    Write metadata to the local workingdir when --prep-only is used
+    """
+    if config.urlban:
+        used_url = re.sub(config.urlban, "localhost", tarball.url)
+    else:
+        used_url = tarball.url
+
+    print()
+    print("Exiting after prep due to --prep-only flag")
+    print()
+    print("Results under ./workingdir")
+    print("Source  (./workingdir/{})".format(tarball.tarball_prefix))
+    print("Name    (./workingdir/name)    :", tarball.name)
+    print("Version (./workingdir/version) :", tarball.version)
+    print("URL     (./workingdir/source0) :", used_url)
+    write_out(os.path.join(workingdir, "name"), tarball.name)
+    write_out(os.path.join(workingdir, "version"), tarball.version)
+    write_out(os.path.join(workingdir, "source0"), used_url)
+
+
 def main():
     """
     Main function for autospec
@@ -197,20 +219,6 @@ def package(args, url, name, archives, workingdir):
     tarball.process(url, name, args.version, args.target, archives, filemanager)
     _dir = tarball.path
 
-    if args.prep_only:
-        print()
-        print("Exiting after prep due to --prep-only flag")
-        print()
-        print("Results under ./workingdir")
-        print("Source  (./workingdir/{})".format(tarball.tarball_prefix))
-        print("Name    (./workingdir/name)    :", tarball.name)
-        print("Version (./workingdir/version) :", tarball.version)
-        print("URL     (./workingdir/source0) :", tarball.url)
-        write_out(os.path.join(workingdir, "name"), tarball.name)
-        write_out(os.path.join(workingdir, "version"), tarball.version)
-        write_out(os.path.join(workingdir, "source0"), tarball.url)
-        exit(0)
-
     if args.license_only:
         try:
             with open(os.path.join(build.download_path,
@@ -227,6 +235,10 @@ def package(args, url, name, archives, workingdir):
     config.config_file = args.config
     config.parse_config_files(build.download_path, args.bump, filemanager)
     config.parse_existing_spec(build.download_path, tarball.name)
+
+    if args.prep_only:
+        write_prep(workingdir)
+        exit(0)
 
     buildreq.set_build_req()
     buildreq.scan_for_configure(_dir)

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -153,6 +153,9 @@ def main():
                         default=False,
                         help="Search for package signature from source URL and "
                              "attempt to verify package")
+    parser.add_argument("-p", "--prep-only", action="store_true",
+                        default=False,
+                        help="Only perform preparatory work on package")
     parser.add_argument("--non_interactive", action="store_true",
                         default=False,
                         help="Disable interactive mode for package verification")
@@ -175,6 +178,14 @@ def main():
             "-a/--archives or options.conf['package']['archives'] requires an "
             "even number of arguments"))
 
+    if args.prep_only:
+        package(args, url, name, archives, "./workingdir")
+    else:
+        with tempfile.TemporaryDirectory() as workingdir:
+            package(args, url, name, archives, workingdir)
+
+
+def package(args, url, name, archives, workingdir):
     check_requirements(args.git)
     build.setup_workingdir(workingdir)
 
@@ -185,6 +196,11 @@ def main():
     filemanager = files.FileManager()
     tarball.process(url, name, args.version, args.target, archives, filemanager)
     _dir = tarball.path
+
+    if args.prep_only:
+        print("Exiting after prep due to --prep-only flag")
+        print("Results under './workingdir'")
+        exit(0)
 
     if args.license_only:
         try:
@@ -268,5 +284,4 @@ def main():
 
 
 if __name__ == '__main__':
-    with tempfile.TemporaryDirectory() as workingdir:
-        main()
+    main()

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -198,8 +198,17 @@ def package(args, url, name, archives, workingdir):
     _dir = tarball.path
 
     if args.prep_only:
+        print()
         print("Exiting after prep due to --prep-only flag")
-        print("Results under './workingdir'")
+        print()
+        print("Results under ./workingdir")
+        print("Source  (./workingdir/{})".format(tarball.tarball_prefix))
+        print("Name    (./workingdir/name)    :", tarball.name)
+        print("Version (./workingdir/version) :", tarball.version)
+        print("URL     (./workingdir/source0) :", tarball.url)
+        write_out(os.path.join(workingdir, "name"), tarball.name)
+        write_out(os.path.join(workingdir, "version"), tarball.version)
+        write_out(os.path.join(workingdir, "source0"), tarball.url)
         exit(0)
 
     if args.license_only:

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -33,18 +33,15 @@ success = 0
 round = 0
 must_restart = 0
 base_path = None
-output_path = None
 download_path = None
 uniqueext = ''
 
 
 def setup_workingdir(workingdir):
     global base_path
-    global output_path
     global download_path
     base_path = workingdir
-    output_path = os.path.join(base_path, "output")
-    download_path = os.path.join(output_path, tarball.name)
+    download_path = os.path.join(base_path, tarball.name)
 
 
 def simple_pattern_pkgconfig(line, pattern, pkgconfig):

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -454,7 +454,7 @@ def prepare_and_extract(extract_cmd):
     """
     shutil.rmtree(os.path.join(build.base_path, name), ignore_errors=True)
     shutil.rmtree(os.path.join(build.base_path, tarball_prefix), ignore_errors=True)
-    os.makedirs("{}".format(build.output_path), exist_ok=True)
+    os.makedirs("{}".format(build.base_path), exist_ok=True)
     call("mkdir -p %s" % build.download_path)
     call(extract_cmd)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,7 +23,6 @@ class TestBuildpattern(unittest.TestCase):
         build.round = 0
         build.must_restart = 0
         build.base_path = None
-        build.output_path = None
         build.download_path = None
         build.buildreq.buildreqs = set()
         build.config.config_opts['32bit'] = False
@@ -35,9 +34,7 @@ class TestBuildpattern(unittest.TestCase):
         build.tarball.name = "testtarball"
         build.setup_workingdir("test_directory")
         self.assertEqual(build.base_path, "test_directory")
-        self.assertEqual(build.output_path, "test_directory/output")
-        self.assertEqual(build.download_path,
-                         "test_directory/output/testtarball")
+        self.assertEqual(build.download_path, "test_directory/testtarball")
 
     def test_simple_pattern_pkgconfig(self):
         """


### PR DESCRIPTION
For non-autospec enabled packages this option can be used to download
the upstream tarball, any specified archives, extract them and put the
archives at their destination, and update the upstream file, but not
actually attempt to build a specfile.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>