### PR TITLE
Support spec %description section override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,6 +282,14 @@ make_check_command
   This may be useful when a package uses a custom test suite, or requires
   additional work/parameters, to work correctly.
 
+Controlling miscellaneous spec metadata
+---------------------------------------
+
+description
+  Provides content for the %description section, overriding the content
+  autospec autodetects. This is useful if autospec cannot find proper content
+  for the description, if one wants to customize the content for better
+  presentation, etc.
 
 Controlling flags and optimization
 ----------------------------------

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -50,6 +50,7 @@ disable_static = "--disable-static"
 make_install_append = []
 patches = []
 autoreconf = False
+custom_desc = ""
 
 license_fetch = None
 license_show = None
@@ -492,6 +493,7 @@ def parse_config_files(path, bump, filemanager):
     global patches
     global autoreconf
     global yum_conf
+    global custom_desc
 
     packages_file = None
 
@@ -720,6 +722,8 @@ def parse_config_files(path, bump, filemanager):
     prep_append = read_conf_file(os.path.join(path, "prep_append"))
 
     profile_payload = read_conf_file(os.path.join(path, "profile_payload"))
+
+    custom_desc = read_conf_file(os.path.join(path, "description"))
 
 
 def load_specfile(specfile):

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -74,6 +74,7 @@ def commit_to_git(path):
     call("git add options.conf", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure_misses", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add whatrequires", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add description", check=False, stderr=subprocess.DEVNULL, cwd=path)
 
     # remove deprecated config files
     call("git rm use_clang", check=False, stderr=subprocess.DEVNULL, cwd=path)

--- a/autospec/specdescription.py
+++ b/autospec/specdescription.py
@@ -295,4 +295,7 @@ def load_specfile(specfile):
     Load specfile with parse results
     """
     specfile.default_sum = default_summary
-    specfile.default_desc = default_description
+    if config.custom_desc:
+        specfile.default_desc = "\n".join(config.custom_desc)
+    else:
+        specfile.default_desc = default_description


### PR DESCRIPTION
In case the user wants to override the base package %description content autodetected by autospec, add support for a config file named "description" to provide the content instead.