### PR TITLE
Set MAKEFLAGS for Python3 distutils

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -998,6 +998,7 @@ class Specfile(object):
         self.write_prep()
         self.write_lang_c(export_epoch=True)
         self.write_variables()
+        self._write_strip("export MAKEFLAGS=%{?_smp_mflags}")
         if self.subdir:
             self._write_strip("pushd " + self.subdir)
         self._write_strip("python3 setup.py build  " + config.extra_configure)


### PR DESCRIPTION
Because the Python script runs make, we don't get the chance to pass
the -j option directly.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>