### PR TITLE
Update format of custom_extras files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,18 +368,26 @@ dev_extras
   software that Autospec does not automatically detect.
 
 ${custom}_extras
-  A `toml <https://github.com/toml-lang/toml>`_ file with a required 'files'
-  keypair that has as its value a list of strings that are full paths that
-  will be put in the ``extras-${custom}`` subpackage. It can also contain an
-  optional 'requires' keypair that has as its value a list of strings that
-  are subpackage names of other subpackages in the package. For example a
-  foo_extras file containing::
+  Same as "extras" above, but instead of the files being placed in an
+  ``-extras`` subpackage, they will be placed in the ``extras-${custom}``
+  subpackage.
 
-    files = ['/usr/bin/foo', '/usr/lib64/libfoo.so']
-    requires = ['data']
+${custom}_extras_requires
+  Each line contains a subpackage names of other subpackages in the package.
+  This is used when the ``extras-${custom}`` subpackage has a runtime
+  requirement on a sibling subpackage.
 
-  will produce a spec file package section for example-foo-extras with the
-  following content::
+  An example of the ``${custom}_extras`` and ``${custom}_extras_requires``
+  being used together with::
+
+    /usr/bin/foo
+
+  in foo_extras and::
+
+    data
+
+  in foo_extras_requires will produce a spec file package
+  section for example-foo-extras with the following content::
 
     %package extras-foo
     Summary: extras-foo components for the example package.

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -60,7 +60,6 @@ def commit_to_git(path):
     call("bash -c 'shopt -s failglob; git add -f *.sha256'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add -f *.sign'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("bash -c 'shopt -s failglob; git add -f *.pkey'", check=False, stderr=subprocess.DEVNULL, cwd=path)
-    call("bash -c 'shopt -s failglob; git add -f *_extras'", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure32", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure64", check=False, stderr=subprocess.DEVNULL, cwd=path)


### PR DESCRIPTION
Switching to flat file handling using the same conf file parsing as
other config files like extras and dev_extras.

Moves to two different config files for the file list and the requires
list.