### PR TITLE
Run R package tests in build workspace; fixes lib stripping

### DIFF
--- a/autospec/check.py
+++ b/autospec/check.py
@@ -131,10 +131,8 @@ def scan_for_tests(src_dir):
 
     elif buildpattern.default_pattern == "R":
         tests_config = "export _R_CHECK_FORCE_SUGGESTS_=false\n"              \
-                       "R CMD check --no-manual --no-examples --no-codoc -l " \
-                       "%{buildroot}/usr/lib64/R/library "                    \
-                       + tarball.rawname + "|| : \ncp ~/.stash/* "            \
-                       "%{buildroot}/usr/lib64/R/library/*/libs/ || :"
+                       "R CMD check --no-manual --no-examples --no-codoc "    \
+                       + tarball.rawname + " || :"
 
     if "tox.ini" in files:
         buildreq.add_buildreq("tox")


### PR DESCRIPTION
If using `-l` option for `R CMD check`, content is overwritten/deleted at the specified location, thus requiring the re-installation of the avx2/avx512 libraries backed up in `~/.stash`.

We can avoid this issue entirely by running the tests within the build workspace, which is the default behavior when `-l` (and `-o`) is not specified.

The important side effect of this change is that libraries installed by `%install`, also post-processed with `debugedit` and `find-debuginfo.sh` to extract debuginfo, remain intact. This will result in a large decrease in package sizes for `R-*-lib` across all of Clear Linux OS, and the debuginfo content will be properly linked to the associated binaries/libraries again.