### PR TITLE
Check license server http return code

### DIFF
--- a/autospec/license.py
+++ b/autospec/license.py
@@ -94,7 +94,8 @@ def license_from_copying_hash(copying, srcdir):
         c.setopt(c.URL, config.license_fetch)
         c.setopt(c.WRITEDATA, buffer)
         c.setopt(c.POSTFIELDS, data)
-        c.setopt(c.FOLLOWLOCATION, 1)
+        c.setopt(c.FOLLOWLOCATION, True)
+        c.setopt(c.FAILONERROR, True)
         try:
             c.perform()
             code = c.getinfo(pycurl.HTTP_CODE)

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -97,13 +97,17 @@ def license_from_copying_hash(copying, srcdir):
         c.setopt(c.FOLLOWLOCATION, 1)
         try:
             c.perform()
-        except Exception as excep:
+            code = c.getinfo(pycurl.HTTP_CODE)
+            if code != 200:
+                print_fatal("Fetching license from {} returned {}"
+                            .format(config.license_fetch, code))
+                exit(1)
+        except pycurl.error as excep:
             print_fatal("Failed to fetch license from {}: {}"
                         .format(config.license_fetch, excep))
+            exit(1)
+        finally:
             c.close()
-            sys.exit(1)
-
-        c.close()
 
         response = buffer.getvalue()
         page = response.decode('utf-8').strip()

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -122,7 +122,7 @@ class TestLicense(unittest.TestCase):
                 pass
 
             def perform(_):
-                raise Exception('Test Exception')
+                raise pycurl.error('Test Exception')
 
             def close(_):
                 pass
@@ -168,6 +168,26 @@ class TestLicense(unittest.TestCase):
         # set the mocks
         license.BytesIO = MockBytesIO
 
+        class MockCurl():
+            URL = None
+            WRITEDATA = None
+            POSTFIELDS = None
+            FOLLOWLOCATION = 0
+            def setopt(_, __, ___):
+                pass
+
+            def perform(_):
+                pass
+
+            def close(_):
+                pass
+
+            def getinfo(_, __):
+                return 200
+
+        # set the mock curl
+        license.pycurl.Curl = MockCurl
+
         license.config.license_fetch = 'license.server.url'
         with open('tests/COPYING_TEST', 'rb') as copyingf:
             content = copyingf.read()
@@ -189,6 +209,9 @@ class TestLicense(unittest.TestCase):
 
         # unset the manual mock
         license.BytesIO = BytesIO
+
+        # unset the manual mock
+        license.pycurl.Curl = pycurl.Curl
 
     def test_scan_for_licenses(self):
         """

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -118,6 +118,7 @@ class TestLicense(unittest.TestCase):
             WRITEDATA = None
             POSTFIELDS = None
             FOLLOWLOCATION = 0
+            FAILONERROR = False
             def setopt(_, __, ___):
                 pass
 
@@ -173,6 +174,7 @@ class TestLicense(unittest.TestCase):
             WRITEDATA = None
             POSTFIELDS = None
             FOLLOWLOCATION = 0
+            FAILONERROR = False
             def setopt(_, __, ___):
                 pass
 


### PR DESCRIPTION
This change verifies that the HTTP returning code from license server is
a 200 otherwise any code returned by the server will be accepted as a
successful response and the returned error page will be interpreted as a
valid license hash.

Additonally this change narrows the exception emitted by pycurl perform
method from Exception to pycurl.error.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>