### PR TITLE
Don't add python test buildreqs

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -434,6 +434,13 @@ def grab_python_requirements(descfile):
         lines = f.readlines()
 
     for line in lines:
+        # don't add the test section
+        if clean_python_req(line) == '[test]':
+            break
+        if clean_python_req(line) == '[testing]':
+            break
+        if clean_python_req(line) == '[dev]':
+            break
         add_requires(clean_python_req(line))
 
 


### PR DESCRIPTION
Python package's test requirements can often require alternate
versions of packages in Clear Linux and can introduce dependency
cycles. To avoid this, exclude sections marked for tests from build
dependency consideration.