### PR TITLE
Change default python buildpattern to distutils3

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -259,9 +259,8 @@ def detect_build_from_url(url):
 
     # python
     if "pypi.python.org" in url or "pypi.debian.net" in url:
-        buildpattern.set_build_pattern("distutils23", 10)
+        buildpattern.set_build_pattern("distutils3", 10)
         buildreq.add_buildreq("python3-dev")
-        buildreq.add_buildreq("python-dev")
 
     # cpan
     if ".cpan.org/" in url or ".metacpan.org/" in url:


### PR DESCRIPTION
Change default python buildpattern from distutils23 (both python2 and
python3) to distutils3 (python3 only). This is a step toward deprecating
python2 usage in distro packages. Any packages that rely on python2
should have "distutils23" added to the build_pattern configuration file
to maintain their python2 subpackage (or, preferrably, built with
python3 only as is default).

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>