### PR TITLE
Add support for [un]installation scriptlets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,6 +251,26 @@ install_macro
   The contents of this file be used instead of the automatically detected
   ``install`` routine, i.e. use this if ``%make_install`` is insufficient.
 
+pre_install
+  The contents of this file be executed before ``install`` routine. This file
+  specifies a serie of commands that can be executed in order to set a required
+  environment before the installation stage.
+
+post_install
+  The contents of this file be executed after ``install`` routine. This file
+  specifies a serie of commands that can be executed in order to remove unneeded
+  stuff in the environment after the installation stage.
+
+pre_uninstall
+  The contents of this file be executed before to remove the package. This file
+  specifies a serie of commands that can be executed in order to set a required
+  enviroment before the uninstallation stage.
+
+post_uninstall
+  The contents of this file be executed after to remove the package. This file
+  specifies a serie of commands that can be executed in order to remove unneeded
+  stuff in the environment after the uninstallation stage.
+
 subdir
   Not all packages have their ``Makefile``'s available in the root of the
   tarball.  An example of this may be cross-platform projects that split

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -47,6 +47,10 @@ extra_cmake = ""
 cmake_srcdir = ""
 prep_append = []
 subdir = ""
+pre_install = ""
+pre_uninstall = ""
+post_install = ""
+post_uninstall = ""
 install_macro = "%make_install"
 disable_static = "--disable-static"
 make_install_append = []
@@ -499,6 +503,11 @@ def parse_config_files(path, bump, filemanager):
     global cmake_srcdir
     global prep_append
     global subdir
+    global pre_install
+    global pre_uninstall
+    global post_install
+    global post_uninstall
+
     global install_macro
     global disable_static
     global make_install_append
@@ -678,6 +687,18 @@ def parse_config_files(path, bump, filemanager):
     content = read_conf_file(os.path.join(path, "configure64"))
     extra_configure64 = " \\\n".join(content)
 
+    content = read_conf_file(os.path.join(path, "pre_install"))
+    pre_install = content
+
+    content = read_conf_file(os.path.join(path, "pre_uninstall"))
+    pre_uninstall = content
+
+    content = read_conf_file(os.path.join(path, "post_install"))
+    post_install = content
+
+    content = read_conf_file(os.path.join(path, "post_uninstall"))
+    post_uninstall = content
+
     if config_opts["keepstatic"]:
         disable_static = ""
     if config_opts['broken_parallel_build']:
@@ -770,6 +791,10 @@ def load_specfile(specfile):
     specfile.cmake_srcdir = cmake_srcdir or specfile.cmake_srcdir
     specfile.prep_append = prep_append
     specfile.subdir = subdir
+    specfile.pre_install = pre_install
+    specfile.pre_uninstall = pre_uninstall
+    specfile.post_install = post_install
+    specfile.post_uninstall = post_uninstall
     specfile.install_macro = install_macro
     specfile.disable_static = disable_static
     specfile.make_install_append = make_install_append

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -70,6 +70,10 @@ class Specfile(object):
         self.need_avx512_flags = False
         self.tests_config = ""
         self.subdir = ""
+        self.pre_install = ""
+        self.pre_uninstall = ""
+        self.post_install = ""
+        self.post_uninstall = ""
         self.install_macro = "%make_install"
         self.disable_static = "--disable-static"
         self.extra_cmake = ""
@@ -303,6 +307,26 @@ class Specfile(object):
         """
         Write post and pre scripts to spec file
         """
+        if len(self.pre_install):
+            self._write("\n%pre\n")
+            for line in self.pre_install:
+                self._write_strip("{}\n".format(line))
+
+        if len(self.pre_uninstall):
+            self._write("\n%preun\n")
+            for line in self.pre_uninstall:
+                self._write_strip("{}\n".format(line))
+
+        if len(self.post_install):
+            self._write("\n%post\n")
+            for line in self.post_install:
+                self._write_strip("{}\n".format(line))
+
+        if len(self.post_uninstall):
+            self._write("\n%postun\n")
+            for line in self.post_uninstall:
+                self._write_strip("{}\n".format(line))
+
         for pkg in sorted(self.packages):
             if pkg in ["ignore", "main", "locales"]:
                 continue


### PR DESCRIPTION
These commits add support for pre/post/preun/postun scriptlets.
This in order to control the RPM package [un]installation.

The serie of commands can be established in a file according to the
functionality, this relation is described below:

| Scriptlet | File name      |
| --------- | -------------- |
| %pre      | pre_install    |
| %preun    | pre_uninstall  |
| %post     | post_install   |
| %postun   | post_uninstall |
