### PR TITLE
Add phpize package support.

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -632,6 +632,8 @@ def scan_for_configure(dirn):
         add_buildreq("buildreq-scons")
     elif buildpattern.default_pattern == "R":
         add_buildreq("buildreq-R")
+    elif buildpattern.default_pattern == "phpize":
+        add_buildreq("buildreq-php")
 
     count = 0
     for dirpath, _, files in os.walk(dirn):
@@ -680,6 +682,10 @@ def scan_for_configure(dirn):
         if "meson.build" in files:
             add_buildreq("buildreq-meson")
             buildpattern.set_build_pattern("meson", default_score)
+
+        if "config.m4" in files:
+            add_buildreq("buildreq-php")
+            buildpattern.set_build_pattern("phpize", 1)
 
         for name in files:
             if name.lower() == "cargo.toml" and dirpath == dirn:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1502,6 +1502,21 @@ class Specfile(object):
         self._write_strip("DESTDIR=%{buildroot} ninja -C builddir install")
         self.write_find_lang()
 
+    def write_phpize_pattern(self):
+        """Write phpize build pattern to spec file."""
+        self.write_prep()
+        self._write_strip("%build")
+        self.write_build_prepend()
+        self.write_proxy_exports()
+        self._write_strip("phpize")
+        self._write_strip("%configure")
+        self.write_make_line()
+        self._write_strip("\n")
+        self._write_strip("%install")
+        self.write_install_prepend()
+        self._write_strip("%make_install")
+        self._write_strip("\n")
+
     def write_find_lang(self):
         """Write %find_lang macro to spec file."""
         for lang in self.locales:


### PR DESCRIPTION
This relies on the convention that `phpize` reads a `config.m4` file and from that finds all the needed PHP stuff.