### PR TITLE
Display URL attempted for signature file download

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -244,8 +244,8 @@ def get_signature_file(package_url, package_path):
                 return sign_file
             elif os.path.exists(dest):
                 os.unlink(dest)
-        except pycurl.error as e:
-            print(e.args)
+        except pycurl.error:
+            print(f"Download of signature file {url} failed")
             if os.path.exists(dest):
                 os.unlink(dest)
 


### PR DESCRIPTION
When displaying an error message for signature file downloads, display
the URL that was attempted as part of the error message as it is more
useful than the error code.