### PR TITLE
Set GOPATH only if no go.mod file exists

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -636,6 +636,8 @@ def scan_for_configure(dirn):
         if any(f.endswith(".go") for f in files):
             add_buildreq("buildreq-golang")
             buildpattern.set_build_pattern("golang", default_score)
+            if any(f == "go.mod" for f in files):
+                config.set_gopath = False
 
         if "CMakeLists.txt" in files and "configure.ac" not in files:
             add_buildreq("buildreq-cmake")

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -58,6 +58,7 @@ install_append = []
 patches = []
 autoreconf = False
 custom_desc = ""
+set_gopath = True
 
 license_fetch = None
 license_show = None
@@ -542,6 +543,7 @@ def parse_config_files(path, bump, filemanager, version):
     global install_append
     global patches
     global autoreconf
+    global set_gopath
     global yum_conf
     global custom_desc
     global failed_pattern_dir
@@ -839,3 +841,4 @@ def load_specfile(specfile):
     specfile.install_append = install_append
     specfile.patches = patches
     specfile.autoreconf = autoreconf
+    specfile.set_gopath = set_gopath

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -56,6 +56,7 @@ class Specfile(object):
         self.locales = []
         self.default_pattern = ""
         self.autoreconf = False
+        self.set_gopath = True
         self.extra_make = ""
         self.extra32_make = ""
         self.extra_make_install = ""
@@ -1416,7 +1417,8 @@ class Specfile(object):
         self.write_build_prepend()
         self.write_proxy_exports()
         self._write_strip("export LANG=C")
-        self._write_strip("export GOPATH=\"$PWD\"")
+        if self.set_gopath:
+            self._write_strip("export GOPATH=\"$PWD\"")
         self._write_strip("go build {}".format(self.extra_make))
         self._write_strip("\n")
         self._write_strip("%install")


### PR DESCRIPTION
This detects _any_ go.mod within the tarball, and if found, will _not_ write out the `export GOPATH` statement in the spec file.