### PR TITLE
Add support for multiple destinations per archive

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -65,8 +65,9 @@ def add_sources(download_path, archives):
             "{}.tmpfiles".format(tarball.name))
     if tarball.gcov_file:
         buildpattern.sources["gcov"].append(tarball.gcov_file)
+    buildpattern.sources["archive"] = archives[::2]
+    buildpattern.sources["destination"] = archives[1::2]
     for archive, destination in zip(archives[::2], archives[1::2]):
-        buildpattern.sources["archive"].append(archive)
         buildpattern.archive_details[archive + "destination"] = destination
 
 

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -377,13 +377,13 @@ class Specfile(object):
                                       .format(self.tarball_prefix,
                                               self.source_index[archive]))
 
-        for archive in self.sources["archive"]:
+        for archive, destination in zip(self.sources["archive"], self.sources["destination"]):
             self._write_strip("mkdir -p {}"
-                              .format(self.archive_details[archive + "destination"]))
-            self._write_strip("mv %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
+                              .format(destination))
+            self._write_strip("cp -r %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
                               .format(self.archive_details[archive + "prefix"],
                                       self.tarball_prefix,
-                                      self.archive_details[archive + "destination"]))
+                                      destination))
         self.apply_patches()
         if config.config_opts['32bit']:
             self._write_strip("pushd ..")


### PR DESCRIPTION
For incredibly complex uses of git submodules, for example, a single
archive may be appropriate to unpack in multiple destinations. First,
track pairs of archives and destinations, second, copy (instead of move)
from the tree where an archive is unpacked into the destination, so that
it can be used again. Order of archives was already respected.