### PR TITLE
cmake_args: support multi-line

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -706,8 +706,7 @@ def parse_config_files(path, bump, filemanager):
         install_macro = content[0]
 
     content = read_conf_file(os.path.join(path, "cmake_args"))
-    if content and content[0]:
-        extra_cmake = content[0]
+    extra_cmake = "\\\n".join(content)
 
     content = read_conf_file(os.path.join(path, "cmake_srcdir"))
     if content and content[0]:


### PR DESCRIPTION
Support multi-line and keep it consistent with configure file.

Fixes: #152 

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>