### PR TITLE
Fixups for github url name and version detection

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -341,10 +341,10 @@ def name_and_version(name_arg, version_arg, filemanager):
         # define regex accepted for valid packages, important for specific
         # patterns to come before general ones
         github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/[v|r]?.*/(.*).tar",
-                           r"https?://github.com/(.*)/(.*?)/archive/[-a-zA-Z-_]*-(.*).tar",
+                           r"https?://github.com/(.*)/(.*?)/archive/[-a-zA-Z_]*-(.*).tar",
                            r"https?://github.com/(.*)/(.*?)/archive/[vVrR]?(.*).tar",
                            r"https?://github.com/(.*)/.*-downloads/releases/download/.*?/(.*)-(.*).tar",
-                           r"https?://github.com/(.*)/(.*?)/releases/download/.*?/(.*).tar",
+                           r"https?://github.com/(.*)/(.*?)/releases/download/(.*)/",
                            r"https?://github.com/(.*)/(.*?)/files/.*?/(.*).tar"]
 
         for pattern in github_patterns:
@@ -358,7 +358,10 @@ def name_and_version(name_arg, version_arg, filemanager):
                     name = re.sub("release-", '', name)
                     name = re.sub("\d*$", '', name)
                 rawname = name
-                version = convert_version(m.group(3))
+                version = m.group(3).replace(name, '')
+                if "archive" not in pattern:
+                    version = re.sub(r"^[-_.a-zA-Z]+", "", version)
+                version = convert_version(version)
                 giturl = "https://github.com/" + m.group(1).strip() + "/" + repo + ".git"
                 break
 

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -746,7 +746,7 @@ https://github.com/intel-iot-devkit/mraa/archive/v1.4.0.tar.gz,mraa,1.4.0
 http://pypi.debian.net/msgpack-python/msgpack-python-0.4.8.tar.gz,msgpack-python,0.4.8
 http://downloads.sourceforge.net/project/msmtp/msmtp/1.6.6/msmtp-1.6.6.tar.xz,msmtp,1.6.6
 https://01.org/sites/default/files/downloads/msr-tools/msr-tools-1.3.zip,msr-tools,1.3
-https://github.com/Mellanox/mstflint/releases/download/v4.7.0-1/mstflint-4.7.0.tar.gz,mstflint,4.7.0
+https://github.com/Mellanox/mstflint/releases/download/v4.7.0-1/mstflint-4.7.0.tar.gz,mstflint,4.7.0.1
 http://bitmath.org/code/mtdev/mtdev-1.1.5.tar.gz,mtdev,1.1.5
 http://ftp.gnome.org/pub/GNOME/sources/murrine/0.98/murrine-0.98.2.tar.xz,murrine,0.98.2
 https://www.musl-libc.org/releases/musl-1.1.16.tar.gz,musl,1.1.16
@@ -890,7 +890,7 @@ https://sourceforge.net/projects/pcre/files/pcre2/10.30/pcre2-10.30.tar.gz,pcre2
 http://pypi.debian.net/pecan/pecan-1.2.1.tar.gz,pecan,1.2.1
 https://github.com/erocarrera/pefile/releases/download/v2017.8.1/pefile-2017.8.1.tar.gz,pefile,2017.8.1
 http://pypi.debian.net/pep8/pep8-1.7.0.tar.gz,pep8,1.7.0
-https://github.com/linux-rdma/perftest/releases/download/V4.1-0.2/perftest-4.1-0.2.g770623f.tar.gz,perftest,4.1.0.2.g770623f
+https://github.com/linux-rdma/perftest/releases/download/V4.1-0.2/perftest-4.1-0.2.g770623f.tar.gz,perftest,4.1.0.2
 http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.21.tar.gz,perl-B-Hooks-EndOfScope,0.21
 http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.46.tar.gz,perl-Capture-Tiny,0.46
 http://search.cpan.org/CPAN/authors/id/T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz,perl-Class-Data-Inheritable,0.08


### PR DESCRIPTION
Improve version detection for the release pattern of github by using
the release tag specifically rather than the package filename.