### PR TITLE
Fix mismatched quotes in specfile write

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1010,7 +1010,7 @@ class Specfile(object):
             self._write_strip('export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"')
             self._write_strip('export CFLAGS="$CFLAGS -m32"')
             self._write_strip('export CXXFLAGS="$CXXFLAGS -m32"')
-            self._write_strip('cmake " + self.cmake_srcdir + " -G "Unix Makefiles" '
+            self._write_strip('cmake ' + self.cmake_srcdir + ' -G "Unix Makefiles" '
                               "-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:BOOL=ON "
                               "-DLIB_INSTALL_DIR:PATH=/usr/lib32 "
                               "-DCMAKE_AR=/usr/bin/gcc-ar "
@@ -1028,7 +1028,7 @@ class Specfile(object):
             self.need_avx2_flags = saved_avx2flags
             self._write_strip('export CFLAGS="$CFLAGS -march=haswell"')
             self._write_strip('export CXXFLAGS="$CXXFLAGS -march=haswell"')
-            self._write_strip('cmake " + self.cmake_srcdir + " -G "Unix Makefiles" '
+            self._write_strip('cmake ' + self.cmake_srcdir + ' -G "Unix Makefiles" '
                               "-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:BOOL=ON "
                               "-DLIB_INSTALL_DIR:PATH=/usr/lib/haswell "
                               "-DCMAKE_AR=/usr/bin/gcc-ar "


### PR DESCRIPTION
The intention here is to use the self.cmake_srcdir variable, not print
the literal string to the file...

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>