### PR TITLE
Avoid crashing on binary files that may look like a license file.

### DIFF
--- a/autospec/license.py
+++ b/autospec/license.py
@@ -95,6 +95,10 @@ def license_from_copying_hash(copying, srcdir):
             license_charset = 'ISO-8859-13'
         elif b'\xd2' in data and b'\xd3' in data:
             license_charset = 'mac_roman'
+    if not license_charset:
+        """This is not a text file"""
+        return
+
     data = data.decode(license_charset)
 
     if config.license_fetch:


### PR DESCRIPTION
Test case: libreoffice. It has several files with the word "license"
and "copying" in the filename, which are ZIP files and thus not
any valid encoding. These files need to be skipped entirely.

Forcing an encoding here just propagates the problem as things like
ASCII and utf-8 will just move the crash down a few lines.