### PR TITLE
Print instructions when not automatically committing

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -351,6 +351,8 @@ def package(args, url, name, archives, workingdir, infile_dict):
 
     if args.git:
         git.commit_to_git(build.download_path)
+    else:
+        print("To commit your changes, run 'git commit -F commitmsg'")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When skipping automatic git commit due to --skip-git flag print a
message informing the user they must commit their changes themselves.

Fixes #89

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>