### PR TITLE
Fix config use_lto default wanting to be a string

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -340,7 +340,7 @@ def create_conf(path):
             config_f['autospec'][fname] = 'false'
 
     # default lto to true for new things
-    config_f['autospec']['use_lto'] = True
+    config_f['autospec']['use_lto'] = 'true'
 
     # renamed options need special care
     if os.path.exists("skip_test_suite"):


### PR DESCRIPTION
Introduced in f3914aa2521940614b752679351f24cb7f9af569 as a boolean to default LTO but configparser wants a string.

```
Traceback (most recent call last):
  File "./projects/autospec/autospec/autospec.py", line 362, in <module>
    main()
  File "./projects/autospec/autospec/autospec.py", line 237, in main
    package(args, url, name, archives, workingdir, infile_dict)
  File "./projects/autospec/autospec/autospec.py", line 267, in package
    config.parse_config_files(build.download_path, args.bump, filemanager, tarball.version)
  File "/home/puneetse/clearlinux/projects/autospec/autospec/config.py", line 616, in parse_config_files
    read_config_opts(path)
  File "/home/puneetse/clearlinux/projects/autospec/autospec/config.py", line 385, in read_config_opts
    create_conf(path)
  File "/home/puneetse/clearlinux/projects/autospec/autospec/config.py", line 343, in create_conf
    config_f['autospec']['use_lto'] = True
  File "/usr/lib/python3.7/configparser.py", line 1255, in __setitem__
    self._parser._validate_value_types(option=key, value=value)
  File "/usr/lib/python3.7/configparser.py", line 1182, in _validate_value_types
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```