### PR TITLE
Update mzcaller-saved option

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -436,7 +436,7 @@ class Specfile(object):
                 flags.extend(["-Os", "-ffunction-sections", "-fdata-sections", "-fno-semantic-interposition"])
         if config.config_opts['security_sensitive']:
             flags.append("-fstack-protector-strong")
-            flags.append("-mzero-caller-saved-regs")
+            flags.append("-mzero-caller-saved-regs=used")
         if self.need_avx2_flags:
             flags.extend(["-O3", "-march=haswell"])
         if self.need_avx512_flags:


### PR DESCRIPTION
Latest update of GCC 8 has a change in the patch zero-regs-gcc8.patch,
now instead of having just the option -mzero-caller-saved-regs (which add
the fnctionality to emit zero touched caller-saved general registers
upon function return) it now adds -mzero-caller-saved-regs=[skip|used|all]

In clear linux we will use the option:

-mzero-caller-saved-regs=used

This option emit a zero only on used caller-saved general registers upon
function return.

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>