### PR TITLE
Drop legacypython requires always

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -190,7 +190,7 @@ class Specfile(object):
             if pkg == "autostart" and self.no_autostart:
                 continue
             if pkg in ["ignore", "main", "dev", "active-units", "extras",
-                       "lib32", "dev32"]:
+                       "lib32", "dev32", "legacypython"]:
                 continue
             self._write("Requires: {}-{}\n".format(self.name, pkg))
 


### PR DESCRIPTION
As part of moving away from python2, no longer keep legacypython
subpackages as part of the autorequires of the base package.