### PR TITLE
Add new failed pattern

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -195,6 +195,7 @@ failed_pats = [
     (r"Checking for (.*?)\s*: not found", 0, None),
     (r"configure: error: pkg-config missing (.*)", 0, None),
     (r"configure: error: Cannot find (.*)\. Make sure", 0, None),
+    (r"configure: error: (.*) not found", 0, None),
     (r"checking for (.*?)\.\.\. no", 0, None),
     (r"checking for (.*) support\.\.\. no", 0, None),
     (r"checking (.*?)\.\.\. no", 0, None),


### PR DESCRIPTION
In response to autospec failing to detect a configure failure, add new
pattern to be used for detection.