### PR TITLE
Match additional github URL patterns

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -340,7 +340,12 @@ def name_and_version(name_arg, version_arg, filemanager):
             m = re.search(pattern, url)
             if m:
                 repo = m.group(2).strip()
-                name = repo
+                if repo not in name:
+                    # Only take the repo name as the package name if it's more descriptive
+                    name = repo
+                elif name != repo:
+                    name = re.sub("release-", '', name)
+                    name = re.sub("\d*$", '', name)
                 rawname = name
                 version = convert_version(m.group(3))
                 giturl = "https://github.com/" + m.group(1).strip() + "/" + repo + ".git"

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -284,6 +284,7 @@ def name_and_version(name_arg, version_arg, filemanager):
     global version
     global url
     global giturl
+    global repo
 
     tarfile = os.path.basename(url)
 
@@ -338,10 +339,11 @@ def name_and_version(name_arg, version_arg, filemanager):
         for pattern in github_patterns:
             m = re.search(pattern, url)
             if m:
-                name = m.group(2).strip()
+                repo = m.group(2).strip()
+                name = repo
                 rawname = name
                 version = convert_version(m.group(3))
-                giturl = "https://github.com/" + m.group(1).strip() + "/" + name + ".git"
+                giturl = "https://github.com/" + m.group(1).strip() + "/" + repo + ".git"
                 break
 
     if "mirrors.kernel.org" in url:

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -332,7 +332,8 @@ def name_and_version(name_arg, version_arg, filemanager):
         github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/[v|r]?.*/(.*).tar",
                            r"https?://github.com/(.*)/(.*?)/archive/[-a-zA-Z]*-(.*).tar",
                            r"https?://github.com/(.*)/(.*?)/archive/[vVrR]?(.*).tar",
-                           r"https?://github.com/(.*)/(.*?)/releases/download/v.*/(.*).tar"]
+                           r"https?://github.com/(.*)/(.*?)/releases/download/.*?/(.*).tar",
+                           r"https?://github.com/(.*)/(.*?)/files/.*?/(.*).tar"]
 
         for pattern in github_patterns:
             m = re.search(pattern, url)

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -34,9 +34,11 @@ def test_generator(url, name, version):
         self.assertEqual(name, tarball.name)
         self.assertEqual(version, tarball.version)
         if re.match("https?://github.com", url) != None:
+            self.assertIsNotNone(tarball.giturl)
+            self.assertNotEqual('', tarball.giturl, "giturl should not be empty")
             self.assertIsNotNone(
                     re.match("https://github.com/[^/]+/"+tarball.repo+".git",
-                    tarball.giturl))
+                    tarball.giturl), "%s looks incorrect" % tarball.giturl)
 
     return test_packageurl
 

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -31,11 +31,11 @@ def test_generator(url, name, version):
         tarball.giturl = ''
         tarball.url = url
         tarball.name_and_version('', '', FileManager())
-        self.assertEqual(tarball.name, name)
-        self.assertEqual(tarball.version, version)
+        self.assertEqual(name, tarball.name)
+        self.assertEqual(version, tarball.version)
         if re.match("https?://github.com", url) != None:
             self.assertIsNotNone(
-                    re.match("https://github.com/[^/]+/"+tarball.name+".git",
+                    re.match("https://github.com/[^/]+/"+tarball.repo+".git",
                     tarball.giturl))
 
     return test_packageurl

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch, Mock, mock_open, call
 import build  # needs to be imported before tarball due to dependencies
 import tarball
+import re
 
 
 class FileManager():
@@ -27,10 +28,15 @@ def test_generator(url, name, version):
         """
         tarball.name = ''
         tarball.version = ''
+        tarball.giturl = ''
         tarball.url = url
         tarball.name_and_version('', '', FileManager())
         self.assertEqual(tarball.name, name)
         self.assertEqual(tarball.version, version)
+        if re.match("https?://github.com", url) != None:
+            self.assertIsNotNone(
+                    re.match("https://github.com/[^/]+/"+tarball.name+".git",
+                    tarball.giturl))
 
     return test_packageurl
 


### PR DESCRIPTION
Extend existing github_patterns to match, e.g.:
https://github.com/Linux-Comedi/comedilib/releases/download/r0_11_0/comedilib-0.11.0.tar.gz

Signed-off-by: Brett T. Warden <brett.t.warden@intel.com>