### PR TITLE
Ignore bare excepts with flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 check: autospec/*.py
-	@flake8 --max-line-length=199 --ignore=E402 $^
+	@flake8 --max-line-length=199 --ignore=E722 $^
 
 test_pkg_integrity:
 	PYTHONPATH=${CURDIR}/autospec python3 tests/test_pkg_integrity.py


### PR DESCRIPTION
The previous ignore, import not at top of file (E402) was unneeded. Bare
excepts are handy when we want to fail gracefully from any error. This
is a script, not an imported library.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>