### PR TITLE
Remove obsolete compat-python36 from cmake module mapping

### DIFF
--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -69,7 +69,7 @@ PostgreSQL, postgresql-dev
 Protobuf, protobuf-dev
 PulseAudio, extra-cmake-modules pkgconfig(libpulse)
 Python, python3
-Python3, compat-python36 python3-dev
+Python3, python3-dev
 PythonInterp, python3
 PythonLibs, python3-dev
 QHelpGenerator, extra-cmake-modules qttools-dev


### PR DESCRIPTION
The compat-python36 package no longer exists in latest Clear Linux, so it should be removed from this mapping file.