### PR TITLE
Remove cargo buildreq

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -226,7 +226,6 @@ def parse_cargo_toml(filename):
     """
     global cargo_bin
     buildpattern.set_build_pattern("cargo", 1)
-    add_buildreq("cargo")
     add_buildreq("rustc")
     with open(filename, "r", encoding="latin-1") as ctoml:
         cargo = toml.loads(ctoml.read())

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -178,7 +178,7 @@ class TestBuildreq(unittest.TestCase):
         buildreq.toml.loads = loads_backup
 
         self.assertEqual(buildreq.buildreqs,
-                         set(['cargo', 'rustc', 'dep1', 'dep2', 'dep3']))
+                         set(['rustc', 'dep1', 'dep2', 'dep3']))
         self.assertTrue(buildreq.cargo_bin)
         self.assertEqual(buildreq.buildpattern.default_pattern, 'cargo')
 


### PR DESCRIPTION
Cargo is now part of the rustc package so stop adding it as a
buildreq.