### PR TITLE
Add pattern for handling missing meson build dependencies

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -178,6 +178,7 @@ simple_pats = [
 # failed_pattern patterns
 # contains patterns for parsing build.log for missing dependencies
 failed_pats = [
+    (r"Dependency (.*) found: NO", 0, None),
     (r"C library '(.*)' not found", 0, None),
     (r"Target '[a-zA-Z0-9\-]' can't be generated as '(.*)' could not be found", 0, None),
     (r"Program (.*) found: NO", 0, None),


### PR DESCRIPTION
In systemd-netlogd, the Dependency X found: NO pattern is used so add
it to the failed patterns regex.