### PR TITLE
Improve handling variables in pkg_check_modules

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -181,7 +181,7 @@ def parse_modules_list(modules_string, is_cmake=False):
     requirements
     """
     if is_cmake:
-        modules = [m for m in re.split(r'(\s*[><]?=\s*)', modules_string)]
+        modules = [m for m in re.split(r'\s*([><]?=|\${?[^}]*}?)\s*', modules_string)]
         modules = filter(None, modules)
     else:
         modules = [m.strip('[]') for m in modules_string.split()]

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -465,5 +465,20 @@ class TestBuildreq(unittest.TestCase):
                          set(['pkgconfig(gio-unix-2.0)', 'pkgconfig(glib-2.0)']))
 
 
+    def test_parse_cmake_pkg_check_modules_variables(self):
+        """
+        Test parse_cmake to ensure accurate handling of versioned
+        pkgconfig modules with variable version strings.
+        """
+        content = 'pkg_check_modules(AVCODEC libavcodec${_avcodec_ver} libavutil$_avutil_ver)'
+        with tempfile.TemporaryDirectory() as tmpd:
+            with open(os.path.join(tmpd, 'fname'), 'w') as f:
+                f.write(content)
+            buildreq.parse_cmake(os.path.join(tmpd, 'fname'))
+
+        self.assertEqual(buildreq.buildreqs,
+                         set(['pkgconfig(libavcodec)', 'pkgconfig(libavutil)']))
+
+
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
Strip out variables in e.g.:
pkg_check_modules(AVCODEC libavcodec${_avcodec_ver})