### PR TITLE
Fix misdetection of new CVEs for commit summaries

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -527,7 +527,7 @@ def parse_existing_spec(path, name):
             if key == "version":
                 old_version = value
             elif key.startswith("patch"):
-                old_patches.append(value)
+                old_patches.append(value.lower())
 
     # Ignore nopatch
     for patch in patches:


### PR DESCRIPTION
The names of existing CVE patches, as detected from an existing spec
file, have been detected as new CVE patches by mistake, and the
resulting git commit summaries explicitly mention the previously fixed
CVEs.

Fix the issue by lowercasing the patch names when populated the list of
old patches, because the code block below this one also lowercases them
prior to checking their names.