### PR TITLE
Keep the list of licence files sorted

### DIFF
--- a/autospec/license.py
+++ b/autospec/license.py
@@ -143,4 +143,4 @@ def load_specfile(specfile):
     global licenses
     global license_files
     specfile.licenses = licenses if licenses else [default_license]
-    specfile.license_files = license_files
+    specfile.license_files = sorted(license_files)


### PR DESCRIPTION
Otherwise, after autospec'ing a package, the .spec file may change due
to the order in which the files were unpacked in the filesystem.

Things like:

 -cp LICENSE.LGPL3 %{buildroot}/usr/share/doc/PKGNAME/LICENSE.LGPL3
 -cp LICENSE.FDL %{buildroot}/usr/share/doc/PKGNAME/LICENSE.FDL
 +cp LICENSE.GPL3 %{buildroot}/usr/share/doc/PKGNAME/LICENSE.GPL3
  cp LICENSE.GPL3-EXCEPT %{buildroot}/usr/share/doc/PKGNAME/LICENSE.GPL3-EXCEPT
  cp LICENSE.GPL2 %{buildroot}/usr/share/doc/PKGNAME/LICENSE.GPL2
 -cp LICENSE.GPL3 %{buildroot}/usr/share/doc/PKGNAME/LICENSE.GPL3
 +cp LICENSE.FDL %{buildroot}/usr/share/doc/PKGNAME/LICENSE.FDL
 +cp LICENSE.LGPL3 %{buildroot}/usr/share/doc/PKGNAME/LICENSE.LGPL3

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>