### PR TITLE
Introduce -services subpackage.

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -293,8 +293,8 @@ class FileManager(object):
             # now a set of catch-all rules
             (r"^/etc/", "config", "", "%config "),
             (r"^/usr/etc/", "config", "", "%config "),
-            (r"^/lib/systemd", "config"),
-            (r"^/usr/lib/systemd", "config"),
+            (r"^/lib/systemd", "services"),
+            (r"^/usr/lib/systemd", "services"),
             (r"^/usr/lib/udev/rules.d", "config"),
             (r"^/usr/lib/modules-load.d", "config"),
             (r"^/usr/lib/tmpfiles.d", "config"),

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -239,12 +239,13 @@ class Specfile(object):
         groups["lib"] = "Libraries"
         groups["doc"] = "Documentation"
         groups["data"] = "Data"
+        groups["services"] = "Systemd services"
 
         deps = {}
         deps["dev"] = ["lib", "bin", "data"]
         deps["doc"] = ["man"]
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
-        deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "man"]
+        deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "man", "services"]
         deps["lib"] = ["data", "libexec", "license"]
         deps["libexec"] = ["config", "license"]
         deps["lib32"] = ["data", "license"]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -128,7 +128,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         autostart = '/usr/lib/systemd/system/some.target.wants/some'
         self.fm.push_file(autostart)
-        calls = [call(autostart, 'autostart'), call('%exclude ' + autostart, 'config')]
+        calls = [call(autostart, 'autostart'), call('%exclude ' + autostart, 'services')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_file_extras(self):


### PR DESCRIPTION
It contains files in /usr/lib/systemd or /lib/systemd. Previously was
part of -config subpackage. Helps avoiding unwanted deps on services
files when -config is required by another subpackage (such as -libexec)
which, in turn, does not require actual executables (-bin subpackage).

CC: @bryteise 