### PR TITLE
Set CMAKE_INSTALL_LIBDIR for 32 bits builds

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1203,6 +1203,7 @@ class Specfile(object):
             self.write_variables()
             self.write_32bit_exports()
             self._write_strip("%cmake -DLIB_INSTALL_DIR:PATH=/usr/lib32 "
+                              "-DCMAKE_INSTALL_LIBDIR=/usr/lib32 "
                               "-DLIB_SUFFIX=32 "
                               "{} {} ".format(self.cmake_srcdir, self.extra_cmake))
             self.write_make_line()


### PR DESCRIPTION
Besides the LIB_INSTALL_DIR the %cmake macro now sets the
CMAKE_INSTALL_LIBDIR to /usr/lib64, since some things use either one
or other.  So we need to override it in 32 bits builds to avoid it
mistakenly installing 32 files into lib64.