### PR TITLE
Add autoupdate flag to options.conf

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -107,7 +107,9 @@ config_options = {
     "nostrip": "disable stripping binaries",
     "verify_required": "require package verification for build",
     "security_sensitive": "set flags for security-sensitive builds",
-    "so_to_lib": "add .so files to the lib package instead of dev"}
+    "so_to_lib": "add .so files to the lib package instead of dev",
+    "autoupdate": "this package is trusted enough to automatically update "
+                  "(used by other tools)"}
 
 # simple_pattern_pkgconfig patterns
 # contains patterns for parsing build.log for missing dependencies


### PR DESCRIPTION
This flag is a no-op for autospec itself, but allows humans to indicate
that a package is trusted enough to automatically release new updates of
the package. In practice this should be used by a tool that runs
autospec in an automated manner to push the package to a build server.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>