### PR TITLE
Add new option to customize Mock config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Synopsis
   usage: autospec.py [-h] [-g] [-n NAME] [-v VERSION]
                      [-a [ARCHIVES [ARCHIVES ...]]] [-l] [-b] [-c CONFIG]
                      [-t TARGET] [-i] [-p] [--non_interactive] [-C]
-                     [--infile INFILE]
+                     [--infile INFILE] [-m MOCK_CONFIG]
                      [url]
 
     url                 (required - unless infile is passed) tarball URL
@@ -91,7 +91,10 @@ optional arguments:
   --infile INFILE       Additional input to contribute to specfile creation.
                         Can be a url, directory of files, or a file.
   -C, --cleanup         Clean up mock chroot after building the package
-
+  -m MOCK_CONFIG, --mock-config MOCK_CONFIG
+                        Value to pass with Mock's -r option. Defaults to
+                        "clear", meaning that Mock will use
+                        /etc/mock/clear.cfg.
 
 
 Requirements

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -200,6 +200,10 @@ def main():
                         help="Clean up mock chroot after building the package")
     parser.add_argument("--infile", action="store", dest="infile", default="",
                         help="type of input file for .specfile creation")
+    parser.add_argument("-m", "--mock-config", action="store", default="clear",
+                        help="Value to pass with Mock's -r option. Defaults to "
+                             "\"clear\", meaning that Mock will use "
+                             "/etc/mock/clear.cfg.")
 
     args = parser.parse_args()
 
@@ -304,7 +308,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
 
     specfile.write_spec(build.download_path)
     while 1:
-        build.package(filemanager, args.cleanup)
+        build.package(filemanager, args.mock_config, args.cleanup)
         filemanager.load_specfile(specfile)
         specfile.write_spec(build.download_path)
         filemanager.newfiles_printed = 0

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -203,7 +203,7 @@ def get_mock_cmd():
     return 'sudo /usr/bin/mock'
 
 
-def package(filemanager, cleanup=False):
+def package(filemanager, mockconfig, cleanup=False):
     global round
     global uniqueext
     round = round + 1
@@ -222,16 +222,16 @@ def package(filemanager, cleanup=False):
 
     shutil.rmtree('{}/results'.format(download_path), ignore_errors=True)
     os.makedirs('{}/results'.format(download_path))
-    util.call("{} -r clear --buildsrpm --sources=./ --spec={}.spec "
+    util.call("{} -r {} --buildsrpm --sources=./ --spec={}.spec "
               "--uniqueext={} --result=results/ {}"
-              .format(mock_cmd, tarball.name, uniqueext, cleanup_flag),
+              .format(mock_cmd, mockconfig, tarball.name, uniqueext, cleanup_flag),
               logfile="%s/mock_srpm.log" % download_path, cwd=download_path)
 
     util.call("rm -f results/build.log", cwd=download_path)
     srcrpm = "results/%s-%s-%s.src.rpm" % (tarball.name, tarball.version, tarball.release)
-    returncode = util.call("{} -r clear  --result=results/ {} "
+    returncode = util.call("{} -r {} --result=results/ {} "
                            "--enable-plugin=ccache  --uniqueext={} {}"
-                           .format(mock_cmd, srcrpm, uniqueext, cleanup_flag),
+                           .format(mock_cmd, mockconfig, srcrpm, uniqueext, cleanup_flag),
                            logfile="%s/mock_build.log" % download_path, check=False, cwd=download_path)
     # sanity check the build log
     if not os.path.exists(download_path + "/results/build.log"):


### PR DESCRIPTION
Instead of hardcoding the "-r clear" option to specify the Mock config, make this configurable with a new -m/--mock-config command line option.