### PR TITLE
Turn off ConfigParser string interpolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ test_util:
 test_infile_parser:
 	PYTHONPATH=${CURDIR}/autospec python3 -m unittest discover -b -s tests -p 'test_infile_*'
 
+test_general:
+	PYTHONPATH=${CURDIR}/autospec python3 tests/test_general.py
+
 unittests:
 	PYTHONPATH=${CURDIR}/autospec coverage run -m unittest discover -b -s tests -p 'test_*.py' && coverage report
 

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -105,7 +105,7 @@ def read_old_metadata():
     if not os.path.exists(os.path.join(os.getcwd(), 'options.conf')):
         return None, None, []
 
-    config_f = configparser.ConfigParser()
+    config_f = configparser.ConfigParser(interpolation=None)
     config_f.read('options.conf')
     if "package" not in config_f.sections():
         return None, None, []

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -297,7 +297,7 @@ def create_conf(path):
     """
     Create options.conf file. Use deprecated configuration files or defaults to populate
     """
-    config_f = configparser.ConfigParser(allow_no_value=True)
+    config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
 
     # first the metadata
     config_f['package'] = get_metadata_conf()
@@ -336,7 +336,7 @@ def read_config_opts(path):
     if not os.path.exists(opts_path):
         create_conf(path)
 
-    config_f = configparser.ConfigParser()
+    config_f = configparser.ConfigParser(interpolation=None)
     config_f.read(opts_path)
     if "autospec" not in config_f.sections():
         print("Missing autospec section in options.conf")
@@ -355,7 +355,7 @@ def rewrite_config_opts(path):
     """
     Rewrite options.conf file when an option has changed (verify_required for example)
     """
-    config_f = configparser.ConfigParser(allow_no_value=True)
+    config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
     config_f['package'] = get_metadata_conf()
     config_f['autospec'] = {}
 

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -190,7 +190,7 @@ def download_tarball(target_dir):
     tarfile = os.path.basename(url)
     target = os.path.join(os.getcwd(), name)
     if os.path.exists(os.path.join(os.getcwd(), 'options.conf')):
-        config_f = configparser.ConfigParser()
+        config_f = configparser.ConfigParser(interpolation=None)
         config_f.read('options.conf')
         if "package" in config_f.sections():
             if (config_f["package"].get("name") == name or

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,0 +1,24 @@
+import subprocess
+import unittest
+
+
+class TestGeneral(unittest.TestCase):
+
+    def test_ConfigParser_regressions(self):
+        """
+        Make sure ConfigParser is always called with the required
+        interpolation=None argument
+        """
+        grep_cmd = ["grep", "-e", 
+                    "ConfigParser(.*\(^interpolation=None\).*)",
+                    "autospec/autospec.py"]
+        try:
+            output = subprocess.check_output(grep_cmd).decode('utf-8')
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode('utf-8')
+
+        self.assertEqual(output.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)


### PR DESCRIPTION
configparser.ConfigParser attempts to interpolate "%" characters in the
values of the key-value pairs when parsing. This is absolutely unwanted
behavior, especially when parsing URLs such as

<sourceforge url>/joe-editor/files/JOE%20sources/<joe tar>

which cause an uncaught exception.

Turn off interpolation by passing the interpolation=None argument to
ConfigParser.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>