### PR TITLE
catkin: introduce catkin pattern recognition

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -101,6 +101,9 @@ def failed_pattern(line, pattern, verbose, buildtool=None):
                 must_restart += buildreq.add_buildreq(config.maven_jars[s])
             else:
                 must_restart += buildreq.add_buildreq('jdk-%s' % s)
+        elif buildtool == 'catkin':
+            must_restart += buildreq.add_pkgconfig_buildreq(s)
+
     except:
         if verbose > 0:
             print("Unknown pattern match: ", s)

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -270,7 +270,8 @@ failed_pats = [
     (r"\[ERROR\] .* Cannot access central \(.*\) in offline mode and the artifact "
      r".*:(.*):[jar|pom]+:.* has not been downloaded from it before.*", 0, 'maven'),
     (r"\[WARNING\] The POM for .*:(.*):[jar|pom]+:.* is missing, no dependency information "
-     r"available", 0, 'maven')]
+     r"available", 0, 'maven'),
+    (r"^.*Could not find a package configuration file provided by \"(.*)\" with.*$", 0, 'catkin')]
 
 
 def get_metadata_conf():


### PR DESCRIPTION
Catkin is based on cmake and is a way to package/build modules as a
cmake components. This patch recognizes the patterns and handle the
dependencies, every catkin package provides a package-config descriptor
so it's pretty safe to rely on that.