### PR TITLE
Add buildreq_cache

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -272,7 +272,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
 
     config.setup_patterns()
     config.config_file = args.config
-    config.parse_config_files(build.download_path, args.bump, filemanager)
+    config.parse_config_files(build.download_path, args.bump, filemanager, tarball.version)
     config.parse_existing_spec(build.download_path, tarball.name)
 
     if args.prep_only:
@@ -355,6 +355,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     logcheck(build.download_path)
 
     commitmessage.guess_commit_message(pkg_integrity.IMPORTED)
+    config.create_buildreq_cache(build.download_path, tarball.version)
 
     if args.git:
         git.commit_to_git(build.download_path)

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -49,7 +49,7 @@ def simple_pattern_pkgconfig(line, pattern, pkgconfig):
     pat = re.compile(pattern)
     match = pat.search(line)
     if match:
-        must_restart += buildreq.add_pkgconfig_buildreq(pkgconfig)
+        must_restart += buildreq.add_pkgconfig_buildreq(pkgconfig, cache=True)
 
 
 def simple_pattern(line, pattern, req):
@@ -57,7 +57,7 @@ def simple_pattern(line, pattern, req):
     pat = re.compile(pattern)
     match = pat.search(line)
     if match:
-        must_restart += buildreq.add_buildreq(req)
+        must_restart += buildreq.add_buildreq(req, cache=True)
 
 
 def failed_pattern(line, pattern, verbose, buildtool=None):
@@ -72,38 +72,38 @@ def failed_pattern(line, pattern, verbose, buildtool=None):
         if not buildtool:
             req = config.failed_commands[s]
             if req:
-                must_restart += buildreq.add_buildreq(req)
+                must_restart += buildreq.add_buildreq(req, cache=True)
         elif buildtool == 'pkgconfig':
-            must_restart += buildreq.add_pkgconfig_buildreq(s)
+            must_restart += buildreq.add_pkgconfig_buildreq(s, cache=True)
         elif buildtool == 'R':
-            if buildreq.add_buildreq("R-" + s) > 0:
+            if buildreq.add_buildreq("R-" + s, cache=True) > 0:
                 must_restart += 1
                 buildreq.add_requires("R-" + s)
         elif buildtool == 'perl':
-            must_restart += buildreq.add_buildreq('perl(%s)' % s)
+            must_restart += buildreq.add_buildreq('perl(%s)' % s, cache=True)
         elif buildtool == 'pypi':
             s = util.translate(s)
             if not s:
                 return
-            must_restart += buildreq.add_buildreq(util.translate('%s-python' % s))
+            must_restart += buildreq.add_buildreq(util.translate('%s-python' % s), cache=True)
         elif buildtool == 'ruby':
             if s in config.gems:
-                must_restart += buildreq.add_buildreq(config.gems[s])
+                must_restart += buildreq.add_buildreq(config.gems[s], cache=True)
             else:
-                must_restart += buildreq.add_buildreq('rubygem-%s' % s)
+                must_restart += buildreq.add_buildreq('rubygem-%s' % s, cache=True)
         elif buildtool == 'ruby table':
             if s in config.gems:
-                must_restart += buildreq.add_buildreq(config.gems[s])
+                must_restart += buildreq.add_buildreq(config.gems[s], cache=True)
             else:
                 print("Unknown ruby gem match", s)
         elif buildtool == 'maven':
             if s in config.maven_jars:
-                must_restart += buildreq.add_buildreq(config.maven_jars[s])
+                must_restart += buildreq.add_buildreq(config.maven_jars[s], cache=True)
             else:
-                must_restart += buildreq.add_buildreq('jdk-%s' % s)
+                must_restart += buildreq.add_buildreq('jdk-%s' % s, cache=True)
         elif buildtool == 'catkin':
-            must_restart += buildreq.add_pkgconfig_buildreq(s)
-            must_restart += buildreq.add_buildreq(s)
+            must_restart += buildreq.add_pkgconfig_buildreq(s, cache=True)
+            must_restart += buildreq.add_buildreq(s, cache=True)
 
     except:
         if verbose > 0:

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -32,6 +32,7 @@ import subprocess
 
 banned_requires = set()
 buildreqs = set()
+buildreqs_cache = set()
 requires = set()
 extra_cmake = set()
 verbose = False
@@ -53,11 +54,12 @@ autoreconf_reqs = ["gettext-bin",
                    "pkg-config-dev"]
 
 
-def add_buildreq(req):
+def add_buildreq(req, cache=False):
     """
     Add req to the global buildreqs set if req is not banned
     """
     global buildreqs
+    global buildreqs_cache
     new = True
 
     req.strip()
@@ -70,6 +72,8 @@ def add_buildreq(req):
         print("  Adding buildreq:", req)
 
     buildreqs.add(req)
+    if cache:
+        buildreqs_cache.add(req)
     return new
 
 
@@ -95,15 +99,15 @@ def add_requires(req, override=False):
     return new
 
 
-def add_pkgconfig_buildreq(preq):
+def add_pkgconfig_buildreq(preq, cache=False):
     """
     Format preq as pkgconfig req and add to buildreqs
     """
     if config.config_opts['32bit']:
         req = "pkgconfig(32" + preq + ")"
-        add_buildreq(req)
+        add_buildreq(req, cache)
     req = "pkgconfig(" + preq + ")"
-    return add_buildreq(req)
+    return add_buildreq(req, cache)
 
 
 def configure_ac_line(line):


### PR DESCRIPTION
Enable having a cache for detected buildreqs to avoid needing to
redetect the same buildreqs when rebuilding the same version of a
package.