### PR TITLE
failed_commands: add pattern to detect ldap.h

### DIFF
--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -505,3 +505,4 @@ libxml/xmlversion.h, libxml2-dev
 g-ir-scanner, gobject-introspection
 get_mempolicy, numactl-dev
 pcap_dump, libpcap-dev
+ldap.h, openldap-dev


### PR DESCRIPTION
with this change autospec detects when ldap.h is missing
to add the openldap-dev build requirement.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>