### PR TITLE
Be more picky on licenses from included spec files

### DIFF
--- a/autospec/specdescription.py
+++ b/autospec/specdescription.py
@@ -119,7 +119,7 @@ def description_from_spec(specfile):
             else:
                 words = clean_license_string(words).split()
                 for word in words:
-                    if ":" not in word or word.startswith('http'):
+                    if ":" not in word and not word.startswith("@"):
                         print("Adding license from spec:", word)
                         license.add_license(word)
 


### PR DESCRIPTION
Exclude likely macros from being used as licenses autospec will pick
up from the spec files included in the project's sources. As part of
this stop potentially adding urls as license strings.