### PR TITLE
Fixup meson 32 bit flags

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1282,9 +1282,9 @@ qmake {}QMAKE_CFLAGS=\"$CFLAGS\" QMAKE_CXXFLAGS=\"$CXXFLAGS\" QMAKE_LFLAGS=\"$LD
             self._write_strip('export CFLAGS="$CFLAGS -m32"')
             self._write_strip('export CXXFLAGS="$CXXFLAGS -m32"')
             self._write_strip('export LDFLAGS="$LDFLAGS -m32"')
-            self._write_strip('CFLAGS="$CFLAGS -m32" CXXFLAGS="$CXXFLAGS -m32" LDFLAGS="$LDFLAGS "'
-                              '"-m32 PKG_CONFIG_PATH="/usr/lib32/pkgconfig" meson "'
-                              '"--libdir=/usr/lib32 --prefix /usr --buildtype=plain {0} builddir'
+            self._write_strip('CFLAGS="$CFLAGS -m32" CXXFLAGS="$CXXFLAGS -m32" LDFLAGS="$LDFLAGS -m32" '
+                              'PKG_CONFIG_PATH="/usr/lib32/pkgconfig" meson '
+                              '--libdir=/usr/lib32 --prefix /usr --buildtype=plain {0} builddir'
                               .format(config.extra_configure))
             self._write_strip('ninja -v -C builddir')
             self._write_strip('popd')


### PR DESCRIPTION
Quoting for meson 32bit builds was incorrect in a few places, causing
environment variables to be split and syntax errors in the command
with double quotes.