### PR TITLE
Download SHA256 checksums from download.qt.io

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -244,6 +244,8 @@ def get_signature_url(package_url):
 def get_hash_url(package_url):
     if 'download.gnome.org' in package_url:
         return package_url.replace('.tar.xz', '.sha256sum')
+    if 'download.qt.io' in package_url:
+        return package_url + '.sha256'
     return None
 
 


### PR DESCRIPTION
They're always there.

INFO   : Attempting to download http://download.qt.io/official_releases/qt/5.11/5.11.1/submodules/qtserialport-everywhere-src-5.11.1.tar.xz.sha256 for domain verification

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>