### PR TITLE
Make git URI configuration optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Example ``autospec.conf`` file::
     upstream = http://yourhost/tarballs/%(HASH)s/%(NAME)s
 
 git
-  The upstream git repository URL base
+  Optional URI template for remote git repository
 
 license_fetch
   Optional URL to use for scanning license files

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -543,7 +543,7 @@ def parse_config_files(path, bump, filemanager):
     read_config_opts(path)
 
     if not git_uri:
-        print("Warning: Set [autospec][git] upstream template for git support")
+        print("Warning: Set [autospec][git] upstream template for remote git URI configuration")
     if not license_fetch:
         print("Warning: Set [autospec][license_fetch] uri for license fetch support")
     if not license_show:

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -30,16 +30,15 @@ import config
 
 def commit_to_git(path):
 
-    if not config.git_uri:
-        return
-
     call("git init", stdout=subprocess.DEVNULL, cwd=path)
 
-    try:
-        call("git config --get remote.origin.url", cwd=path)
-    except subprocess.CalledProcessError:
-        upstream_uri = config.git_uri % {'NAME': tarball.name}
-        call("git remote add origin %s" % upstream_uri, cwd=path)
+    # This config is used for setting the remote URI, so it is optional.
+    if config.git_uri:
+        try:
+            call("git config --get remote.origin.url", cwd=path)
+        except subprocess.CalledProcessError:
+            upstream_uri = config.git_uri % {'NAME': tarball.name}
+            call("git remote add origin %s" % upstream_uri, cwd=path)
 
     for config_file in config.config_files:
         call("git add %s" % config_file, cwd=path, check=False)


### PR DESCRIPTION
Fix #148

Previous to this commit, if the autospec.conf `git` configuration value is unset, autospec would not instantiate a git repo and not commit any changes.

However, because the purpose of that config value is to define a pattern for the git remote URI, it should be completely optional. Users may not be pushing their repo to a remote location, or the remote repo name may not match the local repo name (e.g. with Github not allowing certain characters to appear to repo names).

With this change, autospec will now always commit changes unless `--skip-git` is passed on the command line.