### PR TITLE
Add 7z support

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1144,7 +1144,7 @@ class Specfile(object):
         self.subdir = "clr-build"
         self.write_prep()
         self.write_lang_c(export_epoch=True)
-        self._write_strip("mkdir clr-build")
+        self._write_strip("mkdir -p clr-build")
         self._write_strip("pushd clr-build")
         self.write_variables()
         self._write_strip("%cmake {} {}".format(self.cmake_srcdir, self.extra_cmake))
@@ -1161,7 +1161,7 @@ class Specfile(object):
         self._write_strip("popd")
 
         if config.config_opts['32bit']:
-            self._write_strip("mkdir clr-build32")
+            self._write_strip("mkdir -p clr-build32")
             self._write_strip("pushd clr-build32")
             self.write_variables()
             self._write_strip('export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"')
@@ -1175,7 +1175,7 @@ class Specfile(object):
             self._write_strip("popd")
 
         if config.config_opts['use_avx2']:
-            self._write_strip("mkdir clr-build-avx2")
+            self._write_strip("mkdir -p clr-build-avx2")
             self._write_strip("pushd clr-build-avx2")
             saved_avx2flags = self.need_avx2_flags
             self.need_avx2_flags = True
@@ -1188,7 +1188,7 @@ class Specfile(object):
             self._write_strip("popd")
 
         if config.config_opts['use_avx512']:
-            self._write_strip("mkdir clr-build-avx512")
+            self._write_strip("mkdir -p clr-build-avx512")
             self._write_strip("pushd clr-build-avx512")
             saved_avx512flags = self.need_avx512_flags
             self.need_avx512_flags = True

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -156,6 +156,64 @@ def build_unzip(zip_path):
     return extract_cmd, prefix
 
 
+def build_un7z(zip_path):
+    """Return correct 7z command and the prefix folder name of the contents of 7z file
+
+    This function will run the 7z file through a content list, parsing that list to get the
+    root folder name containing the 7z file's contents.
+
+    The output of the 7z l command has the following format:
+    ***snip***
+    7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+    p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,4 CPUs Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz (406E3),ASM,AES-NI)
+
+    Scanning the drive for archives:
+    1 file, 7933454 bytes (7748 KiB)
+
+    Listing archive: foo.7z
+
+    --
+    Path = foo.7z
+    Type = 7z
+    Physical Size = 7933454
+    Headers Size = 1526
+    Method = LZMA2:23
+    Solid = +
+    Blocks = 1
+
+    Date         Time    Attr         Size   Compressed  Name
+    ------------------- ----- ------------ ------------  ------------------------
+    2018-05-15 05:50:54 ....A        25095      7931928  prefix-dir/sub_dir1/subdir2
+    ***snip***
+
+    and this function gets the 'prefix-dir' portion from the start of the unzip -l output.
+    """
+    prefix = ""
+    contents = subprocess.check_output(["7z", "l", zip_path], universal_newlines=True)
+    lines = contents.splitlines() if contents else []
+    # looking for directory prefix in unzip output as it may differ from default
+    past_header = False
+    for line in lines:
+        if past_header:
+            # This should be an archive entry; use it
+            prefix = line.split("/")[0].split()[-1]
+            break
+        if line.startswith('----------'):
+            # This is the header line; next line should be an archive entry
+            past_header = True
+
+    if not past_header:
+        print_fatal("Zip file doesn't appear to have any content")
+        exit(1)
+
+    if not prefix:
+        print_fatal("Malformed zipfile, unable to determine zipfile prefix")
+        exit(1)
+
+    extract_cmd = "7z x -o{0} {1}".format(build.base_path, zip_path)
+    return extract_cmd, prefix
+
+
 def build_gem_unpack(tarball_path):
     """
     gem unpack --verbose
@@ -496,6 +554,8 @@ def process_archives(archives):
         source_tarball_path = check_or_get_file(archive, os.path.basename(archive))
         if source_tarball_path.lower().endswith('.zip'):
             extract_cmd, source_tarball_prefix = build_unzip(source_tarball_path)
+        elif source_tarball_path.lower().endswith('.7z'):
+            extract_cmd, source_tarball_prefix = build_un7z(source_tarball_path)
         else:
             extract_cmd, source_tarball_prefix = build_untar(source_tarball_path)
         buildpattern.archive_details[archive + "prefix"] = source_tarball_prefix

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -133,6 +133,16 @@ class TestTarballVersionName(unittest.TestCase):
         self.assertEqual(tarball.build_unzip('zip/path'),
                          ('unzip -qq -d . zip/path', 'prefix-dir'))
 
+    def test_build_un7z(self):
+        """
+        Test build_un7z
+        """
+        check_output_backup = subprocess.check_output
+        tarball.subprocess.check_output = mock_gen(rv=UN7Z_OUT)
+        tarball.build.base_path = '.'
+        self.assertEqual(tarball.build_un7z('zip/path'),
+                         ('7z x -o. zip/path', 'src'))
+
     def test_build_gem_unpack(self):
         """
         Test build_gem_unpack
@@ -199,6 +209,37 @@ GEM_OUT = '/path/to/dir/file1\n'                           \
           '...\n'                                          \
           'Unpacked gem: \'/path/to/gem/test-prefix\''
 
+
+UN7Z_OUT = '\n'                                                             \
+           '7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : '      \
+           '2016-05-21\n'                                                   \
+           'p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,' \
+           '64 bits,4 CPUs Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz (406E3)'\
+           ',ASM,AES-NI)\n'                                                 \
+           '\n'                                                             \
+           'Scanning the drive for archives:\n'                             \
+           '1 file, 7933454 bytes (7748 KiB)\n'                             \
+           '\n'                                                             \
+           'Listing archive: converted_ogg_to_mp3-0.91.7z\n'                \
+           '\n'                                                             \
+           '--\n'                                                           \
+           'Path = converted_ogg_to_mp3-0.91.7z\n'                          \
+           'Type = 7z\n'                                                    \
+           'Physical Size = 7933454\n'                                      \
+           'Headers Size = 1526\n'                                          \
+           'Method = LZMA2:23\n'                                            \
+           'Solid = +\n'                                                    \
+           'Blocks = 1\n'                                                   \
+           '\n'                                                             \
+           '   Date      Time    Attr         Size   Compressed  Name\n'    \
+           '------------------- ----- ------------ ------------  '          \
+           '------------------------\n'                                     \
+           '2018-05-15 05:50:54 ....A        25095      7931928  '          \
+           'src/activities/chronos/resource/sound/1.mp3\n'                  \
+           '2018-05-15 05:50:54 ....A        23214               '          \
+           'src/activities/chronos/resource/sound/2.mp3\n'                  \
+           '2018-05-15 05:50:54 ....A        36589               '          \
+           'src/activities/chronos/resource/sound/3.mp3\n'
 
 # Run test_setup to generate tests
 test_setup()


### PR DESCRIPTION
The mkdir -p change is required for archives that need to be pre-extracted under the build directory for cmake projects.

The main change is implementing a function to handle 7z archives, basically ripped off from build_unzip, but modified to deal with 7z's extra-verbose headers.

All together, this allows me to build a cmake-based package that requires downloading some media and translations that are distributed as 7z archives.