### PR TITLE
cmake: Ignore entries inside comments

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -304,8 +304,8 @@ def rakefile(filename):
 
 def parse_cmake(filename):
     """Scan a .cmake or CMakeLists.txt file for what's it's actually looking for."""
-    findpackage = re.compile(r"find_package\((\w+)\b.*\)", re.I)
-    pkgconfig = re.compile(r"pkg_check_modules\s*\(\w+ (.*)\)", re.I)
+    findpackage = re.compile(r"^[^#]*find_package\((\w+)\b.*\)", re.I)
+    pkgconfig = re.compile(r"^[^#]*pkg_check_modules\s*\(\w+ (.*)\)", re.I)
     pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
                             'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
     extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -464,6 +464,22 @@ class TestBuildreq(unittest.TestCase):
         self.assertEqual(buildreq.buildreqs,
                          set(['pkgconfig(gio-unix-2.0)', 'pkgconfig(glib-2.0)']))
 
+    def test_parse_cmake_pkg_check_modules_in_a_comment(self):
+        """
+        Test parse_cmake to ensure it ignores pkg_check_modules in comments.
+        """
+        content = '''
+# For example, consider the following patch to some CMakeLists.txt.
+#     - pkg_check_modules(FOO REQUIRED foo>=1.0)
+#     + pkg_check_modules(FOO REQUIRED foo>=2.0)
+'''
+        with tempfile.TemporaryDirectory() as tmpd:
+            with open(os.path.join(tmpd, 'fname'), 'w') as f:
+                f.write(content)
+            buildreq.parse_cmake(os.path.join(tmpd, 'fname'))
+
+        self.assertEqual(buildreq.buildreqs,
+                         set([]))
 
     def test_parse_cmake_pkg_check_modules_variables(self):
         """


### PR DESCRIPTION
Change the regexp to match only non-comment lines.  Found when I
figured waffle was depending on "pkgconfig(foo)".  Added a test for
that case.