### PR TITLE
Do not add man pages for bin subpackages

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -225,7 +225,7 @@ class Specfile(object):
         deps["dev"] = ["lib", "bin", "data"]
         deps["doc"] = ["man"]
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
-        deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "man", "services"]
+        deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "services"]
         deps["lib"] = ["data", "libexec", "license"]
         deps["libexec"] = ["config", "license"]
         deps["lib32"] = ["data", "license"]


### PR DESCRIPTION
Avoid requiring -man from the -bin subpackage. The top level package
requires -man and -bin, so making -bin require -man just forces
content to be included that otherwise was intentionally not selected.