### PR TITLE
Remove verbose flag for make line

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -361,9 +361,9 @@ class Specfile(object):
         """
         Write make line to spec file
 
-        make V=1 <config.parallel_build> <extra_make>
+        make <config.parallel_build> <extra_make>
         """
-        self._write_strip("make V=1 {}{}".format(config.parallel_build, self.extra_make))
+        self._write_strip("make {}{}".format(config.parallel_build, self.extra_make))
 
     def write_prep(self, ruby_pattern=False):
         """Write prep section to spec file"""


### PR DESCRIPTION
Autospec does not parse the verbose output from make, so V=1 is not
necessary and slows down autospec build log parsing considerably. If
users want to debug a build at that level they should add the V=1 back
manually.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>