### PR TITLE
Ensure R packages contain full debuginfo

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -918,6 +918,7 @@ class Specfile(object):
         self._write_strip("echo \"CFLAGS = $CFLAGS -march=haswell -ftree-vectorize \" > ~/.R/Makevars")
         self._write_strip("echo \"FFLAGS = $FFLAGS -march=haswell -ftree-vectorize \" >> ~/.R/Makevars")
         self._write_strip("echo \"CXXFLAGS = $CXXFLAGS -march=haswell -ftree-vectorize \" >> ~/.R/Makevars")
+        self._write_strip("echo \"PKG_LIBS = -g \" >> ~/.R/Makevars")
 
         self._write_strip("R CMD INSTALL "
                           "--install-tests "
@@ -929,6 +930,7 @@ class Specfile(object):
         self._write_strip("echo \"CFLAGS = $CFLAGS -ftree-vectorize \" > ~/.R/Makevars")
         self._write_strip("echo \"FFLAGS = $FFLAGS -ftree-vectorize \" >> ~/.R/Makevars")
         self._write_strip("echo \"CXXFLAGS = $CXXFLAGS -ftree-vectorize \" >> ~/.R/Makevars")
+        self._write_strip("echo \"PKG_LIBS = -g \" >> ~/.R/Makevars")
 
         self._write_strip("R CMD INSTALL "
                           "--preclean "


### PR DESCRIPTION
Because the -g option is not specified by default when linking R shared libraries, add it manually to the PKG_LIBS variable in Makevars to inject -g into the linker command line. This ensures that the shared library (or libraries) contain full debuginfo.