### PR TITLE
Make "libexec" sub-package depend on the "config" one

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -246,6 +246,7 @@ class Specfile(object):
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
         deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "man"]
         deps["lib"] = ["data", "libexec", "license"]
+        deps["libexec"] = ["config", "license"]
         deps["lib32"] = ["data", "license"]
         deps["python"] = ["python3"]
         if config.config_opts['dev_requires_extras']:


### PR DESCRIPTION
"libexec" contains binaries, so like "bin", they should depend on
having the config files present.

The following packages will be affected in Clear when re-autospeced
(they all contain libexec files and a "config" sub-package):

  accountsservice
  at-spi2-core
  bluez
  ceph
  cockpit
  colord
  dovecot
  evince
  evolution-data-server
  flatpak
  fwupdate
  fwupd
  gdm
  geoclue
  glib
  glib-networking
  glusterfs
  gnome-settings-daemon
  gnome-shell
  gnome-terminal
  gvfs
  libvirt
  man-db
  NetworkManager
  openldap
  os-autoinst
  ostree
  p11-kit
  pulseaudio
  rdma-core
  samba
  sddm
  tracker-miners
  tracker
  udisks2
  upower
  weston

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>