### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
+dist: xenial
 sudo: enabled
 python:
   - "3.6"
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libgnutls-dev
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
The CI infra will occasionally choose Ubuntu 16.04 LTS by default
instead of 14.04 LTS, which results in pycurl failing to build due to a
missing dependency (libgnutls-dev).

Resolve the issue by installing the missing dependency and forcing
xenial (16.04) as the default.