### PR TITLE
Add the ability to move certain files to dev

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -696,12 +696,17 @@ def parse_config_files(path, bump, filemanager, version):
 
     content = read_conf_file(os.path.join(path, "extras"))
     for extra in content:
-        print("extras for: %s." % extra)
+        print("extras for  : %s." % extra)
     filemanager.extras += content
+
+    content = read_conf_file(os.path.join(path, "dev_extras"))
+    for extra in content:
+        print("dev for     : %s." % extra)
+    filemanager.dev_extras += content
 
     content = read_conf_file(os.path.join(path, "setuid"))
     for suid in content:
-        print("setuid for: %s." % suid)
+        print("setuid for  : %s." % suid)
     filemanager.setuid += content
 
     content = read_conf_file(os.path.join(path, "attrs"))

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -39,6 +39,7 @@ class FileManager(object):
         self.files_blacklist = set()
         self.excludes = []
         self.extras = []
+        self.dev_extras = []
         self.setuid = []
         self.attrs = {}
         self.locales = []
@@ -188,6 +189,9 @@ class FileManager(object):
         # extras
         if filename in self.extras:
             self.push_package_file(filename, "extras")
+            self.excludes.append(filename)
+        if filename in self.dev_extras:
+            self.push_package_file(filename, "dev")
             self.excludes.append(filename)
 
         if filename in self.setuid:


### PR DESCRIPTION
This is useful when the package includes executables used for
development but not for other cases.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>