### PR TITLE
Fixups for buildreq cache

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -72,7 +72,7 @@ def add_buildreq(req, cache=False):
         print("  Adding buildreq:", req)
 
     buildreqs.add(req)
-    if cache:
+    if cache and new:
         buildreqs_cache.add(req)
     return new
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -357,7 +357,7 @@ def create_buildreq_cache(path, version):
     with open(os.path.join(path, 'buildreq_cache'), mode) as cachefile:
         if old_version == version:
             # add newline to append new buildreqs to the exist cache
-            cachefile.write("\n".join(["\n"] + list(buildreq.buildreqs_cache)))
+            cachefile.write("\n".join([""] + list(buildreq.buildreqs_cache)))
         else:
             # include version with the cache
             cachefile.write("\n".join([version] + list(buildreq.buildreqs_cache)))


### PR DESCRIPTION
Only add content to the cache if it hasn't been added before (this
will prevent things that are always added from creeping into the cache
when they are detected to be added as well). Also don't add a newline
when appending content, just an empty string to allow new content to
be put on its own line without adding an empty line between new and
old cache content.