### PR TITLE
Deprecate Makefile writing

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -441,22 +441,6 @@ def find_extract(tar_path, tarfile):
     return extract_cmd, tar_prefix
 
 
-def write_makefile(archives):
-    """
-    Write the new makefile with url, name, and archives
-    """
-    with open(build.download_path + "/Makefile", "w") as f:
-        f.write("PKG_NAME := " + name + "\n")
-        f.write("URL := " + url + "\n")
-        sep = "ARCHIVES := "
-        for archive in archives:
-            f.write("{}{}".format(sep, archive))
-            sep = " " if sep != " " else " \\\n\t"
-        f.write("\n")
-        f.write("\n")
-        f.write("include ../common/Makefile.common\n")
-
-
 def prepare_and_extract(extract_cmd):
     """
     Prepare the directory and extract the tarball
@@ -532,8 +516,6 @@ def process(url_arg, name_arg, ver_arg, target, archives_arg, filemanager):
     # Now that the metadata has been collected print the header
     print_header()
     # write out the Makefile with the name, url, and archives we found
-    # DEPRECATED, this will be removed in a future version
-    write_makefile(archives_arg)
     # prepare directory and extract tarball
     prepare_and_extract(extract_cmd)
     # locate or download archives and move them into the right spot

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -168,30 +168,6 @@ class TestTarballVersionName(unittest.TestCase):
         tarball.build_gem_unpack = build_gem_unpack_backup
         tarball.build_untar = build_untar_backup
 
-    def test_write_makefile(self):
-        """
-        Test write_makefile for correct archive format
-        """
-        archives = ['archive1', 'dest1', 'archive2', 'dest2']
-        build.download_path = '.'
-        tarball.name = 'test'
-        tarball.url = 'url'
-        m_open = mock_open()
-        with patch('tarball.open', m_open, create=True):
-            tarball.write_makefile(archives)
-
-        exp_calls = [call().write('PKG_NAME := test\n'),
-                     call().write('URL := url\n'),
-                     call().write('ARCHIVES := archive1'),
-                     call().write(' dest1'),
-                     call().write(' \\\n\tarchive2'),
-                     call().write(' dest2'),
-                     call().write('\n'),
-                     call().write('\n'),
-                     call().write('include ../common/Makefile.common\n')]
-        for m_call in exp_calls:
-            self.assertIn(m_call, m_open.mock_calls)
-
 
 TAR_OUT = 'libjpeg-turbo-1.5.1/\n'                         \
           'libjpeg-turbo-1.5.1/md5/\n'                     \


### PR DESCRIPTION
The package metadata is now written to options.conf so the Makefile
writing is no longer needed.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>