### PR TITLE
Allow the RPM %check content to be more than one line

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -789,8 +789,8 @@ def parse_config_files(path, bump, filemanager, version):
         autoreconf = False
 
     content = read_conf_file(os.path.join(path, "make_check_command"))
-    if content and content[0]:
-        test.tests_config = content[0]
+    if content:
+        test.tests_config = '\n'.join(content)
 
     content = read_conf_file(os.path.join(path, tarball.name + ".license"))
     if content and content[0]:


### PR DESCRIPTION
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>