### PR TITLE
Print commitmessage as a string

### DIFF
--- a/autospec/commitmessage.py
+++ b/autospec/commitmessage.py
@@ -282,6 +282,6 @@ def guess_commit_message():
 
     print("Guessed commit message:")
     try:
-        print(commitmessage)
+        print("\n".join(commitmessage))
     except:
         print("Can't print")


### PR DESCRIPTION
commitmessage is a list and is being printed as a string representation
of a list. Join it to a string to the print looks sane.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>