### PR TITLE
Don't package scripts as licence files

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -43,13 +43,21 @@ archives = []
 giturl = ""
 
 
+def get_contents(filename):
+    """
+    Get contents of filename (tar file)
+    """
+    with open(filename, "rb") as f:
+        return f.read()
+    return None
+
+
 def get_sha1sum(filename):
     """
     Get sha1 sum of filename (tar file)
     """
     sh = hashlib.sha1()
-    with open(filename, "rb") as f:
-        sh.update(f.read())
+    sh.update(get_contents(filename))
     return sh.hexdigest()
 
 


### PR DESCRIPTION
Just becuase they start with "licence" or "copyright" does not mean
they are licence texts. They can be scripts, as this one in qemu does:
 https://github.com/qemu/ipxe/blob/master/src/util/licence.pl

PS: "licence" is not misspelling. It's the correct spelling for those
of us who use British English (see
https://en.wiktionary.org/wiki/licence#English)

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>