### PR TITLE
Fix handling of symlinks to directories in %files

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -145,7 +145,8 @@ class FileManager(object):
                 res.add(f)
                 continue
 
-            if os.path.isdir(os.path.join(root, f.lstrip("/"))):
+            path = os.path.join(root, f.lstrip("/"))
+            if os.path.isdir(path) and not os.path.islink(path):
                 util.print_warning("Removing directory {} from file list".format(f))
                 self.files_blacklist.add(f)
                 removed = True

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -251,6 +251,42 @@ class TestFiles(unittest.TestCase):
                              set(["%dir /directory", "/file1", "/file2"]))
 
 
+    def test_clean_directories_with_symlink_to_dir(self):
+        """
+        Test clean_directories with a symlink to a directory in the list. The
+        symlink should remain, but the directory should be cleaned.
+        """
+        with tempfile.TemporaryDirectory() as tmpd:
+            dirname = os.path.join(tmpd, "directory")
+            linkname = os.path.join(tmpd, "symlink")
+            os.mkdir(dirname)
+            os.symlink(dirname, linkname)
+            self.fm.packages["main"] = set()
+            self.fm.packages["main"].add("/directory")
+            self.fm.packages["main"].add("/symlink")
+            self.fm.clean_directories(tmpd)
+            self.assertEqual(self.fm.packages["main"],
+                             set(["/symlink"]))
+
+
+    def test_clean_directories_with_symlink_to_explicit_dir(self):
+        """
+        Test clean_directories with a symlink to a %dir directory in the list.
+        The symlink and directory should both remain.
+        """
+        with tempfile.TemporaryDirectory() as tmpd:
+            dirname = os.path.join(tmpd, "directory")
+            linkname = os.path.join(tmpd, "symlink")
+            os.mkdir(dirname)
+            os.symlink(dirname, linkname)
+            self.fm.packages["main"] = set()
+            self.fm.packages["main"].add("%dir /directory")
+            self.fm.packages["main"].add("/symlink")
+            self.fm.clean_directories(tmpd)
+            self.assertEqual(self.fm.packages["main"],
+                             set(["%dir /directory", "/symlink"]))
+
+
     def test_clean_directories_with_doc(self):
         """
         Test clean_directories with a %doc directive in the list. This should


### PR DESCRIPTION
Fixes #135 

Because os.path.isdir() follows symlinks, if it is passed a symlink to a directory, the symlink will be removed from the %files section here.

Ensure the removal does not occur for this case by making the conditional check more strict.