### PR TITLE
add --mock-opts arguments

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -204,6 +204,9 @@ def main():
                         help="Value to pass with Mock's -r option. Defaults to "
                              "\"clear\", meaning that Mock will use "
                              "/etc/mock/clear.cfg.")
+    parser.add_argument("-o", "--mock-opts", action="store", default="",
+                        help="Arbitrary options to pass down to mock when "
+                        "building a package.")
 
     args = parser.parse_args()
 
@@ -308,7 +311,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
 
     specfile.write_spec(build.download_path)
     while 1:
-        build.package(filemanager, args.mock_config, args.cleanup)
+        build.package(filemanager, args.mock_config, args.mock_opts, args.cleanup)
         filemanager.load_specfile(specfile)
         specfile.write_spec(build.download_path)
         filemanager.newfiles_printed = 0

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -203,7 +203,7 @@ def get_mock_cmd():
     return 'sudo /usr/bin/mock'
 
 
-def package(filemanager, mockconfig, cleanup=False):
+def package(filemanager, mockconfig, mockopts, cleanup=False):
     global round
     global uniqueext
     round = round + 1
@@ -223,8 +223,9 @@ def package(filemanager, mockconfig, cleanup=False):
     shutil.rmtree('{}/results'.format(download_path), ignore_errors=True)
     os.makedirs('{}/results'.format(download_path))
     util.call("{} -r {} --buildsrpm --sources=./ --spec={}.spec "
-              "--uniqueext={} --result=results/ {}"
-              .format(mock_cmd, mockconfig, tarball.name, uniqueext, cleanup_flag),
+              "--uniqueext={} --result=results/ {} {}"
+              .format(mock_cmd, mockconfig, tarball.name, uniqueext, cleanup_flag,
+                      mockopts),
               logfile="%s/mock_srpm.log" % download_path, cwd=download_path)
 
     util.call("rm -f results/build.log", cwd=download_path)


### PR DESCRIPTION
The new argument is passed down to mock whenever building a package.
Arbitrary mock options can be provided.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>