### PR TITLE
specfiles: Avoid unnecessary whitespace in -m32 writes

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -402,10 +402,10 @@ class Specfile(object):
     def write_32bit_exports(self):
         """Write 32bit only env exports."""
         self._write_strip('export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"')
-        self._write_strip('export ASFLAGS="$ASFLAGS --32"')
-        self._write_strip('export CFLAGS="$CFLAGS -m32"')
-        self._write_strip('export CXXFLAGS="$CXXFLAGS -m32"')
-        self._write_strip('export LDFLAGS="$LDFLAGS -m32"')
+        self._write_strip('export ASFLAGS="${ASFLAGS}${ASFLAGS:+ }--32"')
+        self._write_strip('export CFLAGS="${CFLAGS}${CFLAGS:+ }-m32"')
+        self._write_strip('export CXXFLAGS="${CXXFLAGS}${CXXFLAGS:+ }-m32"')
+        self._write_strip('export LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-m32"')
 
     def write_variables(self):
         """Write variable exports to spec file."""


### PR DESCRIPTION
With newer CMake versions, having unsanitized " -m32" LDFLAGS with the
whitespace will violate policy CMP0004 causing build failures in SDL2.
Thus we modify the .spec file to only set "-m32" if the string is empty,
otherwise include " -m32" and the existing variable.

Signed-off-by: Ikey Doherty <ikey.doherty@intel.com>