### PR TITLE
Add detection of candidates for HSW technology

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -22,6 +22,7 @@ import os
 import re
 import tempfile
 import configparser
+import fileinput
 
 import build
 import buildpattern
@@ -321,6 +322,10 @@ def package(args, url, name, archives, workingdir, infile_dict):
                                                tarball.name,
                                                tarball.version,
                                                tarball.release)
+        if filemanager.is_avx_candidate(mock_chroot):
+            print("Autospec found files candidates to AVX technology !")
+            print("Is recomended to set use_avx2 = true in options.conf")
+
         if filemanager.clean_directories(mock_chroot):
             # directories added to the blacklist, need to re-run
             build.must_restart += 1

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -25,6 +25,9 @@ import config
 import re
 import os
 import util
+import sys
+sys.path.append('/usr/share/clr-avx-tools/')
+from avxjudge import do_file
 from collections import OrderedDict
 # todo package splits
 
@@ -155,6 +158,29 @@ class FileManager(object):
                 res.add(f)
 
         return (res, removed)
+
+    def is_avx_candidate(self,root):
+        """
+        Check with avxjudge if files has SSE instructions
+        """
+        ret = False
+        for pkg in self.packages:
+            for f in self.packages[pkg]:
+                path = os.path.join(root, f.lstrip("/"))
+                quiet = 1
+                verbose = 0
+                quiet = 1
+                deltype = "sse"
+                if os.path.isfile(path):
+                    sys.stdout = open(os.devnull, 'w')
+                    sys.stderr = open(os.devnull, 'w')
+                    records = do_file(path, verbose, quiet, deltype)
+                    sys.stdout = sys.__stdout__
+                    sys.stderr = sys.__stderr__
+                    if records.total_counts["sse"]:
+                        ret = True
+
+        return ret
 
     def clean_directories(self, root):
         """


### PR DESCRIPTION
If a binary or .so is detecting to use basic MMX and SSE instructions
autospec will recomend to set use_avx2 = true in options.conf and
rebuild again

This will help developers to detect packages that are candidate to use
HSW technology such as AVX2 and FMA

This PR needs : https://github.com/clearlinux/clr-avx-tools/pull/8
to run 
Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>