### PR TITLE
Ignore for-review.txt

### DIFF
--- a/autospec/git.py
+++ b/autospec/git.py
@@ -119,6 +119,7 @@ def commit_to_git(path):
         "commitmsg",
         "results/",
         "rpms/",
+        "for-review.txt",
         ""
     ]
     write_out(os.path.join(path, '.gitignore'), '\n'.join(ignorelist))


### PR DESCRIPTION
The Clear Linux OS developer tooling recently gained the ability to
create trimmed-down patches from autospec commits, dumping them to files
named "for-review.txt".

Update .gitignore to ignore these files.