### PR TITLE
Follow http redirects when looking for GPG signatures

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -216,6 +216,7 @@ def head_request(url):
     curl.setopt(curl.CUSTOMREQUEST, "HEAD")
     curl.setopt(curl.NOBODY, True)
     curl.setopt(curl.TIMEOUT, 5)
+    curl.setopt(curl.FOLLOWLOCATION, True)
     curl.perform()
     http_code = curl.getinfo(pycurl.HTTP_CODE)
     curl.close()


### PR DESCRIPTION
Many websites (such as  http://ftpmirror.gnu.org/) issue redirects
(either from http to https or to a mirror) when doing HEAD or GET
requests. This causes autospec to not find gpg signature files
in too many cases.

This patch changes the curl code to just follow redirects