### PR TITLE
Improve python buildreq detection

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -337,6 +337,9 @@ def clean_python_req(req, add_python=True):
     if req.find("#") == 0:
         return ""
     ret = req.rstrip("\n\r").strip()
+    i = ret.find(";")
+    if i > 0:
+        ret = ret[:i]
     i = ret.find("<")
     if i > 0:
         ret = ret[:i]

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -229,6 +229,8 @@ class TestBuildreq(unittest.TestCase):
         """
         self.assertEqual(buildreq.clean_python_req('requirement >= 1.1.2'),
                          'requirement')
+        self.assertEqual(buildreq.clean_python_req('requirement ; python_version > 1.1.2'),
+                         'requirement')
 
     def test_clean_python_req_comment(self):
         """


### PR DESCRIPTION
Add additional logic to handle: "pkg ;  dep <= 'X'", style statements
for python requirements in setup.py. Also update tests to validate the
results are as expected.