### PR TITLE
Fix a bug in root.log parsing function

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -161,7 +161,7 @@ def failed_pattern(line, pattern, verbose, buildtool=None):
 def parse_buildroot_log(filename, returncode):
     """Handle buildroot log contents."""
     if returncode == 0:
-        return
+        return True
     global must_restart
     must_restart = 0
     is_clean = True

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -262,6 +262,56 @@ class TestBuildpattern(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(build.must_restart, 0)
 
+    def test_parse_buildroot_log_pass(self):
+        """
+        Test parse_buildroot_log with a test log indicating no failures
+        """
+        def mock_util_call(cmd):
+            del cmd
+
+        build.config.setup_patterns()
+        build.config.config_opts['32bit'] = True
+        call_backup = build.util.call
+        build.util.call = mock_util_call
+
+        open_name = 'build.open'
+        content = "line 1\nline 2\nline 3\nline 4"
+        m_open = mock_open(read_data=content)
+
+        result = True
+        with patch(open_name, m_open, create=True):
+            result = build.parse_buildroot_log('testname', 1)
+
+        build.util.call = call_backup
+
+        self.assertTrue(result)
+        self.assertEqual(build.must_restart, 0)
+
+    def test_parse_buildroot_log_noop(self):
+        """
+        Test parse_buildroot_log when parsing should be skipped (i.e. mock
+        returned 0)
+        """
+        def mock_util_call(cmd):
+            del cmd
+
+        build.config.setup_patterns()
+        build.config.config_opts['32bit'] = True
+        call_backup = build.util.call
+        build.util.call = mock_util_call
+
+        open_name = 'build.open'
+        content = "line 1\nline 2\nline 3\nline 4"
+        m_open = mock_open(read_data=content)
+
+        result = True
+        with patch(open_name, m_open, create=True):
+            result = build.parse_buildroot_log('testname', 0)
+
+        build.util.call = call_backup
+
+        self.assertTrue(result)
+
     def test_parse_build_results_pkgconfig(self):
         """
         Test parse_build_results with a test log indicating failure due to a


### PR DESCRIPTION
The function was simply returning 'None' instead of a boolean. This bug resulted in autospec never recognizing that no more build rounds were needed when mock returns 0.

Add a unit test for this case and the other case for when mock failed but the root.log contains no relevant errors.