### PR TITLE
Enable auto exclude for library compat packages

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -115,7 +115,9 @@ config_options = {
     "security_sensitive": "set flags for security-sensitive builds",
     "so_to_lib": "add .so files to the lib package instead of dev",
     "autoupdate": "this package is trusted enough to automatically update "
-                  "(used by other tools)"}
+                  "(used by other tools)",
+    "compat": "this package is a library compatability package and only "
+              "ships versioned library files"}
 
 # simple_pattern_pkgconfig patterns
 # contains patterns for parsing build.log for missing dependencies

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,5 @@
 import unittest
+import config
 import files
 import tempfile
 import os
@@ -38,6 +39,28 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file('test-fn', 'dev')
         self.assertEqual(self.fm.packages['dev'], set(['test-fn']))
         self.assertTrue(self.fm.newfiles_printed)
+
+    def test_compat_exclude_keep_file(self):
+        """
+        Test compat_exclude with a file that shouldn't be excluded.
+        """
+        config.config_opts['compat'] = True
+        self.assertFalse(self.fm.compat_exclude('/usr/lib64/libfoo.so.1'))
+
+    def test_compat_exclude_exclude_file(self):
+        """
+        Test compat_exclude with a file that should be excluded.
+        """
+        config.config_opts['compat'] = True
+        self.assertTrue(self.fm.compat_exclude('/usr/lib64/libfoo.so'))
+
+    def test_compat_exclude_not_compat_mode(self):
+        """
+        Test compat_exclude with a file that should be excluded but isn't
+        because the package isn't being run in compat mode.
+        """
+        config.config_opts['compat'] = False
+        self.assertFalse(self.fm.compat_exclude('/usr/lib64/libfoo.so'))
 
     def test_file_pat_match(self):
         """


### PR DESCRIPTION
When making a library compatibility package, the only files that are
needed are the library binary and versioned symlinks to the
library. All the other files are to be excluded as they might conflict
with the files in the main package.

To that end, add a setting in options.conf for a package to signify it
is a compatibility library and do matching for files that meet the
above requirements and exclude all others.