### PR TITLE
autospec: add path systemd unit file to sources

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -53,7 +53,7 @@ def add_sources(download_path, archives):
     Add archives to buildpattern sources and archive_details
     """
     for srcf in os.listdir(download_path):
-        if re.search(r".*\.(mount|service|socket|target|timer)$", srcf):
+        if re.search(r".*\.(mount|service|socket|target|timer|path)$", srcf):
             buildpattern.sources["unit"].append(srcf)
     buildpattern.sources["unit"].sort()
     #


### PR DESCRIPTION
path unit file allow systemd to trigger a service if a folder is modified
or if a file or path exists.

https://www.freedesktop.org/software/systemd/man/systemd.path.html

Signed-off-by: Josue David Hernandez <josue.d.hernandez.gutierrez@intel.com>