### PR TITLE
Check for ConfigParser regressions in all source files

### DIFF
--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -9,9 +9,9 @@ class TestGeneral(unittest.TestCase):
         Make sure ConfigParser is always called with the required
         interpolation=None argument
         """
-        grep_cmd = ["grep", "-e", 
+        grep_cmd = ["grep", "-re",
                     "ConfigParser(.*\(^interpolation=None\).*)",
-                    "autospec/autospec.py"]
+                    "autospec"]
         try:
             output = subprocess.check_output(grep_cmd).decode('utf-8')
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Was only checking one file in last commit. This checks all files under autospec/

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>