### PR TITLE
Add 32bit versions of make/make_install args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,9 +228,19 @@ make_args
   The contents of this file are appended to the ``make`` invocation. This may be
   useful for passing arguments to ``make``, i.e. ``make TOOLDIR=/usr``
 
+make32_args
+  The contents of this file are appended to the ``make`` invocation of the 32bit
+  build. It is appended after the make_args content so 32bit specific overrides
+  can be added.
+
 make_install_args
   Much like ``make_args``, this will pass arguments to the ``make install``
   macro in the ``.spec``
+
+make32_install_args
+  Much like ``make32_args``, this will pass arguments to the ``make install``
+  macro in the ``.spec`` for the 32bit build. Again it is appended after
+  make_install_args so 32bit specific overrides can be added.
 
 make_install_append
   Additional actions that should take place after the ``make install`` step has

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -40,7 +40,9 @@ config_files = set()
 parallel_build = " %{?_smp_mflags} "
 urlban = ""
 extra_make = ""
+extra32_make = ""
 extra_make_install = ""
+extra_make32_install = ""
 extra_cmake = ""
 cmake_srcdir = ""
 prep_append = []
@@ -484,7 +486,9 @@ def parse_config_files(path, bump, filemanager):
     global profile_payload
     global config_opts
     global extra_make
+    global extra32_make
     global extra_make_install
+    global extra_make32_install
     global extra_cmake
     global cmake_srcdir
     global prep_append
@@ -668,9 +672,17 @@ def parse_config_files(path, bump, filemanager):
     if content and content[0]:
         extra_make = content[0]
 
+    content = read_conf_file(os.path.join(path, "make32_args"))
+    if content and content[0]:
+        extra32_make = content[0]
+
     content = read_conf_file(os.path.join(path, "make_install_args"))
     if content and content[0]:
         extra_make_install = content[0]
+
+    content = read_conf_file(os.path.join(path, "make32_install_args"))
+    if content and content[0]:
+        extra_make32_install = content[0]
 
     content = read_conf_file(os.path.join(path, "install_macro"))
     if content and content[0]:
@@ -736,7 +748,9 @@ def load_specfile(specfile):
     specfile.keepstatic = config_opts['keepstatic']
     specfile.no_autostart = config_opts['no_autostart']
     specfile.extra_make = extra_make
+    specfile.extra32_make = extra32_make
     specfile.extra_make_install = extra_make_install
+    specfile.extra_make32_install = extra_make32_install
     specfile.extra_cmake = extra_cmake
     specfile.cmake_srcdir = cmake_srcdir or specfile.cmake_srcdir
     specfile.prep_append = prep_append

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -57,7 +57,9 @@ class Specfile(object):
         self.default_pattern = ""
         self.autoreconf = False
         self.extra_make = ""
+        self.extra32_make = ""
         self.extra_make_install = ""
+        self.extra_make32_install = ""
         self.tarball_prefix = ""
         self.gcov_file = ""
         self.rawname = ""
@@ -357,13 +359,16 @@ class Specfile(object):
         self._write_strip("export https_proxy=http://127.0.0.1:9/")
         self._write_strip("export no_proxy=localhost,127.0.0.1,0.0.0.0")
 
-    def write_make_line(self):
+    def write_make_line(self, build32=False):
         """
         Write make line to spec file
 
         make <config.parallel_build> <extra_make>
         """
-        self._write_strip("make {}{}".format(config.parallel_build, self.extra_make))
+        if build32:
+            self._write_strip("make {}{}{}".format(config.parallel_build, self.extra_make, self.extra32_make))
+        else:
+            self._write_strip("make {}{}".format(config.parallel_build, self.extra_make))
 
     def write_prep(self, ruby_pattern=False):
         """Write prep section to spec file"""
@@ -503,7 +508,8 @@ class Specfile(object):
 
         if config.config_opts['32bit']:
             self._write_strip("pushd ../build32/" + self.subdir)
-            self._write_strip("%make_install32 " + self.extra_make_install)
+            self._write_strip("%make_install32 {} {}".format(self.extra_make_install,
+                                                             self.extra_make32_install))
             self._write_strip("if [ -d  %{buildroot}/usr/lib32/pkgconfig ]")
             self._write_strip("then")
             self._write_strip("    pushd %{buildroot}/usr/lib32/pkgconfig")
@@ -555,7 +561,8 @@ class Specfile(object):
 
         if config.config_opts['32bit']:
             self._write_strip("pushd clr-build32")
-            self._write_strip("%make_install32 " + self.extra_make_install)
+            self._write_strip("%make_install32 {} {}".format(self.extra_make_install,
+                                                             self.extra_make32_install))
             self._write_strip("if [ -d  %{buildroot}/usr/lib32/pkgconfig ]")
             self._write_strip("then")
             self._write_strip("    pushd %{buildroot}/usr/lib32/pkgconfig")
@@ -690,7 +697,7 @@ class Specfile(object):
                               .format(self.disable_static,
                                       config.extra_configure,
                                       config.extra_configure32))
-            self.write_make_line()
+            self.write_make_line(True)
             self._write_strip("popd")
 
         if config.config_opts['use_avx2']:
@@ -755,7 +762,7 @@ class Specfile(object):
                               .format(self.disable_static,
                                       config.extra_configure,
                                       config.extra_configure32))
-            self.write_make_line()
+            self.write_make_line(True)
             self._write_strip("popd")
 
         if config.config_opts['use_avx2']:
@@ -827,7 +834,7 @@ class Specfile(object):
                               .format(self.disable_static,
                                       config.extra_configure,
                                       config.extra_configure32))
-            self.write_make_line()
+            self.write_make_line(True)
             self._write_strip("popd")
         self.write_check()
         self.write_make_install()


### PR DESCRIPTION
Add make32_args and make32_install_args config file handling to allow
specific options to be passed that are specific to the 32bit builds.