### PR TITLE
cmake: properly unset the PKG_CONFIG_PATH variable

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1157,6 +1157,7 @@ class Specfile(object):
                               "-DLIB_SUFFIX=32 "
                               "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib " + self.extra_cmake)
             self._write_strip("make {}{}".format(config.parallel_build, self.extra_make))
+            self._write_strip("unset PKG_CONFIG_PATH")
             self._write_strip("popd")
 
         if config.config_opts['use_avx2']:


### PR DESCRIPTION
Otherwise, it'll be used by the AVX2 and AVX512 builds. The CFLAGS and
CXXFLAGS variables will be reset by the write_variables() calls.