### PR TITLE
Fix formatting --target option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Usage: ``python3 autospec.py [options] URL``
 -l, --license-only                              Only scan for license files
 -b, --skip-bump                                 Don't bump release number
 -c CONFIG, --config CONFIG                      Set configuration file to use
--t DIRECTORY --target DIRECTORY                 Set location to create or use
+-t DIRECTORY, --target DIRECTORY                Set location to create or use
 
 
 


### PR DESCRIPTION
Add missing comma to --target help text, fixing formatting to match previous command-line options.