### PR TITLE
Unlink integrity files when pycurl errors occur

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -223,6 +223,7 @@ def download_file(url, destination):
             curl.perform()
         except pycurl.error as e:
             print(e.args)
+            os.unlink(sign_file)
             return None
         code = curl.getinfo(pycurl.HTTP_CODE)
         curl.close()


### PR DESCRIPTION
Setting `curl.FAILONERROR` means that pycurl will raise an error for certain conditions that previously succeeded. Make sure to unlink integrity files for these error cases.