### PR TITLE
Honor requires_ban in subpackages as well.

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -234,6 +234,12 @@ class Specfile(object):
         deps["libexec"] = ["config", "license"]
         deps["lib32"] = ["data", "license"]
         deps["python"] = ["python3"]
+        for pkg, pkg_reqs in deps.items():
+            for pkg_req in pkg_reqs:
+                if "{}-{}".format(self.name, pkg_req) in buildreq.banned_requires:
+                    pkg_reqs.remove(pkg_req)
+                    continue
+
         if config.config_opts['dev_requires_extras']:
             deps["dev"].append("extras")
         for k, v in self.custom_extras.items():


### PR DESCRIPTION
The top-level package does honor a subpackage ban in requires_ban.
However, autodependencies do not honor it. Unless they do, it's
meaningless to control subpackages via requires_ban. For example, if I
want to ban pkg-services, top-level package will not require it, but the
content will still be installed since pkg requires pkg-bin, which, in
turn, will require pkg-services. With this change, it will not.

None of the existing packages is impacted by this change.