### PR TITLE
Try to autodetect python version by classifiers

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -391,6 +391,26 @@ def grab_pip_requirements(pkgname):
                     add_requires(w2)
 
 
+def get_python_build_version_from_classifier(filename):
+    """
+    Detect if setup should use distutils23 or distutils3 only.
+
+    Uses "Programming Language :: Python :: [2,3] :: Only" classifiers in the
+    setup.py file.  Defaults to distutils23 if no such classifiers are found.
+    """
+
+    with open(filename) as setup_file:
+        data = setup_file.read()
+
+    if "Programming Language :: Python :: 3 :: Only" in data:
+        return "distutils3"
+
+    elif "Programming Language :: Python :: 2 :: Only" in data:
+        return "distutils2"
+
+    return "distutils23"
+
+
 def add_setup_py_requires(filename):
     """
     Detect build requirements listed in setup.py in the install_requires and
@@ -563,7 +583,8 @@ def scan_for_configure(dirn):
             add_buildreq("pbr")
             add_buildreq("pip")
             add_setup_py_requires(dirpath + '/setup.py')
-            buildpattern.set_build_pattern("distutils23", default_score)
+            python_pattern = get_python_build_version_from_classifier(dirpath + '/setup.py')
+            buildpattern.set_build_pattern(python_pattern, default_score)
 
         if "Makefile.PL" in files or "Build.PL" in files:
             buildpattern.set_build_pattern("cpan", default_score)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name="autospec",
             'Topic :: Software Development :: Build Tools',
             'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
             # Python versions supported.
+            'Programming Language :: Python :: 3 :: Only',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.2',
             'Programming Language :: Python :: 3.3',

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -367,6 +367,54 @@ class TestBuildreq(unittest.TestCase):
         self.assertEqual(buildreq.buildreqs, set())
         self.assertEqual(buildreq.requires, set())
 
+    def test_setup_py3_version_classifier(self):
+        """
+        test detection of python version from setup.py classifier
+        """
+
+        open_name = 'buildreq.open'
+        content = """classifiers = [
+                    'Programming Language :: Python :: 3 :: Only',
+                ]"""
+
+        m_open = mock_open(read_data=content)
+        with patch(open_name, m_open, create=True):
+            build_pattern = buildreq.get_python_build_version_from_classifier("filename")
+
+        self.assertEqual(build_pattern, "distutils3")
+
+    def test_setup_py2_version_classifier(self):
+        """
+        test detection of python version from setup.py classifier
+        """
+
+        open_name = 'buildreq.open'
+        content = """classifiers = [
+                    'Programming Language :: Python :: 2 :: Only',
+                ]"""
+
+        m_open = mock_open(read_data=content)
+        with patch(open_name, m_open, create=True):
+            build_pattern = buildreq.get_python_build_version_from_classifier("filename")
+
+        self.assertEqual(build_pattern, "distutils2")
+
+    def test_setup_py23_version_classifier(self):
+        """
+        test detection of python version from setup.py classifier
+        """
+
+        open_name = 'buildreq.open'
+        content = """classifiers = [
+                    'Programming Language :: Python :: 3',
+                ]"""
+
+        m_open = mock_open(read_data=content)
+        with patch(open_name, m_open, create=True):
+            build_pattern = buildreq.get_python_build_version_from_classifier("filename")
+
+        self.assertEqual(build_pattern, "distutils23")
+
     def test_scan_for_configure(self):
         """
         Test scan_for_configure with a mocked package structure. There is so


### PR DESCRIPTION
If a python package is python3-only and has a setup.py,
"distutils23" will be used as build pattern even if the project is
explicitely specified as python 2 or python 3 only.

This change tries to find if either of these are the case by
looking at the classifiers in the setup.py file for the following
string:

"Programming Language :: Python :: 3 :: Only"
"Programming Language :: Python :: 2 :: Only"

The default is still "distutils23" unless either of these strings
are found.  If they are "distutils2" or "distutils3" will be used
corresponding to the version in the classifier.