### PR TITLE
Fix typo "xcb-utl-dev" -> "xcb-util-dev"

### DIFF
--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -100,5 +100,5 @@ Wget, wget
 Wish, tk
 X11, libX11-dev libICE-dev libSM-dev libXau-dev libXcomposite-dev libXcursor-dev libXdamage-dev libXdmcp-dev libXext-dev libXfixes-dev libXft-dev libXi-dev libXinerama-dev libXi-dev libXmu-dev libXpm-dev libXrandr-dev libXrender-dev libXres-dev libXScrnSaver-dev libXt-dev libXtst-dev libXv-dev libXxf86misc-dev libXxf86vm-dev
 X11_XCB, extra-cmake-modules pkgconfig(x11-xcb)
-XCB, extra-cmake-modules pkgconfig(xcb) xcb-util-cursor-dev xcb-util-image-dev xcb-util-keysyms-dev xcb-util-renderutil-dev xcb-util-wm-dev xcb-utl-dev
+XCB, extra-cmake-modules pkgconfig(xcb) xcb-util-cursor-dev xcb-util-image-dev xcb-util-keysyms-dev xcb-util-renderutil-dev xcb-util-wm-dev xcb-util-dev
 ZLIB, zlib-dev


### PR DESCRIPTION
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>