### PR TITLE
Checking return code after download

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -63,6 +63,11 @@ def really_download(upstream_url, destination):
         c.setopt(c.FOLLOWLOCATION, True)
         try:
             c.perform()
+            code = c.getinfo(pycurl.HTTP_CODE)
+            if code != 200:
+                print_fatal("get request to {} returned {}".format(upstream_url, code))
+                os.remove(destination)
+                exit(1)
         except pycurl.error as excep:
             print_fatal("unable to download {}: {}".format(upstream_url, excep))
             os.remove(destination)


### PR DESCRIPTION
Function really_download in tarball.py does not handle http server
codes that can be interpreted as errors i.e. 404 501. When there is no
failure returned in a 404 response the 404 page contents are saved as
the tarball. This change adds code to test that the response from the
server is a 200

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>