### PR TITLE
Remove empty download file on pycurl failure

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -66,6 +66,7 @@ def really_download(upstream_url, destination):
             c.perform()
         except pycurl.error:
             print_fatal("unable to download {}".format(upstream_url))
+            os.remove(destination)
             exit(1)
         finally:
             c.close()


### PR DESCRIPTION
Fixes #26

Remove empty file created when a download fails. The empty file caused
autospec to fail on consecutive runs due to autospec attempting to reuse
the file when it exists.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>