### PR TITLE
Use the "llvm" package for using Clang

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -802,7 +802,7 @@ def parse_config_files(path, bump, filemanager, version):
 
     if config_opts['use_clang']:
         config_opts['funroll-loops'] = False
-        buildreq.add_buildreq("llvm-dev")
+        buildreq.add_buildreq("llvm")
 
     if config_opts['32bit']:
         buildreq.add_buildreq("glibc-libc32")

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -432,7 +432,7 @@ cap_rights_init, libcap-ng-dev
 cargo, cargo
 ccolamd.h, SuiteSparse-dev
 cffi, cffi
-clang, llvm-dev
+clang, llvm
 cmake, cmake
 cmdtest, cmdtest
 cmp, diffutils


### PR DESCRIPTION
The llvm-dev package is for developing against Clang & LLVM libraries.

LLVM package release 71 has the necessary fixes.