### PR TITLE
Implement unified download interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 check: autospec/*.py
 	@flake8 --ignore=D100,I201 $^
 
+test_download:
+	PYTHONPATH=${CURDIR}/autospec python3 tests/test_download.py
+
 test_pkg_integrity:
 	PYTHONPATH=${CURDIR}/autospec python3 tests/test_pkg_integrity.py
 

--- a/autospec/download.py
+++ b/autospec/download.py
@@ -1,0 +1,75 @@
+#!/usr/bin/true
+#
+# download.py - part of autospec
+# Copyright (C) 2018 Intel Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from io import BytesIO
+import os
+import sys
+
+import pycurl
+from util import print_fatal
+
+
+def do_curl(url, dest=None, post=None, is_fatal=False):
+    """
+    Perform a curl operation for `url`.
+
+    If `post` is set, a POST is performed for `url` with fields taken from the
+    specified value. Otherwise a GET is performed for `url`. If `dest` is set,
+    the curl response (if successful) is written to the specified path and the
+    path is returned. Otherwise a successful response is returned as a BytesIO
+    object. If `is_fatal` is `True` (`False` is the default), a GET failure,
+    POST failure, or a failure to write to the path specified for `dest`
+    results in the program exiting with an error. Otherwise, `None` is returned
+    for any of those error conditions.
+    """
+    c = pycurl.Curl()
+    c.setopt(c.URL, url)
+    if post:
+        c.setopt(c.POSTFIELDS, post)
+    c.setopt(c.FOLLOWLOCATION, True)
+    c.setopt(c.FAILONERROR, True)
+    buf = BytesIO()
+    c.setopt(c.WRITEDATA, buf)
+    try:
+        c.perform()
+    except pycurl.error as e:
+        if is_fatal:
+            print_fatal("Unable to fetch {}: {}".format(url, e))
+            sys.exit(1)
+        return None
+    finally:
+        c.close()
+
+    # write to dest if specified
+    if dest:
+        try:
+            with open(dest, 'wb') as fp:
+                fp.write(buf.getvalue())
+        except IOError as e:
+            if os.path.exists(dest):
+                os.unlink(dest)
+            if is_fatal:
+                print_fatal("Unable to write to {}: {}".format(dest, e))
+                sys.exit(1)
+            return None
+
+    if dest:
+        return dest
+    else:
+        return buf

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -453,7 +453,7 @@ class PyPiVerifier(MD5Verifier):
         global EMAIL
         print("Searching for package information in pypi")
         name, release = self.parse_name()
-        info = self.get_info(name)
+        info = PyPiVerifier.get_info(name)
         releases_info = info.get('releases', None)
         if releases_info is None:
             self.print_result(False, err_msg='Error in package info from {}'.format(PYPIORG_API))
@@ -595,8 +595,8 @@ class GEMShaVerifier(Verifier):
             return
         name, _ = re.split(r'-\d+\.', gemname)
         number = gemname.replace(name + '-', '')
-        geminfo = self.get_rubygems_info(name)
-        gemsha = self.get_gemnumber_sha(geminfo, number)
+        geminfo = GEMShaVerifier.get_rubygems_info(name)
+        gemsha = GEMShaVerifier.get_gemnumber_sha(geminfo, number)
 
         if geminfo is None:
             self.print_result(False, "unable to parse info for gem {}".format(gemname))

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -28,7 +28,7 @@ import subprocess
 import build
 import buildpattern
 import buildreq
-import pycurl
+import download
 from util import call, print_fatal, write_out
 
 name = ""
@@ -57,33 +57,11 @@ def get_sha1sum(filename):
     return sh.hexdigest()
 
 
-def really_download(upstream_url, destination):
-    """Ok, really download the tarball from url."""
-    with open(destination, 'wb') as dfile:
-        c = pycurl.Curl()
-        c.setopt(c.URL, upstream_url)
-        c.setopt(c.WRITEDATA, dfile)
-        c.setopt(c.FOLLOWLOCATION, True)
-        try:
-            c.perform()
-            code = c.getinfo(pycurl.HTTP_CODE)
-            if code != 200:
-                print_fatal("get request to {} returned {}".format(upstream_url, code))
-                os.remove(destination)
-                exit(1)
-        except pycurl.error as excep:
-            print_fatal("unable to download {}: {}".format(upstream_url, excep))
-            os.remove(destination)
-            exit(1)
-        finally:
-            c.close()
-
-
 def check_or_get_file(upstream_url, tarfile):
     """Download tarball from url unless it is present locally."""
     tarball_path = build.download_path + "/" + tarfile
     if not os.path.isfile(tarball_path):
-        really_download(upstream_url, tarball_path)
+        download.do_curl(upstream_url, dest=tarball_path, is_fatal=True)
     return tarball_path
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,160 @@
+from enum import Enum, auto
+import unittest
+from unittest.mock import patch, mock_open, call
+
+import pycurl
+
+import download
+
+
+class MockOpts(Enum):
+    URL = auto()
+    WRITEDATA = auto()
+    POSTFIELDS = auto()
+    FOLLOWLOCATION = auto()
+    FAILONERROR = auto()
+
+
+def init_curl_instance(mock_curl):
+    instance = mock_curl.return_value
+    instance.URL = MockOpts.URL
+    instance.FOLLOWLOCATION = MockOpts.FOLLOWLOCATION
+    instance.FAILONERROR = MockOpts.FAILONERROR
+    instance.WRITEDATA = MockOpts.WRITEDATA
+    instance.POSTFIELDS = MockOpts.POSTFIELDS
+    return instance
+
+
+def test_opts(*opts):
+    if not opts:
+        raise Exception("no curl options specified")
+    if len(opts) != 2:
+        raise Exception("expected two args to setopt()")
+    key, val = opts
+    if key == MockOpts.WRITEDATA:
+        val.write(b'foobar')
+
+
+class TestDownload(unittest.TestCase):
+
+    @patch('download.pycurl.Curl')
+    def test_download_get_success_no_dest(self, test_curl):
+        """
+        Test successful GET request when dest is not set.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        data = download.do_curl("foo")
+        self.assertEqual(b'foobar', data.getvalue())
+
+    @patch('download.pycurl.Curl')
+    def test_download_set_basic(self, test_curl):
+        """
+        Test curl option settings set by default
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        data = download.do_curl("foo")
+        calls = [
+            call().setopt(MockOpts.URL, 'foo'),
+            call().setopt(MockOpts.FOLLOWLOCATION, True),
+            call().setopt(MockOpts.FAILONERROR, True),
+        ]
+        test_curl.assert_has_calls(calls)
+
+    @patch('download.pycurl.Curl')
+    def test_download_set_post(self, test_curl):
+        """
+        Test setting of POSTFIELDS curl option
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        data = download.do_curl("foo", post='postdata')
+        calls = [
+            call().setopt(MockOpts.POSTFIELDS, 'postdata'),
+        ]
+        test_curl.assert_has_calls(calls)
+
+    @patch('download.pycurl.Curl')
+    def test_download_get_failure_no_dest(self, test_curl):
+        """
+        Test failed GET request when dest is not set.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        instance.perform.side_effect = pycurl.error
+        data = download.do_curl("foo")
+        self.assertIsNone(data)
+
+    @patch('download.sys.exit')
+    @patch('download.pycurl.Curl')
+    def test_download_get_failure_fatal(self, test_curl, test_exit):
+        """
+        Test failed GET request when is_fatal is set.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        instance.perform.side_effect = pycurl.error
+        data = download.do_curl("foo", is_fatal=True)
+        test_exit.assert_called_once_with(1)
+
+    @patch('download.open', new_callable=mock_open)
+    @patch('download.pycurl.Curl')
+    def test_download_get_success_dest(self, test_curl, test_open):
+        """
+        Test successful GET request when dest is set.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        data = download.do_curl("foo", "testdest")
+        test_open.assert_called_once_with('testdest', 'wb')
+        test_open().write.assert_called_once_with(b'foobar')
+
+    @patch('download.os.path.exists')
+    @patch('download.open', new_callable=mock_open)
+    @patch('download.pycurl.Curl')
+    def test_download_get_write_fail_dest(self, test_curl, test_open, test_path):
+        """
+        Test failure to write to dest after successful GET request.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        test_open.side_effect = IOError
+        test_path.return_value = None
+        data = download.do_curl("foo", "testdest")
+        self.assertIsNone(data)
+
+    @patch('download.sys.exit')
+    @patch('download.os.path.exists')
+    @patch('download.open')
+    @patch('download.pycurl.Curl')
+    def test_download_write_fail_fatal(self, test_curl, test_open, test_path, test_exit):
+        """
+        Test fatal failure to write to dest after successful GET request.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        test_open.side_effect = IOError
+        test_path.return_value = None
+        data = download.do_curl("foo", "testdest", is_fatal=True)
+        test_exit.assert_called_once_with(1)
+
+    @patch('download.os.unlink')
+    @patch('download.os.path.exists')
+    @patch('download.open')
+    @patch('download.pycurl.Curl')
+    def test_download_write_fail_remove_dest(self, test_curl, test_open, test_path, test_unlink):
+        """
+        Test removal of dest following a write failure.
+        """
+        instance = init_curl_instance(test_curl)
+        instance.setopt.side_effect = test_opts
+        test_open.side_effect = IOError
+        test_path.return_value = True
+        data = download.do_curl("foo", "testdest")
+        test_path.assert_called_once_with("testdest")
+        test_unlink.assert_called_once_with("testdest")
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=True)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,11 +1,14 @@
-import license
-import unittest
-import pycurl
-import tempfile
-import os
 from contextlib import redirect_stdout
 from io import BytesIO, StringIO
+import os
+import tempfile
+import unittest
 from unittest.mock import patch, mock_open, MagicMock
+
+import pycurl
+
+import download
+import license
 
 
 class TestLicense(unittest.TestCase):
@@ -107,8 +110,7 @@ class TestLicense(unittest.TestCase):
 
         self.assertEquals(license.licenses, [])
 
-    @patch('pycurl.Curl')
-    def test_license_from_copying_hash_license_server_excep(self, mock_pycurl_curl):
+    def test_license_from_copying_hash_license_server_excep(self):
         """
         Test license_from_copying_hash with license server when pycurl raises
         an exception.
@@ -129,7 +131,7 @@ class TestLicense(unittest.TestCase):
                 pass
 
         # set the mock curl
-        license.pycurl.Curl = MockCurl
+        download.pycurl.Curl = MockCurl
 
         license.config.license_fetch = 'license.server.url'
         with open('tests/COPYING_TEST', 'rb') as copyingf:
@@ -148,13 +150,12 @@ class TestLicense(unittest.TestCase):
                     with self.assertRaises(SystemExit):
                         license.license_from_copying_hash('copying.txt', '')
 
-        self.assertIn('Failed to fetch license from ', out.getvalue())
+        self.assertIn('Unable to fetch license.server.url: Test Exception', out.getvalue())
 
         # unset the manual mock
-        license.pycurl.Curl = pycurl.Curl
+        download.pycurl.Curl = pycurl.Curl
 
-    @patch('pycurl.Curl')
-    def test_license_from_copying_hash_license_server(self, mock_pycurl_curl):
+    def test_license_from_copying_hash_license_server(self):
         """
         Test license_from_copying_hash with license server. This is heavily
         mocked.
@@ -167,7 +168,7 @@ class TestLicense(unittest.TestCase):
                 return 'GPL-3.0'.encode('utf-8')
 
         # set the mocks
-        license.BytesIO = MockBytesIO
+        download.BytesIO = MockBytesIO
 
         class MockCurl():
             URL = None
@@ -188,7 +189,7 @@ class TestLicense(unittest.TestCase):
                 return 200
 
         # set the mock curl
-        license.pycurl.Curl = MockCurl
+        download.pycurl.Curl = MockCurl
 
         license.config.license_fetch = 'license.server.url'
         with open('tests/COPYING_TEST', 'rb') as copyingf:
@@ -210,10 +211,10 @@ class TestLicense(unittest.TestCase):
         self.assertIn('License     :  GPL-3.0  (server)', out.getvalue())
 
         # unset the manual mock
-        license.BytesIO = BytesIO
+        download.BytesIO = BytesIO
 
         # unset the manual mock
-        license.pycurl.Curl = pycurl.Curl
+        download.pycurl.Curl = pycurl.Curl
 
     def test_scan_for_licenses(self):
         """


### PR DESCRIPTION
The download code for licenses, tarballs, and signature files are
similar enough to warrant consolidation into a unified interface, so add
a new function do_curl() that satisfies the needs of all the callers.

Note that I made one change that noticeably changes the output,
hopefully to reduce confusion: The signature download loop no longer
prints error messages, since the end user should not need to care at all
unless a signature cannot be downloaded and verification is required. If
the latter case is true, autospec will still exit and print the fatal
error, so the issue should be straightforward to diagnose after seeing
that error.

Also, a couple of bugs are fixed as a result of using the new function:

  - The FAILONERROR pycurl option is now set for tarball downloads. This
    prevents certain undesirable side-effects like downloading 404
    response pages.

  - Responses from FTP servers are now handled better, since a more
    common "success" code from FTP servers is 226, not 200.