### PR TITLE
Set default permissions for doc files

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -328,7 +328,10 @@ class Specfile(object):
                 continue
 
             self._write("\n%files {}\n".format(pkg))
-            self._write("%defattr(-,root,root,-)\n")
+            if pkg in ["doc"]:
+                self._write("%defattr(0644,root,root,0755)\n")
+            else:
+                self._write("%defattr(-,root,root,-)\n")
             for filename in sorted(self.packages[pkg]):
                 self._write("{}\n".format(self.quote_filename(filename)))
 


### PR DESCRIPTION
Make the generated spec file set the default attributes for doc files
to be 0644, so the documentation is not executable.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>