### PR TITLE
Support decompressing ZIP files with comments

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -113,7 +113,7 @@ def build_unzip(zip_path):
     and this function gets the 'prefix-dir' portion from the start of the unzip -l output.
     """
     prefix = ""
-    contents = subprocess.check_output(["unzip", "-l", zip_path], universal_newlines=True)
+    contents = subprocess.check_output(["unzip", "-q", "-l", zip_path], universal_newlines=True)
     lines = contents.splitlines() if contents else []
     # looking for directory prefix in unzip output as it may differ from default
     if len(lines) > 3:


### PR DESCRIPTION
While trying to determine the directory name when extracting a ZIP
file, autospec do not consider the (optional) ZIP archive comment,
which is printed to the console while printing the archive contents
with "-l".

By calling unzip with "-q", the archive comment is not printed, and
autospec is happy again.