### PR TITLE
fix attrs usage for file controls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,9 +395,18 @@ setuid
   ``%attr`` macro.
 
 attrs
-  Each line in this file should be a full ``%attr`` macro line that will be
-  included in the ``.spec`` to have fine-grained control over the permissions
-  and ownership of files in the package.
+  Each line in this file should specify mode, user, group and filename
+  (space separated) which is translated into a full ``%attr`` macro
+  line that will be included in the ``.spec`` to have fine-grained control
+  over the permissions and ownership of files in the package.
+
+  An example of a ``attrs`` file would contain::
+
+    4755 root messagebus /usr/libexec/dbus-daemon-launch-helper
+
+  which would translate to the following line in the resulting ``.spec`` file::
+
+    %attr(4755,root,messagebus) /usr/libexec/dbus-daemon-launch-helper
 
 
 Controlling test suites

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -750,12 +750,11 @@ def parse_config_files(path, bump, filemanager, version):
 
     content = read_conf_file(os.path.join(path, "attrs"))
     for line in content:
-        attr = re.split(r'\(|\)|,', line)
-        attr = [a.strip() for a in attr]
+        attr = line.split()
         filename = attr.pop()
-        print("attr for: %s." % filename)
+        print("%attr({0},{1},{2}) for: {3}".format(
+            attr[0], attr[1], attr[2], filename))
         filemanager.attrs[filename] = attr
-        filemanager.excludes.append(filename)
 
     patches += read_conf_file(os.path.join(path, "series"))
     pfiles = [("%s/%s" % (path, x.split(" ")[0])) for x in patches]

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -55,6 +55,12 @@ class FileManager(object):
         if package not in self.packages:
             self.packages[package] = set()
 
+        # prepend the %attr macro if file defined in 'attrs' control file
+        if filename in self.attrs:
+            mod = self.attrs[filename][0]
+            u = self.attrs[filename][1]
+            g = self.attrs[filename][2]
+            filename = "%attr({0},{1},{2}) {3}".format(mod, u, g, filename)
         self.packages[package].add(filename)
         build.must_restart += 1
         if not self.newfiles_printed:
@@ -178,12 +184,6 @@ class FileManager(object):
         if filename in self.setuid:
             newfn = "%attr(4755, root, root) " + filename
             self.push_package_file(newfn, "setuid")
-
-        if filename in self.attrs:
-            newfn = "{0}({1}) {2}".format(self.attrs[filename][0],
-                                          ','.join(self.attrs[filename][1:3]),
-                                          filename)
-            self.push_package_file(newfn, "attr")
 
         # autostart
         part = re.compile(r"^/usr/lib/systemd/system/.+\.target\.wants/.+")

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -82,6 +82,7 @@ def commit_to_git(path):
     call("git add configure_misses", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add whatrequires", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add description", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add attrs", check=False, stderr=subprocess.DEVNULL, cwd=path)
 
     # remove deprecated config files
     call("git rm make_install_append", check=False, stderr=subprocess.DEVNULL, cwd=path)


### PR DESCRIPTION
This commit changes the syntax of the attrs control file and
actually makes use of it for %file setup.

New syntax of the `attrs` file is `<mode> <user> <group> <filename>`
(space separated).

e.g:
4755 root messagebus /usr/libexec/dbus-daemon-launch-helper

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>