### PR TITLE
Improve pkg_check_modules support for cmake

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -313,7 +313,7 @@ def parse_cmake(filename):
     Scan a .cmake or CMakeLists.txt file for what's it's actually looking for
     """
     findpackage = re.compile(r"find_package\((\w+)\b.*\)", re.I)
-    pkgconfig = re.compile(r"pkg_check_modules\(\w+ (.*)\)", re.I)
+    pkgconfig = re.compile(r"pkg_check_modules\s*\(\w+ (.*)\)", re.I)
     pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
                             'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
     extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -165,12 +165,15 @@ def is_number(num_str):
         return False
 
 
-def parse_modules_list(modules_string):
+def parse_modules_list(modules_string, is_cmake=False):
     """
     parse the modules_string for the list of modules, stripping out the version
     requirements
     """
-    modules = [m.strip('[]') for m in modules_string.split()]
+    if is_cmake:
+        modules = [m for m in re.split(r'([><]?=)', modules_string)]
+    else:
+        modules = [m.strip('[]') for m in modules_string.split()]
     res = []
     next_is_ver = False
     for mod in modules:
@@ -341,10 +344,12 @@ def parse_cmake(filename):
                 if wordmatch.group(2) in pkg_search_modifiers:
                     continue
                 # Only one of the two groups can match at a time
-                pkg = wordmatch.group(1)
-                if not pkg:
-                    pkg = wordmatch.group(2)
-                add_pkgconfig_buildreq(pkg)
+                module = wordmatch.group(1)
+                if not module:
+                    module = wordmatch.group(2)
+                # We have a match, so strip out any version info
+                for m in parse_modules_list(module, is_cmake=True):
+                    add_pkgconfig_buildreq(m)
 
 
 def qmake_profile(filename):

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -436,6 +436,20 @@ class TestBuildreq(unittest.TestCase):
         self.assertEqual(buildreq.buildreqs,
                          set(['buildreq-golang', 'buildreq-cmake', 'buildreq-scons', 'buildreq-distutils3', 'buildreq-meson']))
 
+    def test_parse_cmake_pkg_check_modules(self):
+        """
+        Test parse_cmake to ensure accurate detection of versioned and
+        unversioned pkgconfig modules.
+        """
+        content = 'pkg_check_modules(GLIB gio-unix-2.0>=2.46.0 glib-2.0 REQUIRED)'
+        with tempfile.TemporaryDirectory() as tmpd:
+            with open(os.path.join(tmpd, 'fname'), 'w') as f:
+                f.write(content)
+            buildreq.parse_cmake(os.path.join(tmpd, 'fname'))
+
+        self.assertEqual(buildreq.buildreqs,
+                         set(['pkgconfig(gio-unix-2.0)', 'pkgconfig(glib-2.0)']))
+
 
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
There were a couple of autospec issues I ran into when building the latest libdnf. This series addresses those issues and adds a new unit test.