### PR TITLE
Add configure_{avx2,avx512} files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,11 @@ configure
   ``./configure`` for an autootools based tarball would result in ``%configure
   --disable-static`` being emitted in the ``.spec``.
 
+configure32, configure64, configure_avx2, configure_avx512
+  These files are appended to the ``%configure'' macro after the
+  contents of the ``configure'' file above. They are used for 32-bit,
+  regular 64-bit, AVX2 and AVX512 builds, respectively.
+
 cmake_args
   This file contains arguments that should be passed to the ``%cmake`` macro for
   CMake based tarballs. As an example, adding ``-DUSE_LIB64=ON`` to

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -36,6 +36,8 @@ from util import call, write_out
 extra_configure = ""
 extra_configure32 = ""
 extra_configure64 = ""
+extra_configure_avx2 = ""
+extra_configure_avx512 = ""
 config_files = set()
 parallel_build = " %{?_smp_mflags} "
 urlban = ""
@@ -530,6 +532,8 @@ def parse_config_files(path, bump, filemanager, version):
     global extra_configure
     global extra_configure32
     global extra_configure64
+    global extra_configure_avx2
+    global extra_configure_avx512
     global config_files
     global parallel_build
     global license_fetch
@@ -744,6 +748,12 @@ def parse_config_files(path, bump, filemanager, version):
 
     content = read_conf_file(os.path.join(path, "configure64"))
     extra_configure64 = " \\\n".join(content)
+
+    content = read_conf_file(os.path.join(path, "configure_avx2"))
+    extra_configure_avx2 = " \\\n".join(content)
+
+    content = read_conf_file(os.path.join(path, "configure_avx512"))
+    extra_configure_avx512 = " \\\n".join(content)
 
     if config_opts["keepstatic"]:
         disable_static = ""

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -63,6 +63,8 @@ def commit_to_git(path):
     call("git add configure", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure32", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure64", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add configure_avx2", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add configure_avx512", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add make_check_command", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add *.patch'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add *.nopatch'", check=False, stderr=subprocess.DEVNULL, cwd=path)

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -780,7 +780,7 @@ class Specfile(object):
             self._write_strip("%configure {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure64))
+                                      config.extra_configure_avx2))
             self.write_make_line()
             self._write_strip("popd")
 
@@ -794,7 +794,7 @@ class Specfile(object):
             self._write_strip("%configure {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure64))
+                                      config.extra_configure_avx512))
             self.write_make_line()
             self._write_strip("popd")
 
@@ -858,7 +858,7 @@ class Specfile(object):
             self._write_strip("%reconfigure {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure32))
+                                      config.extra_configure_avx2))
             self.write_make_line()
             self._write_strip("popd")
 
@@ -872,7 +872,7 @@ class Specfile(object):
             self._write_strip("%reconfigure {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure64))
+                                      config.extra_configure_avx512))
             self.write_make_line()
             self._write_strip("popd")
 
@@ -947,7 +947,7 @@ class Specfile(object):
             self._write_strip("%autogen {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure64))
+                                      config.extra_configure_avx2))
             self.write_make_line()
             self._write_strip("popd")
 
@@ -960,7 +960,7 @@ class Specfile(object):
             self._write_strip("%autogen {0} {1} {2} "
                               .format(self.disable_static,
                                       config.extra_configure,
-                                      config.extra_configure64))
+                                      config.extra_configure_avx512))
             self.write_make_line()
             self._write_strip("popd")
 


### PR DESCRIPTION
Those contain extra auto(re)conf arguments to be passed to AVX2 and
AVX512 builds, instead of configure64.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>