### PR TITLE
Make qmake builds produce fat LTO objects for static libraries

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1359,9 +1359,9 @@ class Specfile(object):
         if config.config_opts['use_clang']:
             extra_qmake_args = "-spec linux-clang "
         if config.config_opts['use_lto']:
-            extra_qmake_args += "-config ltcg "
+            extra_qmake_args += "-config ltcg -config fat-static-lto "
         else:
-            extra_qmake_args += "QMAKE_CFLAGS+=-fno-lto QMAKE_CXXFLAGS+=-fno-lto"
+            extra_qmake_args += "QMAKE_CFLAGS+=-fno-lto QMAKE_CXXFLAGS+=-fno-lto "
 
         self.write_prep()
         self._write_strip("%build")


### PR DESCRIPTION
By default, qmake builds make thin objects.

Added a missing space for the non-LTO case, as that's concatenated to
the args in the package-supplied "configure" file.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>