### PR TITLE
Let make_check_command work for meson

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1324,6 +1324,7 @@ class Specfile(object):
             self._write_strip('popd')
 
         self._write_strip("\n")
+        self.write_check()
         self._write_strip("%install")
         if len(self.license_files) > 0:
             self._write_strip("mkdir -p %{buildroot}/usr/share/doc/" + self.name)


### PR DESCRIPTION
In the future would be nice to auto-identify this in scan_for_tests,
but the opt-in (by adding make_check_command file) is already useful.