### PR TITLE
Fix the location of files explicitly moved by configuration

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -275,6 +275,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     config.parse_config_files(build.download_path, args.bump, filemanager, tarball.version)
     config.setup_patterns(config.failed_pattern_dir)
     config.parse_existing_spec(build.download_path, tarball.name)
+    filemanager.compile_patterns()
 
     if args.prep_only:
         write_prep(workingdir)

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -711,11 +711,8 @@ def parse_config_files(path, bump, filemanager, version):
 
     content = read_conf_file(os.path.join(path, "attrs"))
     for line in content:
-        attr = re.split(r'\(|\)|,', line)
-        attr = [a.strip() for a in attr]
-        filename = attr.pop()
         print("attr for: %s." % filename)
-        filemanager.attrs[filename] = attr
+    filemanager.attrs += content
 
     patches += read_conf_file(os.path.join(path, "series"))
     pfiles = [("%s/%s" % (path, x.split(" ")[0])) for x in patches]

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -25,6 +25,7 @@ import config
 import re
 import os
 import util
+import sys
 from collections import OrderedDict
 # todo package splits
 
@@ -41,13 +42,147 @@ class FileManager(object):
         self.extras = []
         self.dev_extras = []
         self.setuid = []
-        self.attrs = {}
+        self.attrs = []
         self.locales = []
         self.newfiles_printed = False
         # Do we need ALL include files in a dev package, even if they're not in
         # /usr/include?  Yes in the general case, but for example for R
         # packages, the answer is No.
         self.want_dev_split = True
+
+
+    def compile_patterns(self):
+        def make_pattern(file, package="main"):
+            if file.startswith("/") or file.startswith('%'):
+                return (re.compile(re.escape(file)), package)
+            if file.startswith("^"):
+                return (re.compile(file), package)
+            util.print_fatal("Line in {} pattern must be absolute or start with ^: {}"
+                             .format(package, file))
+            sys.exit(1)
+
+        # Prepare compiled patterns
+        self.patterns = []
+
+        # Start with the rules for manual config
+        for file in self.excludes:
+            self.patterns.append((make_pattern(file, "excludes")[0], "main", "%exclude "))
+        for file in self.extras:
+            self.patterns.append(make_pattern(file, "extras"))
+        for file in self.dev_extras:
+            self.patterns.append(make_pattern(file, "dev"))
+        for file in self.setuid:
+            self.patterns.append((*make_pattern(file, "setuid"), "%attr(4755, root, root) "))
+        for line in self.attrs:
+            attr = re.split(r'\(|\)|,', line)
+            attr = [a.strip() for a in attr]
+            file = attr.pop()
+            prefix = "{0}({1}) ".format(attr[0], ','.join(attr[1:3]))
+            self.patterns.append((re.compile(re.escape(file)), "attrs", prefix))
+
+        # if configured to do so, add .so files to the lib package instead of
+        # the dev package. THis is useful for packages with a plugin
+        # architecture like elfutils and mesa.
+        so_dest = 'lib' if config.config_opts.get('so_to_lib') else 'dev'
+        patterns = [
+            # Patterns for matching files, format is a tuple as follows:
+            # (<raw pattern>, <package>, <optional prefix>)
+            # order matters!
+            (r"^/usr/share/doc/.*/.*COPYING.*", "license"),
+            (r"^/usr/share/doc/.*/.*COPYRIGHT.*", "license"),
+            (r"^/usr/share/doc/.*/.*GPL.*", "license"),
+            (r"^/usr/share/doc/.*/.*MIT.*", "license"),
+            (r"^/usr/share/doc/.*/.*LICENSE.*", "license"),
+            (r"^/usr/share/doc/.*/.*license.*", "license"),
+            (r"^/usr/share/man/man2", "dev"),
+            (r"^/usr/share/man/man3", "dev"),
+            (r"^/usr/share/man/", "man"),
+            (r"^/usr/share/omf", "main"),
+            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
+            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
+            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib32"),
+            (r"^/usr/lib64/lib(asm|dw|elf)-[0-9.]+\.so", "lib"),
+            (r"^/usr/lib32/lib(asm|dw|elf)-[0-9.]+\.so", "lib32"),
+            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
+            (r"^/usr/lib64/gobject-introspection/", "lib"),
+            (r"^/usr/libexec/", "bin"),
+            (r"^/usr/bin/", "bin"),
+            (r"^/usr/sbin/", "bin"),
+            (r"^/sbin/", "bin"),
+            (r"^/bin/", "bin"),
+            (r"^/usr/lib/python3.*/", "python3"),
+            (r"^/usr/lib/python2.*/", "legacypython"),
+            (r"^/usr/lib64/python.*/", "python"),
+            (r"^/usr/share/gir-[0-9\.]+/[a-zA-Z0-9\.\_\-\+]*\.gir", "data"),
+            (r"^/usr/share/girepository-1\.0/.*\.typelib\$", "data"),
+            (r"^/usr/share/cmake/", "data"),
+            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.hxx", "dev"),
+            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.hpp", "dev"),
+            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.h\+\+", "dev"),
+            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.h", "dev"),
+            (r"^/usr/include/", "dev"),
+            (r"^/usr/lib64/girepository-1.0/", "data"),
+            (r"^/usr/share/cmake/", "dev"),
+            (r"^/usr/lib/cmake/", "dev"),
+            (r"^/usr/lib64/cmake/", "dev"),
+            (r"^/usr/lib32/cmake/", "dev32"),
+            (r"^/usr/lib/qt5/mkspecs/", "dev"),
+            (r"^/usr/lib64/qt5/mkspecs/", "dev"),
+            (r"^/usr/lib32/qt5/mkspecs/", "dev32"),
+            (r"^/usr/lib/qt5/", "lib"),
+            (r"^/usr/lib64/qt5/", "lib"),
+            (r"^/usr/lib32/qt5/", "lib32"),
+            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
+            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
+            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest + '32'),
+            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
+            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev"),
+            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev"),
+            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev32"),
+            (r"^/usr/lib/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev"),
+            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev"),
+            (r"^/usr/lib32/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev32"),
+            (r"^/usr/lib/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev"),
+            (r"^/usr/lib64/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev"),
+            (r"^/usr/lib32/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev32"),
+            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev"),
+            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev"),
+            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev32"),
+            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev"),
+            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev"),
+            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev32"),
+            (r"^/usr/share/aclocal/[a-zA-Z0-9\.\_\-\+]*\.ac$", "dev"),
+            (r"^/usr/share/aclocal/[a-zA-Z0-9\.\_\-\+]*\.m4$", "dev"),
+            (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9\.\_\-\+]*\.ac$", "dev"),
+            (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9\.\_\-\+]*\.m4$", "dev"),
+            (r"^/usr/share/doc/" + re.escape(tarball.name) + "/", "doc", "%doc "),
+            (r"^/usr/share/doc/", "doc"),
+            (r"^/usr/share/gtk-doc/html", "doc"),
+            (r"^/usr/share/help", "doc"),
+            (r"^/usr/share/info/", "doc", "%doc "),
+            (r"^/etc/systemd/system/.*\.wants/", "active-units"),
+            # now a set of catch-all rules
+            (r"^/etc/", "config", "%config "),
+            (r"^/usr/etc/", "config", "%config "),
+            (r"^/lib/systemd", "config"),
+            (r"^/usr/lib/systemd", "config"),
+            (r"^/usr/lib/udev/rules.d", "config"),
+            (r"^/usr/lib/modules-load.d", "config"),
+            (r"^/usr/lib/tmpfiles.d", "config"),
+            (r"^/usr/lib/sysusers.d", "config"),
+            (r"^/usr/lib/sysctl.d", "config"),
+            (r"^/usr/share/", "data"),
+            # finally move any dynamically loadable plugins (not
+            # perl/python/ruby/etc.. extensions) into lib package
+            (r"^/usr/lib/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib"),
+            (r"^/usr/lib64/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib"),
+            (r"^/usr/lib32/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib32"),
+            # locale data gets picked up via file_is_locale
+            (r"^/usr/share/locale/", "ignore")]
+
+        for p in patterns:
+            self.patterns.append((re.compile(p[0]), ) + p[1:])
+
 
     def push_package_file(self, filename, package="main"):
         """
@@ -86,17 +221,15 @@ class FileManager(object):
 
         return exclude
 
-    def file_pat_match(self, filename, pattern, package, replacement="", prefix=""):
+    def file_pat_match(self, filename, pat, package, prefix=""):
         """
         Search for pattern in filename, if pattern matches push package file.
         If that file is also in the excludes list, prepend "%exclude " before
         pushing the filename.
         Returns True if a file was pushed, False otherwise.
         """
-        if not replacement:
-            replacement = prefix + filename
+        replacement = prefix + filename
 
-        pat = re.compile(pattern)
         match = pat.search(filename)
         if match:
             if filename in self.excludes or self.compat_exclude(filename):
@@ -184,144 +317,24 @@ class FileManager(object):
         part = re.compile(r"^/usr/lib/systemd/system/.+\.target\.wants/.+")
         if part.search(filename) and 'update-triggers.target.wants' not in filename:
             self.push_package_file(filename, "autostart")
-            self.excludes.append(filename)
-
-        # extras
-        if filename in self.extras:
-            self.push_package_file(filename, "extras")
-            self.excludes.append(filename)
-        if filename in self.dev_extras:
-            self.push_package_file(filename, "dev")
-            self.excludes.append(filename)
-
-        if filename in self.setuid:
-            newfn = "%attr(4755, root, root) " + filename
-            self.push_package_file(newfn, "setuid")
-            self.excludes.append(filename)
+            self.push_package_file("%exclude " + filename)
 
         if filename in self.attrs:
             newfn = "{0}({1}) {2}".format(self.attrs[filename][0],
                                           ','.join(self.attrs[filename][1:3]),
                                           filename)
             self.push_package_file(newfn, "attr")
-            self.excludes.append(filename)
-
-        if self.want_dev_split and self.file_pat_match(filename, r"^/usr/.*/include/.*\.h$", "dev"):
-            return
-
-        # if configured to do so, add .so files to the lib package instead of
-        # the dev package. THis is useful for packages with a plugin
-        # architecture like elfutils and mesa.
-        so_dest = 'lib' if config.config_opts.get('so_to_lib') else 'dev'
-
-        patterns = [
-            # Patterns for matching files, format is a tuple as follows:
-            # (<raw pattern>, <package>, <optional replacement>, <optional prefix>)
-            # order matters!
-            (r"^/usr/share/doc/.*/.*COPYING.*", "license"),
-            (r"^/usr/share/doc/.*/.*COPYRIGHT.*", "license"),
-            (r"^/usr/share/doc/.*/.*GPL.*", "license"),
-            (r"^/usr/share/doc/.*/.*MIT.*", "license"),
-            (r"^/usr/share/doc/.*/.*LICENSE.*", "license"),
-            (r"^/usr/share/doc/.*/.*license.*", "license"),
-            (r"^/usr/share/man/man2", "dev"),
-            (r"^/usr/share/man/man3", "dev"),
-            (r"^/usr/share/man/", "man"),
-            (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
-            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
-            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
-            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib32"),
-            (r"^/usr/lib64/lib(asm|dw|elf)-[0-9.]+\.so", "lib"),
-            (r"^/usr/lib32/lib(asm|dw|elf)-[0-9.]+\.so", "lib32"),
-            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.so\.", "lib"),
-            (r"^/usr/lib64/gobject-introspection/", "lib"),
-            (r"^/usr/libexec/", "bin"),
-            (r"^/usr/bin/", "bin"),
-            (r"^/usr/sbin/", "bin"),
-            (r"^/sbin/", "bin"),
-            (r"^/bin/", "bin"),
-            (r"^/usr/lib/python3.*/", "python3", "/usr/lib/python3*/*"),
-            (r"^/usr/lib/python2.*/", "legacypython", "/usr/lib/python2*/*"),
-            (r"^/usr/lib64/python.*/", "python", "/usr/lib64/python*/*"),
-            (r"^/usr/share/gir-[0-9\.]+/[a-zA-Z0-9\.\_\-\+]*\.gir", "data", "/usr/share/gir-1.0/*.gir"),
-            (r"^/usr/share/cmake/", "data", "/usr/share/cmake/*"),
-            (r"^/usr/share/cmake-3.1/", "data", "/usr/share/cmake-3.1/*"),
-            (r"^/usr/share/cmake-3.7/", "data", "/usr/share/cmake-3.7/*"),
-            (r"^/usr/share/cmake-3.8/", "data", "/usr/share/cmake-3.8/*"),
-            (r"^/usr/share/cmake-3.6/", "data", "/usr/share/cmake-3.6/*"),
-            (r"^/usr/share/girepository-1\.0/.*\.typelib\$", "data", "/usr/share/girepository-1.0/*.typelib"),
-            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.hxx", "dev", "/usr/include/*.hxx"),
-            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.hpp", "dev", "/usr/include/*.hpp"),
-            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.h\+\+", "dev", "/usr/include/*.h\+\+"),
-            (r"^/usr/include/[a-zA-Z0-9\.\_\-\+]*\.h", "dev", "/usr/include/*.h"),
-            (r"^/usr/include/", "dev"),
-            (r"^/usr/lib64/girepository-1.0/", "data"),
-            (r"^/usr/share/cmake/", "dev"),
-            (r"^/usr/lib/cmake/", "dev"),
-            (r"^/usr/lib64/cmake/", "dev"),
-            (r"^/usr/lib32/cmake/", "dev32"),
-            (r"^/usr/lib/qt5/mkspecs/", "dev"),
-            (r"^/usr/lib64/qt5/mkspecs/", "dev"),
-            (r"^/usr/lib32/qt5/mkspecs/", "dev32"),
-            (r"^/usr/lib/qt5/", "lib"),
-            (r"^/usr/lib64/qt5/", "lib"),
-            (r"^/usr/lib32/qt5/", "lib32"),
-            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
-            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
-            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest + '32'),
-            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.so$", so_dest),
-            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev", "/usr/lib/*.a"),
-            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev", "/usr/lib64/*.a"),
-            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev32", "/usr/lib32/*.a"),
-            (r"^/usr/lib/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev", "/usr/lib/haswell/*.a"),
-            (r"^/usr/lib64/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev", "/usr/lib64/haswell/*.a"),
-            (r"^/usr/lib32/haswell/[a-zA-Z0-9\.\_\-\+]*\.a$", "dev32", "/usr/lib32/haswell/*.a"),
-            (r"^/usr/lib/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev"),
-            (r"^/usr/lib64/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev"),
-            (r"^/usr/lib32/pkgconfig/[a-zA-Z0-9\.\_\-\+]*\.pc$", "dev32"),
-            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev"),
-            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev"),
-            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.la$", "dev32"),
-            (r"^/usr/lib/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev"),
-            (r"^/usr/lib64/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev"),
-            (r"^/usr/lib32/[a-zA-Z0-9\.\_\-\+]*\.prl$", "dev32"),
-            (r"^/usr/share/aclocal/[a-zA-Z0-9\.\_\-\+]*\.ac$", "dev", "/usr/share/aclocal/*.ac"),
-            (r"^/usr/share/aclocal/[a-zA-Z0-9\.\_\-\+]*\.m4$", "dev", "/usr/share/aclocal/*.m4"),
-            (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9\.\_\-\+]*\.ac$", "dev", "/usr/share/aclocal-1.*/*.ac"),
-            (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9\.\_\-\+]*\.m4$", "dev", "/usr/share/aclocal-1.*/*.m4"),
-            (r"^/usr/share/doc/" + re.escape(tarball.name) + "/", "doc", "%doc /usr/share/doc/" + re.escape(tarball.name) + "/*"),
-            (r"^/usr/share/doc/", "doc"),
-            (r"^/usr/share/gtk-doc/html", "doc"),
-            (r"^/usr/share/help", "doc"),
-            (r"^/usr/share/info/", "doc", "%doc /usr/share/info/*"),
-            (r"^/etc/systemd/system/.*\.wants/", "active-units"),
-            # now a set of catch-all rules
-            (r"^/etc/", "config", "", "%config "),
-            (r"^/usr/etc/", "config", "", "%config "),
-            (r"^/lib/systemd", "config"),
-            (r"^/usr/lib/systemd", "config"),
-            (r"^/usr/lib/udev/rules.d", "config"),
-            (r"^/usr/lib/modules-load.d", "config"),
-            (r"^/usr/lib/tmpfiles.d", "config"),
-            (r"^/usr/lib/sysusers.d", "config"),
-            (r"^/usr/lib/sysctl.d", "config"),
-            (r"^/usr/share/", "data"),
-            # finally move any dynamically loadable plugins (not
-            # perl/python/ruby/etc.. extensions) into lib package
-            (r"^/usr/lib/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib"),
-            (r"^/usr/lib64/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib"),
-            (r"^/usr/lib32/.*/[a-zA-Z0-9\.\_\-\+]*\.so", "lib32"),
-            # locale data gets picked up via file_is_locale
-            (r"^/usr/share/locale/", "ignore")]
-
-        for pat_args in patterns:
-            if self.file_pat_match(filename, *pat_args):
-                return
-
-        if filename in self.excludes:
             self.push_package_file("%exclude " + filename)
             return
 
+        if self.want_dev_split and self.file_pat_match(filename, re.compile(r"^/usr/.*/include/.*\.h$"), "dev"):
+            return
+
+        for pat_args in self.patterns:
+            if self.file_pat_match(filename, *pat_args):
+                return
+
+        # Everything else goes to the main package
         self.push_package_file(filename)
 
     def remove_file(self, filename):


### PR DESCRIPTION
Instead of adding an %exclude line to the main package, simply don't
list it at all. RPM only complains if the file isn't in any package at
all; since we're adding to one of the subpackages, that is sufficient.

This fixes the issue that it wasn't possible to explicitly move a file
moved from one subpackage to another (dev or extras), as the
pattern-matching would make it show up in two.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>