### PR TITLE
Add translation for BSD-3-Clause

### DIFF
--- a/autospec/license_translations
+++ b/autospec/license_translations
@@ -74,3 +74,4 @@ VIM, Vim
 CC0, CC0-1.0
 GPL-2.0+LGPL-2.1, GPL-2.0 LGPL-2.1
 Artistic-1.0+GPL-1.0, Artistic-1.0 GPL-1.0
+BSD(3-clause), BSD-3-Clause


### PR DESCRIPTION
The 'seaborn' package contains a PKG-INFO with 'BSD (3-clause)' declared
as the license, so translate this to a proper SPDX identifier.