### PR TITLE
Add support for lzip-compressed tarballs (.tar.lz)

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -67,6 +67,9 @@ def check_or_get_file(upstream_url, tarfile):
 
 def build_untar(tarball_path):
     """Determine extract command and tarball prefix from tar -tf output."""
+    if tarball_path.lower().endswith('.lz'):
+        buildreq.add_buildreq("lzip")
+
     tar_prefix = ""
     try:
         tarball_contents = subprocess.check_output(


### PR DESCRIPTION
Our GNU tar does recognise it and will run /usr/bin/lzip on its
own. Only that it needs to be installed in the chroot for that to
work.

Homepage: https://www.nongnu.org/lzip/
See also: https://www.nongnu.org/lzip/xz_inadequate.html

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>