### PR TITLE
Move srpms and debuginfo into their own folder

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -126,7 +126,7 @@ def save_build_log(path, iteration):
     Must be saved outside of the results/ directory since it gets wiped away on
     each round.
     """
-    buildlog = os.path.join(path, "results", "build.log")
+    buildlog = os.path.join(path, "results", "logs", "build.log")
     shutil.copyfile(buildlog, "{}/build.log.round{}".format(path, iteration))
 
 

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -240,3 +240,18 @@ def package(filemanager, mockconfig, mockopts, cleanup=False):
         exit(1)
 
     parse_build_results(download_path + "/results/build.log", returncode, filemanager)
+
+    files = os.listdir('{}/results'.format(download_path))
+
+    os.makedirs('{}/results/srpm'.format(download_path), exist_ok=True)
+    os.makedirs('{}/results/debuginfo'.format(download_path), exist_ok=True)
+    os.makedirs('{}/results/logs'.format(download_path), exist_ok=True)
+
+    # organize output files so it's more clear what to use for mixes
+    for f in files:
+        if f.endswith(".src.rpm"):
+            shutil.move('{}/results/{}'.format(download_path, f), '{}/results/srpm/{}'.format(download_path, f))
+        if "debuginfo" in f:
+            shutil.move('{}/results/{}'.format(download_path, f), '{}/results/debuginfo/{}'.format(download_path, f))
+        if f.endswith(".log"):
+            shutil.move('{}/results/{}'.format(download_path, f), '{}/results/logs/{}'.format(download_path, f))

--- a/autospec/logcheck.py
+++ b/autospec/logcheck.py
@@ -23,7 +23,7 @@ import re
 
 
 def logcheck(pkg_loc):
-    log = os.path.join(pkg_loc, 'results', 'build.log')
+    log = os.path.join(pkg_loc, 'results', 'logs', 'build.log')
     if not os.path.exists(log):
         print('build log is missing, unable to perform logcheck.')
         return

--- a/autospec/test.py
+++ b/autospec/test.py
@@ -38,7 +38,7 @@ def check_regression(pkg_dir):
     if config.config_opts['skip_tests']:
         return
 
-    result = count.parse_log(os.path.join(pkg_dir, "results/build.log"))
+    result = count.parse_log(os.path.join(pkg_dir, "results/logs/build.log"))
     titles = [('Package', 'package name', 1),
               ('Total', 'total tests', 1),
               ('Pass', 'total passing', 1),


### PR DESCRIPTION
Debug info rpms are not added to bundles, and adding source RPMs will
make mixer crash because it looks for files that will not exist. Break
up the RPMs so it is more obvious which RPMs should be copied over for
building an image, and which ones are useful meta-data.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>