### PR TITLE
cmake: add cmake_srcdir configuration

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -42,6 +42,7 @@ urlban = ""
 extra_make = ""
 extra_make_install = ""
 extra_cmake = ""
+cmake_srcdir = ""
 prep_append = []
 subdir = ""
 install_macro = "%make_install"
@@ -481,6 +482,7 @@ def parse_config_files(path, bump, filemanager):
     global extra_make
     global extra_make_install
     global extra_cmake
+    global cmake_srcdir
     global prep_append
     global subdir
     global install_macro
@@ -673,6 +675,10 @@ def parse_config_files(path, bump, filemanager):
     if content and content[0]:
         extra_cmake = content[0]
 
+    content = read_conf_file(os.path.join(path, "cmake_srcdir"))
+    if content and content[0]:
+        cmake_srcdir = content[0]
+
     content = read_conf_file(os.path.join(path, "subdir"))
     if content and content[0]:
         subdir = content[0]
@@ -725,6 +731,7 @@ def load_specfile(specfile):
     specfile.extra_make = extra_make
     specfile.extra_make_install = extra_make_install
     specfile.extra_cmake = extra_cmake
+    specfile.cmake_srcdir = cmake_srcdir or specfile.cmake_srcdir
     specfile.prep_append = prep_append
     specfile.subdir = subdir
     specfile.install_macro = install_macro

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -70,6 +70,7 @@ class Specfile(object):
         self.install_macro = "%make_install"
         self.disable_static = "--disable-static"
         self.extra_cmake = ""
+        self.cmake_srcdir = ".."
         self.make_install_append = []
         self.excludes = []
         self.keyid = ""
@@ -983,7 +984,7 @@ class Specfile(object):
         self._write_strip("mkdir clr-build")
         self._write_strip("pushd clr-build")
         self.write_variables()
-        self._write_strip("cmake .. -G \"Unix Makefiles\" "
+        self._write_strip("cmake " + self.cmake_srcdir + " -G \"Unix Makefiles\" "
                           "-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:BOOL=ON "
                           "-DLIB_INSTALL_DIR:PATH=/usr/lib64 "
                           "-DCMAKE_AR=/usr/bin/gcc-ar "
@@ -1009,7 +1010,7 @@ class Specfile(object):
             self._write_strip('export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"')
             self._write_strip('export CFLAGS="$CFLAGS -m32"')
             self._write_strip('export CXXFLAGS="$CXXFLAGS -m32"')
-            self._write_strip('cmake .. -G "Unix Makefiles" '
+            self._write_strip('cmake " + self.cmake_srcdir + " -G "Unix Makefiles" '
                               "-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:BOOL=ON "
                               "-DLIB_INSTALL_DIR:PATH=/usr/lib32 "
                               "-DCMAKE_AR=/usr/bin/gcc-ar "
@@ -1027,7 +1028,7 @@ class Specfile(object):
             self.need_avx2_flags = saved_avx2flags
             self._write_strip('export CFLAGS="$CFLAGS -march=haswell"')
             self._write_strip('export CXXFLAGS="$CXXFLAGS -march=haswell"')
-            self._write_strip('cmake .. -G "Unix Makefiles" '
+            self._write_strip('cmake " + self.cmake_srcdir + " -G "Unix Makefiles" '
                               "-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:BOOL=ON "
                               "-DLIB_INSTALL_DIR:PATH=/usr/lib/haswell "
                               "-DCMAKE_AR=/usr/bin/gcc-ar "


### PR DESCRIPTION
There are some packages that will ship multiple packages in the same
tarball. This configuration works around that and run cmake on the
correct source sub directory.