### PR TITLE
Do not follow location when using HEAD request.

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -205,7 +205,6 @@ def head_request(url):
     curl.setopt(curl.URL, url)
     curl.setopt(curl.CUSTOMREQUEST, "HEAD")
     curl.setopt(curl.NOBODY, True)
-    curl.setopt(curl.FOLLOWLOCATION, True)
     curl.setopt(curl.TIMEOUT, 5)
     curl.perform()
     http_code = curl.getinfo(pycurl.HTTP_CODE)


### PR DESCRIPTION
Suffice to get 302 or 200 on HEAD. Subsequent locations may point to
arbitrary servers which may return 403 on HEAD (while allow GET). This
issue happens with releases hosted on github.com, for example.