### PR TITLE
Add a parser for CMake instruction files

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -308,6 +308,45 @@ def rakefile(filename):
                 print("Rakefile-new: rubygem-" + s)
 
 
+def parse_cmake(filename):
+    """
+    Scan a .cmake or CMakeLists.txt file for what's it's actually looking for
+    """
+    findpackage = re.compile(r"find_package\((\w+)\b.*\)", re.I)
+    pkgconfig = re.compile(r"pkg_check_modules\(\w+ (.*)\)", re.I)
+    pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
+                            'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
+    extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')
+
+    with open(filename, "r", encoding="latin-1") as f:
+        lines = f.readlines()
+    for line in lines:
+        match = findpackage.search(line)
+        if match:
+            module = match.group(1)
+            try:
+                pkg = config.cmake_modules[module]
+                add_buildreq(pkg)
+            except:
+                pass
+
+        match = pkgconfig.search(line)
+        if match:
+            rest = match.group(1)
+            while rest:
+                wordmatch = extractword.search(rest)
+                if not wordmatch:
+                    break
+                rest = wordmatch.group(3)
+                if wordmatch.group(2) in pkg_search_modifiers:
+                    continue
+                # Only one of the two groups can match at a time
+                pkg = wordmatch.group(1)
+                if not pkg:
+                    pkg = wordmatch.group(2)
+                add_pkgconfig_buildreq(pkg)
+
+
 def qmake_profile(filename):
     """
     Scan .pro file for build requirements
@@ -637,6 +676,9 @@ def scan_for_configure(dirn):
                 buildpattern.set_build_pattern("autogen", default_score)
             if name.lower() == "cmakelists.txt":
                 buildpattern.set_build_pattern("cmake", default_score)
+                parse_cmake(os.path.join(dirpath, name))
+            if name.endswith(".cmake") and buildpattern.default_pattern == "cmake":
+                parse_cmake(os.path.join(dirpath, name))
 
     can_reconf = os.path.exists(os.path.join(dirn, "configure.ac"))
     if not can_reconf:

--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -1,0 +1,88 @@
+# This file maps the CMake FIND_PACKAGE name to the packaage name, to be
+# added to BuildRequires. Please keep the list sorted
+# Format: <cmake modulename>, <pkg name(s)>
+AVIFile, avifile-dev
+ALSA, alsa-lib-dev
+ASPELL, aspell-dev
+Argon2, argon2-dev
+Backtrace, glibc-dev
+BISON, bison-dev
+BLAS, openblas-dev
+BZip2, bzip2-dev
+Boost, boost-dev
+CURL, curl-dev
+Cups, cups-dev
+Curses, ncurses-dev
+Doxygen, doxygen-dev
+EXPAT, expat-dev
+FLEX, flex
+FLTK, fltk-dev
+Freetype, freetype-dev
+GDAL, gdal-dev
+GLEW, glew-dev
+GLU, glu-devel
+GLUT, freeglut-dev
+GSL, gsl-dev
+GTest, googletest-dev
+GTK2, gtk+-dev
+Gcrypt, libgcrypt-dev
+Gettext, gettext-devel
+Git, git
+GnuTLS, gnutls-dev
+Gnuplot, gnuplot-dev
+HDF5, hdf5-dev
+Hg, hg
+ICU, icu4c-dev
+Iconv, glibc-dev
+Intl, glibc-dev
+JPEG, libjpeg-turbo-dev
+Java, openjdk9
+JNI, openjdk9-dev
+LATEX, latex
+LibArchive, libarchive-dev
+LibGPGError, libgpg-error-dev
+LibLZMA, xz-dev
+LibXml2, libxml2-dev
+LibXslt, libxslt-dev
+Lua, lu-dev
+MPI, openmpi-dev
+Motif, motif-dev
+OpenAL, openal-soft-dev
+OpenCL, beignet-dev
+OpenGL, mesa-dev
+OpenMP, cmake
+OpenSSL, openssl-dev
+PHP4, php-dev
+PNG, libpng-dev
+Patch, patch
+Perl, perl
+PerlLibs, perl-dev
+PkgConfig, pkg-config
+PostgreSQL, postgresql-dev
+Protobuf, protobuf-dev
+Python, python3
+PythonInterp, python3
+Python3, compat-python36 python3-dev
+PythonLibs, python3-dev
+Qt5, qtbase-dev qtbase-extras mesa-dev
+Qt5LinguistTools, qttools-dev qttools-extras
+Ruby, ruby
+SDL, SDL-dev
+SDL_image, SDL_image-dev
+SDL_mixer, SDL_mixer-dev
+SDL_sound, SDL_sound-dev
+SDL_net, SDL_net-dev
+SDL_ttf, SDL_ttf-dev
+SWIG, swig-dev
+Subversion, subversion
+TCL, tcl-dev tk-dev
+TIFF, tiff-dev
+Tclsh, tcl
+TclStub, tcl-dev
+Threads, glibc-dev
+UnixCommands, bash coreutils gzip
+Vulkan, vulkan-sdk-dev
+Wget, wget
+Wish, tk
+X11, libX11-dev libICE-dev libSM-dev libXau-dev libXcomposite-dev libXcursor-dev libXdamage-dev libXdmcp-dev libXext-dev libXfixes-dev libXft-dev libXi-dev libXinerama-dev libXi-dev libXmu-dev libXpm-dev libXrandr-dev libXrender-dev libXres-dev libXScrnSaver-dev libXt-dev libXtst-dev libXv-dev libXxf86misc-dev libXxf86vm-dev
+ZLIB, zlib-dev

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -77,6 +77,7 @@ license_hashes = {}
 license_translations = {}
 license_blacklist = {}
 qt_modules = {}
+cmake_modules = {}
 
 cves = []
 
@@ -480,6 +481,7 @@ def setup_patterns(path=None):
     global license_translations
     global license_blacklist
     global qt_modules
+    global cmake_modules
 
     read_pattern_conf("ignored_commands", ignored_commands, list_format=True, path=path)
     read_pattern_conf("failed_commands", failed_commands, path=path)
@@ -489,6 +491,7 @@ def setup_patterns(path=None):
     read_pattern_conf("license_translations", license_translations, path=path)
     read_pattern_conf("license_blacklist", license_blacklist, list_format=True, path=path)
     read_pattern_conf("qt_modules", qt_modules, path=path)
+    read_pattern_conf("cmake_modules", cmake_modules, path=path)
 
 
 def parse_existing_spec(path, name):


### PR DESCRIPTION
This is the first part of the change. It will now scan all
CMakeLists.txt and *.cmake files for find_package() calls and match
those against the cmake_modules file.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>