### PR TITLE
Allow unpacking archives in the main tarball's dir

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -395,12 +395,16 @@ class Specfile(object):
                                               self.source_index[archive]))
 
         for archive, destination in zip(self.sources["archive"], self.sources["destination"]):
-            self._write_strip("mkdir -p {}"
-                              .format(destination))
-            self._write_strip("cp -rn %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
-                              .format(self.archive_details[archive + "prefix"],
-                                      self.tarball_prefix,
-                                      destination))
+            if self.archive_details[archive + "prefix"] == self.tarball_prefix:
+                print("Archive {} already unpacked in {}; ignoring destination"
+                      .format(archive, self.tarball_prefix))
+            else:
+                self._write_strip("mkdir -p {}"
+                                  .format(destination))
+                self._write_strip("cp -r %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
+                                  .format(self.archive_details[archive + "prefix"],
+                                          self.tarball_prefix,
+                                          destination))
         self.apply_patches()
         if self.default_pattern != 'cmake':
             if config.config_opts['32bit']:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -397,7 +397,7 @@ class Specfile(object):
         for archive, destination in zip(self.sources["archive"], self.sources["destination"]):
             self._write_strip("mkdir -p {}"
                               .format(destination))
-            self._write_strip("cp -r %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
+            self._write_strip("cp -rn %{{_topdir}}/BUILD/{0}/* %{{_topdir}}/BUILD/{1}/{2}"
                               .format(self.archive_details[archive + "prefix"],
                                       self.tarball_prefix,
                                       destination))

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -524,17 +524,21 @@ def process_archives(archives):
         call(extract_cmd)
         tar_path = os.path.join(build.base_path, source_tarball_prefix)
         tar_files = glob.glob("{}/*".format(tar_path))
-        move_cmd = "mv -n "
-        for tar_file in tar_files:
-            move_cmd += '"{}"'.format(tar_file) + " "
-        move_cmd += '"{0}/{1}"'.format(path, destination)
+        if tar_path == path:
+            print("Archive {} already unpacked in main path {}; ignoring destination"
+                  .format(archive, path))
+        else:
+            move_cmd = "mv "
+            for tar_file in tar_files:
+                move_cmd += '"{}"'.format(tar_file) + " "
+            move_cmd += '"{0}/{1}"'.format(path, destination)
 
-        mkdir_cmd = "mkdir -p "
-        mkdir_cmd += '"{0}/{1}"'.format(path, destination)
+            mkdir_cmd = "mkdir -p "
+            mkdir_cmd += '"{0}/{1}"'.format(path, destination)
 
-        print("mkdir " + mkdir_cmd)
-        call(mkdir_cmd)
-        call(move_cmd)
+            print("mkdir " + mkdir_cmd)
+            call(mkdir_cmd)
+            call(move_cmd)
 
         sha1 = get_sha1sum(source_tarball_path)
         write_upstream(sha1, os.path.basename(archive), mode="a")

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -524,7 +524,7 @@ def process_archives(archives):
         call(extract_cmd)
         tar_path = os.path.join(build.base_path, source_tarball_prefix)
         tar_files = glob.glob("{}/*".format(tar_path))
-        move_cmd = "mv "
+        move_cmd = "mv -n "
         for tar_file in tar_files:
             move_cmd += '"{}"'.format(tar_file) + " "
         move_cmd += '"{0}/{1}"'.format(path, destination)


### PR DESCRIPTION
Some software packages break distribution into a core tarball then
additional tarballs with extra features or content. LibreOffice is one
such example. The additional tarballs provide files in the same
directory tree. The most efficient way to unpack all of these with the
current archive functionality is to place them at the same base dir, ./

At two points during autospec, the code to handle archives attempts to
either move or copy the contents of archive tarballs to the final
directory. If ./ is the unpacking directory, the files are already in
the same place, so mv and cp will fail, complaining that src and dst are
the same.

Add '-n' (no clobber) to these mv and cp commands, so that they simply
do nothing when the files are already in the correct final destination.

**Currently testing this with a build of LibreOffice. Do not merge until this has been tested thoroughly.**