### PR TITLE
Fixup multiline support for cmake_args

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -765,7 +765,7 @@ def parse_config_files(path, bump, filemanager, version):
         install_macro = content[0]
 
     content = read_conf_file(os.path.join(path, "cmake_args"))
-    extra_cmake = "\\\n".join(content)
+    extra_cmake = " \\\n".join(content)
 
     content = read_conf_file(os.path.join(path, "cmake_srcdir"))
     if content and content[0]:


### PR DESCRIPTION
This corrects cmake_args config files not handling multiple lines
correctly due to missing a space between the lines.