### PR TITLE
Fix 32-bit support for 'make' build pattern

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -874,6 +874,14 @@ class Specfile(object):
         if self.subdir:
             self._write_strip("popd")
         self._write_strip("\n")
+        if config.config_opts['32bit']:
+            self._write_strip("pushd ../build32/" + self.subdir)
+            self._write_strip("export PKG_CONFIG_PATH=\"/usr/lib32/pkgconfig\"")
+            self._write_strip("export CFLAGS=\"$CFLAGS -m32\"")
+            self._write_strip("export CXXFLAGS=\"$CXXFLAGS -m32\"")
+            self._write_strip("export LDFLAGS=\"$LDFLAGS -m32\"")
+            self.write_make_line(True)
+            self._write_strip("popd")
         self.write_check()
         self.write_make_install()
 


### PR DESCRIPTION
This is a basic adaptation of 32-bit support that exists for several other build patterns.