### PR TITLE
CMake support: Don't make copies of sources for AVX2/AVX512/32-bit builds

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -396,18 +396,19 @@ class Specfile(object):
                                       self.tarball_prefix,
                                       destination))
         self.apply_patches()
-        if config.config_opts['32bit']:
-            self._write_strip("pushd ..")
-            self._write_strip("cp -a {} build32".format(self.tarball_prefix))
-            self._write_strip("popd")
-        if config.config_opts['use_avx2']:
-            self._write_strip("pushd ..")
-            self._write_strip("cp -a {} buildavx2".format(self.tarball_prefix))
-            self._write_strip("popd")
-        if config.config_opts['use_avx512']:
-            self._write_strip("pushd ..")
-            self._write_strip("cp -a {} buildavx512".format(self.tarball_prefix))
-            self._write_strip("popd")
+        if self.default_pattern != 'cmake':
+            if config.config_opts['32bit']:
+                self._write_strip("pushd ..")
+                self._write_strip("cp -a {} build32".format(self.tarball_prefix))
+                self._write_strip("popd")
+            if config.config_opts['use_avx2']:
+                self._write_strip("pushd ..")
+                self._write_strip("cp -a {} buildavx2".format(self.tarball_prefix))
+                self._write_strip("popd")
+            if config.config_opts['use_avx512']:
+                self._write_strip("pushd ..")
+                self._write_strip("cp -a {} buildavx512".format(self.tarball_prefix))
+                self._write_strip("popd")
         self._write_strip("\n")
 
     def write_32bit_exports(self):


### PR DESCRIPTION

The CMake pattern reuses the same sources by doing different
out-of-tree builds. The copied sources are not useful.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>