### PR TITLE
Improve instructions for --skip-git

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -352,7 +352,8 @@ def package(args, url, name, archives, workingdir, infile_dict):
     if args.git:
         git.commit_to_git(build.download_path)
     else:
-        print("To commit your changes, run 'git commit -F commitmsg'")
+        print("To commit your changes, git add the relevant files and "
+              "run 'git commit -F commitmsg'")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The user should be told they need to add relevant files before they
commit.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>