### PR TITLE
Improve go ecosystem support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -326,8 +326,9 @@ build_pattern
   * distutils3: Only build the Pythonic package with Python 3
   * distutils23: Build the Pythonic package using both Python 2 and Python 3
   * meson: Build package with Meson/Ninja
+  * golang: Build Go package
+  * godep: A go dependency-only package
   * \[WIP\] cargo: Build Rust package with Cargo
-  * \[WIP\] golang: Build Go package
   * \[WIP\] scons: Build package with Scons
 
 series

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -248,6 +248,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     #
     filemanager = files.FileManager()
     tarball.process(url, name, args.version, args.target, archives, filemanager)
+    config.create_versions(build.download_path, tarball.multi_version)
     _dir = tarball.path
 
     if args.license_only:

--- a/autospec/buildpattern.py
+++ b/autospec/buildpattern.py
@@ -21,7 +21,7 @@
 
 default_pattern = "make"
 pattern_strength = 0
-sources = {"unit": [], "gcov": [], "tmpfile": [], "archive": []}
+sources = {"unit": [], "gcov": [], "tmpfile": [], "archive": [], "destination": [], "godep": []}
 source_index = {}
 archive_details = {}
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -369,6 +369,13 @@ def create_buildreq_cache(path, version):
     config_files.add('buildreq_cache')
 
 
+def create_versions(path, versions):
+    """Make versions file."""
+    with open(os.path.join(path, "versions"), 'w') as vfile:
+        vfile.write('\n'.join(sorted(versions, reverse=True)) + '\n')
+    config_files.add("versions")
+
+
 def write_config(config_f, path):
     """Write the config_f to configfile."""
     with open(os.path.join(path, 'options.conf'), 'w') as configfile:
@@ -434,9 +441,10 @@ def filter_blanks(lines):
 
 
 def read_conf_file(path, track=True):
-    """
-    Read configuration file at path. If the config file does not exist (or is
-    not expected to exist) in the package git repo, specify 'track=False'.
+    """Read configuration file at path.
+
+    If the config file does not exist (or is not expected to exist)
+    in the package git repo, specify 'track=False'.
     """
     try:
         with open(path, "r") as f:
@@ -532,6 +540,11 @@ def parse_existing_spec(path, name):
         patch = patch.lower()
         if patch not in old_patches and patch.endswith(".patch") and patch.startswith("cve-"):
             cves.append(patch.upper().split(".PATCH")[0])
+
+
+def parse_config_versions(path):
+    """Parse the versions configuration file."""
+    return set(read_conf_file(os.path.join(path, "versions")))
 
 
 def parse_config_files(path, bump, filemanager, version):

--- a/autospec/download.py
+++ b/autospec/download.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from io import BytesIO
 import os
 import sys
+from io import BytesIO
 
 import pycurl
 from util import print_fatal

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -108,6 +108,8 @@ def commit_to_git(path):
     ignorelist = [
         ".*~",
         "*~",
+        "*.info",
+        "*.mod",
         "*.swp",
         ".repo-index",
         "*.log",

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -99,8 +99,9 @@ def write_out(filename, content, mode="w"):
 
 
 def open_auto(*args, **kwargs):
-    """
-    Open a file with UTF-8 encoding, and "surrogate" escape characters that are
+    """Open a file with UTF-8 encoding.
+
+    Open file with UTF-8 encoding and "surrogate" escape characters that are
     not valid UTF-8 to avoid data corruption.
     """
     # 'encoding' and 'errors' are fourth and fifth positional arguments, so

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -152,6 +152,37 @@ class TestBuildreq(unittest.TestCase):
                               'intltool',
                               'sed']))
 
+    def test_parse_go_mod(self):
+        """
+        Test parse_go_mod
+        """
+        open_name = 'buildreq.open'
+        content = """module example.com/foo/bar
+
+        require (
+        github.com/example/foo v1.0.0
+        git.apache.org/skip.git v0.0.0-20180101111111-barf0000000d
+        github.com/redirect/bar v2.0.0 // indirect
+        "github.com/quote/baz" v0.0.3
+        "github.com/qdirect/raz" v1.0.3 // indirect
+        )"""
+        m_open = mock_open(read_data=content)
+        with patch(open_name, m_open, create=True):
+            result = buildreq.parse_go_mod('filename')
+        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result[0]), 2)
+        self.assertEqual(result[0][0], "github.com/example/foo")
+        self.assertEqual(result[0][1], "v1.0.0")
+        self.assertEqual(len(result[1]), 2)
+        self.assertEqual(result[1][0], "github.com/redirect/bar")
+        self.assertEqual(result[1][1], "v2.0.0")
+        self.assertEqual(len(result[2]), 2)
+        self.assertEqual(result[2][0], "github.com/quote/baz")
+        self.assertEqual(result[2][1], "v0.0.3")
+        self.assertEqual(len(result[3]), 2)
+        self.assertEqual(result[3][0], "github.com/qdirect/raz")
+        self.assertEqual(result[3][1], "v1.0.3")
+
     def test_parse_cargo_toml(self):
         """
         Test parse_cargo_toml

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -55,16 +55,18 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.sources["archive"] = ["archA", "archD", "archB", "archC"]
         self.specfile.sources["tmpfile"] = ["tmp1", "tmp2"]
         self.specfile.sources["gcov"] = ["pkg.gcov"]
+        self.specfile.sources["godep"] = ["pkg.godep"]
         self.specfile.write_sources()
         expect = ["Source1  : archA\n",
                   "Source2  : archB\n",
                   "Source3  : archC\n",
                   "Source4  : archD\n",
                   "Source5  : pkg.gcov\n",
-                  "Source6  : pkg1.service\n",
-                  "Source7  : pkg2.service\n",
-                  "Source8  : tmp1\n",
-                  "Source9  : tmp2\n"]
+                  "Source6  : pkg.godep\n",
+                  "Source7  : pkg1.service\n",
+                  "Source8  : pkg2.service\n",
+                  "Source9  : tmp1\n",
+                  "Source10  : tmp2\n"]
         self.assertEqual(expect, self.WRITES)
 
     def test_write_summary(self):

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -26,13 +26,14 @@ def test_generator(url, name, version):
         """
         Test the name and version detection from tarball url
         """
-        tarball.name = ''
-        tarball.version = ''
         tarball.giturl = ''
         tarball.url = url
-        tarball.name_and_version('', '', FileManager())
-        self.assertEqual(name, tarball.name)
-        self.assertEqual(version, tarball.version)
+        set_multi_version_backup = tarball.set_multi_version
+        tarball.config.parse_config_versions = mock_gen(rv=version)
+        n, _, v = tarball.name_and_version('', '', FileManager())
+        tarball.set_multi_version = set_multi_version_backup
+        self.assertEqual(name, n)
+        self.assertEqual(version, v)
         if re.match("https?://github.com", url) != None:
             self.assertIsNotNone(tarball.giturl)
             self.assertNotEqual('', tarball.giturl, "giturl should not be empty")
@@ -64,9 +65,11 @@ class TestTarballVersionName(unittest.TestCase):
         """
         Test the version and name override from the command line
         """
-        tarball.name_and_version('something', 'else', FileManager())
-        self.assertEqual(tarball.version, 'else')
-        self.assertEqual(tarball.name, 'something')
+        set_multi_version_backup = tarball.set_multi_version
+        n, _, v = tarball.name_and_version('something', 'else', FileManager())
+        tarball.set_multi_version = set_multi_version_backup
+        self.assertEqual(v, 'else')
+        self.assertEqual(n, 'something')
 
     def test_build_untar(self):
         """
@@ -132,6 +135,25 @@ class TestTarballVersionName(unittest.TestCase):
         tarball.build.base_path = '.'
         self.assertEqual(tarball.build_unzip('zip/path'),
                          ('unzip -qq -d . zip/path', 'prefix-dir'))
+
+    def test_build_go_unzip(self):
+        """
+        Test build_go_unzip
+        """
+        build_unzip_backup = tarball.build_unzip
+        tarball.build_unzip = lambda x: (f"unzip {x}", "/foo")
+        tarball.multi_version = ["v1.0.0"]
+        open_name = 'tarball.open'
+        content = "v1.0.0\n"
+        go_sources = ["v1.0.0.info", "v1.0.0.mod", "v1.0.0.zip"]
+        tarball.buildpattern.sources["godep"] = []
+        cmd, prefix = tarball.build_go_unzip("/foo/bar")
+        tarball.build_unzip = build_unzip_backup
+        self.assertEqual(len(cmd), 1)
+        self.assertEqual(cmd[0], "unzip /foo/v1.0.0.zip")
+        self.assertEqual(prefix, "/foo")
+        self.assertEqual(tarball.buildpattern.sources["godep"], go_sources)
+        tarball.buildpattern.sources["godep"] = []
 
     def test_build_un7z(self):
         """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -64,6 +64,5 @@ class TestUtil(unittest.TestCase):
             self.assertTrue(util.binary_in_path('testbin'))
             self.assertEqual(util.os_paths, [tmpd])
 
-
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
Update support for handling go packages by handling missing go
dependencies. Make use of go modules and the go proxy (see
https://tip.golang.org/cmd/go/#hdr-Module_proxy_protocol for more
details on the proxy implementation) to discover what artifacts are
needed.

A new go-dep build_pattern that will package all versions that the
go-proxy finds is also added as part of this change. Additional rework
of the golang build_pattern (and Makefile build_pattern as a number of
go packages use Makefiles) to use module vendoring when module
configuration is detected was added as well.

The new functionality is also intended to be used by a higher level
tool that will wrap autospec calls to build missing dependencies as
well as the requested package.