### PR TITLE
Fixups for rust/cargo building

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -224,6 +224,7 @@ def parse_cargo_toml(filename):
     """
     global cargo_bin
     buildpattern.set_build_pattern("cargo", 1)
+    add_buildreq("cargo")
     add_buildreq("rustc")
     with open(filename, "r", encoding="latin-1") as ctoml:
         cargo = toml.loads(ctoml.read())
@@ -231,8 +232,9 @@ def parse_cargo_toml(filename):
         cargo_bin = True
     if not cargo.get("dependencies"):
         return
-    for bdep in cargo["dependencies"]:
-        add_buildreq(bdep)
+    for cdep in cargo["dependencies"]:
+        if add_buildreq(cdep):
+            add_requires(cdep)
 
 
 def set_build_req():
@@ -556,7 +558,7 @@ def scan_for_configure(dirn):
             buildpattern.set_build_pattern("meson", default_score)
 
         for name in files:
-            if name.lower() == "cargo.toml":
+            if name.lower() == "cargo.toml" and dirpath == dirn:
                 parse_cargo_toml(os.path.join(dirpath, name))
             if name.lower().startswith("configure."):
                 parse_configure_ac(os.path.join(dirpath, name))

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -506,3 +506,4 @@ g-ir-scanner, gobject-introspection
 get_mempolicy, numactl-dev
 pcap_dump, libpcap-dev
 ldap.h, openldap-dev
+cargo, cargo

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1043,7 +1043,7 @@ class Specfile(object):
     def write_cargo_pattern(self):
         """Write cargo build pattern to spec file"""
         self.write_prep()
-        src_dir = "/usr/share/rust/src/{0}-{1}".format(self.name, self.version)
+        src_dir = "/usr/share/rust/src/{0}".format(self.name)
         self._write_strip("%build")
         self.write_proxy_exports()
         self._write_strip("mkdir .cargo")

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -274,6 +274,10 @@ def detect_build_from_url(url):
     if ".maven." in url:
         buildpattern.set_build_pattern("maven", 10)
 
+    # rust crate
+    if "crates.io" in url:
+        buildpattern.set_build_pattern("cargo", 10)
+
 
 def name_and_version(name_arg, version_arg, filemanager):
     """
@@ -395,6 +399,13 @@ def name_and_version(name_arg, version_arg, filemanager):
     # maven
     if ".maven." in url:
         m = re.search(r"/maven.*/org/.*/(.*?)/.*/.*[\-_]([0-9]+[a-zA-Z0-9\+_\.\-\~]*)\.jar", url)
+        if m:
+            name = m.group(1).strip()
+            version = convert_version(m.group(2))
+
+    # rust crate
+    if "crates.io" in url:
+        m = re.search(r"/crates.io/api/v[0-9]+/crates/(.*)/(.*)/download.*\.crate", url)
         if m:
             name = m.group(1).strip()
             version = convert_version(m.group(2))

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -177,7 +177,7 @@ class TestBuildreq(unittest.TestCase):
         buildreq.toml.loads = loads_backup
 
         self.assertEqual(buildreq.buildreqs,
-                         set(['rustc', 'dep1', 'dep2', 'dep3']))
+                         set(['cargo', 'rustc', 'dep1', 'dep2', 'dep3']))
         self.assertTrue(buildreq.cargo_bin)
         self.assertEqual(buildreq.buildpattern.default_pattern, 'cargo')
 


### PR DESCRIPTION
Improve rust/cargo support by:
1) Better handling only toplevel Cargo configuration files for dependency
lookup.
2) Adding runtime requirements for buildreq packages in order to get
dependencies from non directly dependent packages resolved.
3) Add cargo as a buildreq for rust packages to handle the rustc/cargo
split.
4) Add cargo detection from failed_commands.
5) Fix rust source directory destination to not append version in case
the package name already had version information in it.
6) Get name and version information from crates.io package files.

---
Can split up this into individual patches if wanted but thought
generic rust support would be easier to see in one patch.