### PR TITLE
specfiles: Build 32-bit last to avoid CFLAGS contamination

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1196,20 +1196,6 @@ class Specfile(object):
         self.write_make_line()
         self._write_strip("popd")
 
-        if config.config_opts['32bit']:
-            self._write_strip("mkdir -p clr-build32")
-            self._write_strip("pushd clr-build32")
-            self.write_build_prepend()
-            self.write_variables()
-            self.write_32bit_exports()
-            self._write_strip("%cmake -DLIB_INSTALL_DIR:PATH=/usr/lib32 "
-                              "-DCMAKE_INSTALL_LIBDIR=/usr/lib32 "
-                              "-DLIB_SUFFIX=32 "
-                              "{} {} ".format(self.cmake_srcdir, self.extra_cmake))
-            self.write_make_line()
-            self._write_strip("unset PKG_CONFIG_PATH")
-            self._write_strip("popd")
-
         if config.config_opts['use_avx2']:
             self._write_strip("mkdir -p clr-build-avx2")
             self._write_strip("pushd clr-build-avx2")
@@ -1236,6 +1222,20 @@ class Specfile(object):
             self._write_strip('export CXXFLAGS="$CXXFLAGS -march=skylake-avx512 -m64 "')
             self._write_strip("%cmake {} {}".format(self.cmake_srcdir, self.extra_cmake))
             self.write_make_line()
+            self._write_strip("popd")
+
+        if config.config_opts['32bit']:
+            self._write_strip("mkdir -p clr-build32")
+            self._write_strip("pushd clr-build32")
+            self.write_build_prepend()
+            self.write_variables()
+            self.write_32bit_exports()
+            self._write_strip("%cmake -DLIB_INSTALL_DIR:PATH=/usr/lib32 "
+                              "-DCMAKE_INSTALL_LIBDIR=/usr/lib32 "
+                              "-DLIB_SUFFIX=32 "
+                              "{} {} ".format(self.cmake_srcdir, self.extra_cmake))
+            self.write_make_line()
+            self._write_strip("unset PKG_CONFIG_PATH")
             self._write_strip("popd")
 
         if self.subdir:


### PR DESCRIPTION
An issue happens when building libjpeg-turbo: after the 32-bit version
is successfully built, the build fails with an internal compiler error
when trying to build the AVX2 version.  This ICE isn't in fact an ICE[1]:
CMake tries to verify if the C compiler can generate executables, but a
failure happens when linking, with LTO, a 64-bit executable with a
32-bit object.  The 32-bit object shouldn't have been generated in the
first place; it is because CFLAGS is contaminated by the 32-bit build
that happens right before the AVX2 build.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41565

By building the 32-bit version last, we avoid contaminating the
compiler and linker flags with contradicting "-m32" and "-m64" values,
working around the issue.

However, this is merely that, a workaround: the spec-writing code in
autospec should be refactored to manage the compiler flags in a way
that contamination between build profiles isn't possible at all.