### PR TITLE
Remove a debug print

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -552,7 +552,6 @@ def parse_config_files(path, bump, filemanager):
 
     if packages_file:
         os_packages = set(read_conf_file(packages_file))
-        print("Read ", packages_file)
     else:
         os_packages = set(read_conf_file("~/packages"))
 


### PR DESCRIPTION
This print() was recently added, presumably for debugging, so it's not
needed in mainline.