### PR TITLE
Updates for Mock logs handling and common tooling integration

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -119,15 +119,16 @@ def read_old_metadata():
             archives)
 
 
-def save_build_log(path, iteration):
+def save_mock_logs(path, iteration):
     """
-    Save build log to <path>/build.log.round<iteration>
-
-    Must be saved outside of the results/ directory since it gets wiped away on
-    each round.
+    Save Mock build logs to <path>/results/round<iteration>-*.log
     """
-    buildlog = os.path.join(path, "results", "logs", "build.log")
-    shutil.copyfile(buildlog, "{}/build.log.round{}".format(path, iteration))
+    basedir = os.path.join(path, "results")
+    loglist = ["build", "root", "srpm-build", "srpm-root", "mock_srpm", "mock_build"]
+    for l in loglist:
+        src = "{}/{}.log".format(basedir, l)
+        dest = "{}/round{}-{}.log".format(basedir, iteration, l)
+        os.rename(src, dest)
 
 
 def write_prep(workingdir):
@@ -328,7 +329,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
         if build.round > 20 or build.must_restart == 0:
             break
 
-        save_build_log(build.download_path, build.round)
+        save_mock_logs(build.download_path, build.round)
 
     test.check_regression(build.download_path)
 

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -19,7 +19,6 @@
 import argparse
 import sys
 import os
-import shutil
 import re
 import tempfile
 import configparser

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -114,6 +114,7 @@ def commit_to_git(path):
         "*.zip",
         "commitmsg",
         "results/",
+        "rpms/",
         ""
     ]
     write_out(os.path.join(path, '.gitignore'), '\n'.join(ignorelist))

--- a/autospec/logcheck.py
+++ b/autospec/logcheck.py
@@ -23,7 +23,7 @@ import re
 
 
 def logcheck(pkg_loc):
-    log = os.path.join(pkg_loc, 'results', 'logs', 'build.log')
+    log = os.path.join(pkg_loc, 'results', 'build.log')
     if not os.path.exists(log):
         print('build log is missing, unable to perform logcheck.')
         return

--- a/autospec/test.py
+++ b/autospec/test.py
@@ -38,7 +38,7 @@ def check_regression(pkg_dir):
     if config.config_opts['skip_tests']:
         return
 
-    result = count.parse_log(os.path.join(pkg_dir, "results/logs/build.log"))
+    result = count.parse_log(os.path.join(pkg_dir, "results/build.log"))
     titles = [('Package', 'package name', 1),
               ('Total', 'total tests', 1),
               ('Pass', 'total passing', 1),


### PR DESCRIPTION
The Clear Linux common tooling has some pending changes to how Mock logs are handled, reverting mostly to the previous behavior, but introducing some improvements as well.

This PR aligns autospec with those changes.