### PR TITLE
Don't require staticdev32 in the main package

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -185,7 +185,8 @@ class Specfile(object):
             if pkg.endswith("-extras"):
                 continue
             if pkg in ["ignore", "main", "dev", "active-units", "extras",
-                       "lib32", "dev32", "legacypython", "doc", "abi", "staticdev"]:
+                       "lib32", "dev32", "legacypython", "doc", "abi", "staticdev",
+                       "staticdev32"]:
                 continue
             # honor requires_ban for manual overrides
             if "{}-{}".format(self.name, pkg) in buildreq.banned_requires:
@@ -276,6 +277,9 @@ class Specfile(object):
                 self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))
 
             if pkg == "staticdev":
+                self._write("Requires: {}-dev = %{{version}}-%{{release}}\n".format(self.name))
+
+            if pkg == "staticdev32":
                 self._write("Requires: {}-dev = %{{version}}-%{{release}}\n".format(self.name))
 
             if pkg == "python3":


### PR DESCRIPTION
The original implementation missed the staticdev32 exclude, this
change fixes that gap.