### PR TITLE
Enable distutils for python 3.6

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -587,6 +587,8 @@ def scan_for_configure(dirn):
     """Scan the package directory for build files to determine build pattern."""
     if buildpattern.default_pattern == "distutils":
         add_buildreq("buildreq-distutils")
+    elif buildpattern.default_pattern == "distutils36":
+        add_buildreq("buildreq-distutils36")
     elif buildpattern.default_pattern == "distutils23":
         add_buildreq("buildreq-distutils23")
     elif buildpattern.default_pattern == "distutils3":


### PR DESCRIPTION
Open Stack python packages requrie python 3.6 to build, this patch
enable the capability to build a pypi package with python 3.6

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>