### PR TITLE
Save buildreq_cache on failure

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -325,6 +325,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     check.check_regression(build.download_path)
 
     if build.success == 0:
+        config.create_buildreq_cache(build.download_path, tarball.version)
         print_fatal("Build failed, aborting")
         sys.exit(1)
     elif os.path.isfile("README.clear"):


### PR DESCRIPTION
In cases where autospec spends multiple rounds resolving dependencies,
before ultimately failing, it would be nice to save the buildreq_cache.
This could save a lot of time while attempting to whittle away actual
build problems.