### PR TITLE
Remove directories from file list

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -270,6 +270,15 @@ def package(args, url, name, archives, workingdir):
         filemanager.load_specfile(specfile)
         specfile.write_spec(build.download_path)
         filemanager.newfiles_printed = 0
+        mock_chroot = "/var/lib/mock/clear-{}/root/builddir/build/BUILDROOT/" \
+                      "{}-{}-{}.x86_64".format(build.uniqueext,
+                                               tarball.name,
+                                               tarball.version,
+                                               tarball.release)
+        if filemanager.clean_directories(mock_chroot):
+            # directories added to the blacklist, need to re-run
+            build.must_restart += 1
+
         if build.round > 20 or build.must_restart == 0:
             break
 

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -111,6 +111,14 @@ class FileManager(object):
         removed = False
 
         for f in files:
+            # autospec does not currently support adding empty directories to
+            # the file list by prefixing "%dir". Regardless, skip these entries
+            # because if they exist at this point it is intentional (i.e.
+            # support was added).
+            if f.startswith("%dir"):
+                res.add(f)
+                continue
+
             if os.path.isdir(os.path.join(root, f.lstrip("/"))):
                 util.print_warning("Removing directory {} from file list".format(f))
                 self.files_blacklist.add(f)

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -110,12 +110,15 @@ class FileManager(object):
         res = set()
         removed = False
 
+        directive_re = re.compile("(%\w+(\([^\)]*\))?\s+)(.*)")
         for f in files:
+            # skip the files with directives at the beginning, including %doc
+            # and %dir directives.
             # autospec does not currently support adding empty directories to
             # the file list by prefixing "%dir". Regardless, skip these entries
             # because if they exist at this point it is intentional (i.e.
             # support was added).
-            if f.startswith("%dir"):
+            if directive_re.match(f):
                 res.add(f)
                 continue
 

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -23,6 +23,8 @@ import build
 import tarball
 import config
 import re
+import os
+import util
 from collections import OrderedDict
 # todo package splits
 
@@ -100,6 +102,35 @@ class FileManager(object):
             return True
         else:
             return False
+
+    def _clean_dirs(self, root, files):
+        """
+        Do the work to remove the directories from the files list
+        """
+        res = set()
+        removed = False
+
+        for f in files:
+            if os.path.isdir(os.path.join(root, f.lstrip("/"))):
+                util.print_warning("Removing directory {} from file list".format(f))
+                self.files_blacklist.add(f)
+                removed = True
+            else:
+                res.add(f)
+
+        return (res, removed)
+
+    def clean_directories(self, root):
+        """
+        Remove directories from file list
+        """
+        removed = False
+        for pkg in self.packages:
+            self.packages[pkg], _rem = self._clean_dirs(root, self.packages[pkg])
+            if _rem:
+                removed = True
+
+        return removed
 
     def push_file(self, filename):
         """

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -212,6 +212,7 @@ class TestFiles(unittest.TestCase):
         remain.
         """
         with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, "directory"))
             with open(os.path.join(tmpd, "file1"), "w") as f:
                 f.write(" ")
 
@@ -225,6 +226,28 @@ class TestFiles(unittest.TestCase):
             self.fm.clean_directories(tmpd)
             self.assertEqual(self.fm.packages["main"],
                              set(["%dir /directory", "/file1", "/file2"]))
+
+
+    def test_clean_directories_with_doc(self):
+        """
+        Test clean_directories with a %doc directive in the list. This should
+        remain.
+        """
+        with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, "directory"))
+            with open(os.path.join(tmpd, "file1"), "w") as f:
+                f.write(" ")
+
+            with open(os.path.join(tmpd, "file2"), "w") as f:
+                f.write(" ")
+
+            self.fm.packages["main"] = set()
+            self.fm.packages["main"].add("%doc /directory")
+            self.fm.packages["main"].add("/file1")
+            self.fm.packages["main"].add("/file2")
+            self.fm.clean_directories(tmpd)
+            self.assertEqual(self.fm.packages["main"],
+                             set(["%doc /directory", "/file1", "/file2"]))
 
 
 if __name__ == '__main__':

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -206,5 +206,26 @@ class TestFiles(unittest.TestCase):
             self.assertEqual(self.fm.packages["main"], set(["/file1", "/file2"]))
 
 
+    def test_clean_directories_with_dir(self):
+        """
+        Test clean_directories with a %dir directory in the list. This should
+        remain.
+        """
+        with tempfile.TemporaryDirectory() as tmpd:
+            with open(os.path.join(tmpd, "file1"), "w") as f:
+                f.write(" ")
+
+            with open(os.path.join(tmpd, "file2"), "w") as f:
+                f.write(" ")
+
+            self.fm.packages["main"] = set()
+            self.fm.packages["main"].add("%dir /directory")
+            self.fm.packages["main"].add("/file1")
+            self.fm.packages["main"].add("/file2")
+            self.fm.clean_directories(tmpd)
+            self.assertEqual(self.fm.packages["main"],
+                             set(["%dir /directory", "/file1", "/file2"]))
+
+
 if __name__ == '__main__':
     unittest.main(buffer=True)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,5 +1,7 @@
 import unittest
 import files
+import tempfile
+import os
 from unittest.mock import call, MagicMock
 from files import FileManager
 
@@ -183,6 +185,26 @@ class TestFiles(unittest.TestCase):
         self.fm.remove_file('test')
         self.assertNotIn('test', self.fm.files)
         self.assertNotIn('test', self.fm.files_blacklist)
+
+    def test_clean_directories(self):
+        """
+        Test clean_directories with a directory in the list
+        """
+        with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, "directory"))
+            with open(os.path.join(tmpd, "file1"), "w") as f:
+                f.write(" ")
+
+            with open(os.path.join(tmpd, "file2"), "w") as f:
+                f.write(" ")
+
+            self.fm.packages["main"] = set()
+            self.fm.packages["main"].add("/directory")
+            self.fm.packages["main"].add("/file1")
+            self.fm.packages["main"].add("/file2")
+            self.fm.clean_directories(tmpd)
+            self.assertEqual(self.fm.packages["main"], set(["/file1", "/file2"]))
+
 
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
Clean directories from package file lists. If directories are
encountered, print a warning, add the directory to the blacklist, and
re-run.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>