### PR TITLE
license: Add tests for complete coverage of license module

### DIFF
--- a/autospec/license.py
+++ b/autospec/license.py
@@ -75,8 +75,8 @@ def license_from_copying_hash(copying):
         try:
             c.perform()
         except Exception as excep:
-            print_fatal("Failed to fetch license from " + config.license_fetch,
-                        excep)
+            print_fatal("Failed to fetch license from {}: {}"
+                        .format(config.license_fetch, excep))
             c.close()
             sys.exit(1)
 


### PR DESCRIPTION
The additional test uncovered a syntax error in the print_fatal call in
license_from_copying_hash, which was fixed as well. An unnecessary mock
was removed from another test.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>