### PR TITLE
Add the ability to make the dev package depend on extras

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -119,6 +119,7 @@ config_options = {
     "verify_required": "require package verification for build",
     "security_sensitive": "set flags for security-sensitive builds",
     "so_to_lib": "add .so files to the lib package instead of dev",
+    "dev_requires_extras": "dev package requires the extras to be installed",
     "autoupdate": "this package is trusted enough to automatically update "
                   "(used by other tools)",
     "compat": "this package is a library compatability package and only "

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -245,6 +245,8 @@ class Specfile(object):
         deps["lib"] = ["data", "license"]
         deps["lib32"] = ["data", "license"]
         deps["python"] = ["python3"]
+        if config.config_opts['dev_requires_extras']:
+            deps["dev"].append("extras")
 
         # migration workaround; if we have a python3 or legacypython package
         # we add an artificial python package


### PR DESCRIPTION
Sometimes we move libraries with API to extras, so the dev package
should cause it to be installed.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>