### PR TITLE
autospec/specfiles.py: only add zero-caller flags for x86

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -443,6 +443,7 @@ class Specfile(object):
     def write_variables(self):
         """Write variable exports to spec file"""
         flags = []
+        arch = os.uname()[4]
         if config.config_opts['use_clang']:
             self._write_strip("export CC=clang\n")
             self._write_strip("export CXX=clang++\n")
@@ -454,7 +455,8 @@ class Specfile(object):
                 flags.extend(["-Os", "-ffunction-sections", "-fdata-sections", "-fno-semantic-interposition"])
         if config.config_opts['security_sensitive']:
             flags.append("-fstack-protector-strong")
-            flags.append("-mzero-caller-saved-regs=used")
+            if arch == 'x86_64':
+                flags.append("-mzero-caller-saved-regs=used")
         if self.need_avx2_flags:
             flags.extend(["-O3", "-march=haswell"])
         if self.need_avx512_flags:


### PR DESCRIPTION
This flag is currently only available for x86, so only append when
autospec is being ran from that architecture.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>