### PR TITLE
Ignore the ChangeLog when the giturl is available

### DIFF
--- a/autospec/commitmessage.py
+++ b/autospec/commitmessage.py
@@ -258,7 +258,13 @@ def guess_commit_message(keyinfo):
                                  .format(tarball.name, tarball.version))
     commitmessage.append("")
 
-    for newsfile in ["NEWS", "ChangeLog"]:
+    # Only use Changelog if the giturl isn't defined as it is often
+    # duplicate content from the git log.
+    if tarball.giturl:
+        newsfiles = ["NEWS"]
+    else:
+        newsfiles = ["NEWS", "ChangeLog"]
+    for newsfile in newsfiles:
         # parse news files for relevant version updates and cve fixes
         newcommitmessage, newcves = process_NEWS(newsfile)
         commitmessage.extend(newcommitmessage)

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -369,6 +369,7 @@ def write_config(config_f, path):
 def read_config_opts(path):
     """Read config options from path/options.conf."""
     global config_opts
+    global transforms
     opts_path = os.path.join(path, 'options.conf')
     if not os.path.exists(opts_path):
         create_conf(path)
@@ -386,6 +387,16 @@ def read_config_opts(path):
     # configuration file may exist without any comments (either due to an older
     # version of autospec or if it was user-created)
     rewrite_config_opts(path)
+
+    # Don't use the ChangeLog files if the giturl is set
+    # ChangeLog is just extra noise when we can already see the gitlog
+    if "package" in config_f.sections() and config_f['package'].get('giturl'):
+        keys = []
+        for k, v in transforms.items():
+            if v == "ChangeLog":
+                keys.append(k)
+        for k in keys:
+            transforms.pop(k)
 
 
 def rewrite_config_opts(path):


### PR DESCRIPTION
Often the ChangeLog is a poor duplicate of the git log for a given
release and introduces unnecessary noise into package updates. To
avoid this only use the ChangeLog if the giturl is undefined.