### PR TITLE
Fix excludes v extras.

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -713,6 +713,7 @@ def parse_config_files(path, bump, filemanager, version):
     for extra in content:
         print("extras for  : %s." % extra)
     filemanager.extras += content
+    filemanager.excludes += content
 
     for fname in os.listdir(path):
         if not re.search('.+_extras$', fname) or fname == "dev_extras":
@@ -731,16 +732,19 @@ def parse_config_files(path, bump, filemanager, version):
                 continue
         print(f"{name}-extras for {content['files']}")
         filemanager.custom_extras[f"{name}-extras"] = content
+        filemanager.excludes += content['files']
 
     content = read_conf_file(os.path.join(path, "dev_extras"))
     for extra in content:
         print("dev for     : %s." % extra)
     filemanager.dev_extras += content
+    filemanager.excludes += content
 
     content = read_conf_file(os.path.join(path, "setuid"))
     for suid in content:
         print("setuid for  : %s." % suid)
     filemanager.setuid += content
+    filemanager.excludes += content
 
     content = read_conf_file(os.path.join(path, "attrs"))
     for line in content:
@@ -749,6 +753,7 @@ def parse_config_files(path, bump, filemanager, version):
         filename = attr.pop()
         print("attr for: %s." % filename)
         filemanager.attrs[filename] = attr
+        filemanager.excludes.append(filename)
 
     patches += read_conf_file(os.path.join(path, "series"))
     pfiles = [("%s/%s" % (path, x.split(" ")[0])) for x in patches]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -138,6 +138,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.extras.append('test')
+        self.fm.excludes.append("test")
         self.fm.push_file('test')
         calls = [call('test', 'extras'), call('%exclude test')]
         self.fm.push_package_file.assert_has_calls(calls)
@@ -150,6 +151,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.custom_extras = {'test-extras': {'files': ["test"]}}
+        self.fm.excludes.append("test")
         self.fm.push_file('test')
         calls = [call('test', 'test-extras'), call('%exclude test')]
         self.fm.push_package_file.assert_has_calls(calls)
@@ -162,6 +164,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.setuid.append('test')
+        self.fm.excludes.append("test")
         self.fm.push_file('test')
         calls = [call('%attr(4755, root, root) test', 'setuid'), call('%exclude test')]
         self.fm.push_package_file.assert_has_calls(calls)


### PR DESCRIPTION
When adding a file to extras (as well as excludes, setuid etc.), the
files are added to the exclude list dynamically. Instead, load all known
files upfront.

Also, process file-configured subpackages (-extras, custom-extras etc.)
first and only then process "built-in" (pattern-based) packages (such as
-lib64, -lib32, -autostart etc.)