### PR TITLE
Add Module::Build as buildreq for Perl packages

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -598,6 +598,7 @@ def scan_for_configure(dirn):
             buildpattern.set_build_pattern(python_pattern, default_score)
 
         if "Makefile.PL" in files or "Build.PL" in files:
+            add_buildreq("perl-Module-Build")
             buildpattern.set_build_pattern("cpan", default_score)
 
         if "SConstruct" in files:


### PR DESCRIPTION
Add perl(Module::Build) to buildreqs for Perl packages that use
Module::Build to build themselves.

Fixes #191