### PR TITLE
Change default keyring to package directory

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -347,7 +347,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     # record logcheck output
     logcheck(build.download_path)
 
-    commitmessage.guess_commit_message()
+    commitmessage.guess_commit_message(pkg_integrity.IMPORTED)
 
     if args.git:
         git.commit_to_git(build.download_path)

--- a/autospec/commitmessage.py
+++ b/autospec/commitmessage.py
@@ -218,7 +218,7 @@ def process_git(giturl, oldversion, newversion):
         return shortlog
 
 
-def guess_commit_message():
+def guess_commit_message(keyinfo):
     """
     guess_commit_message() parses newsfiles and determines a sane commit
     message. The commit message defaults to the following for an updated
@@ -276,6 +276,9 @@ def guess_commit_message():
         commitmessage.append("CVEs fixed in this build:")
         commitmessage.extend(sorted(list(cves)))
         commitmessage.append("")
+
+    if keyinfo:
+        commitmessage.append("Key imported:\n{}".format(keyinfo))
 
     util.write_out(os.path.join(build.download_path, "commitmsg"),
                    "\n".join(commitmessage) + "\n")

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -56,6 +56,7 @@ def commit_to_git(path):
     call("bash -c 'shopt -s failglob; git add -f *.sig'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add -f *.sha256'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add -f *.sign'", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("bash -c 'shopt -s failglob; git add -f *.pkey'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure32", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure64", check=False, stderr=subprocess.DEVNULL, cwd=path)

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -45,6 +45,7 @@ RUBYORG_API = "https://rubygems.org/api/v1/versions/{}.json"
 PYPIORG_API = "https://pypi.python.org/pypi/{}/json"
 KEYID_TRY = ""
 KEYID = ""
+IMPORTED = ""
 EMAIL = ""
 GNUPGCONF = """keyserver keys.gnupg.net"""
 CMD_TIMEOUT = 20
@@ -606,6 +607,7 @@ class InputGetter(object):
 
 
 def attempt_key_import(keyid, key_fullpath):
+    global IMPORTED
     print(SEPT)
     ig = InputGetter('\nDo you want to attempt to import keyid {}: (y/N) '.format(keyid))
     import_key_answer = ig.get_answer()
@@ -630,6 +632,7 @@ def attempt_key_import(keyid, key_fullpath):
         print("\n", content)
         ig = InputGetter(message='\nDo you want to keep this key: (Y/n) ', default='y')
         if ig.get_answer() is True:
+            IMPORTED = content
             return True
         else:
             os.unlink(key_fullpath)


### PR DESCRIPTION
Instead of relying on a centralized keyring that resides in the autospec
repository, make the default keyring the package directory itself. Any
key imports will be to the package repository and will be committed as
part of the automatic autospec commit.

Retain the autospec repo keyring as a fallback keyring when the public
key does not exist in the package repo.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>