### PR TITLE
build: skip blank lines when populating file list

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -231,7 +231,10 @@ def parse_build_results(filename, returncode, filemanager):
         if "Installed (but unpackaged) file(s) found:" in line:
             infiles = 1
         elif infiles == 1 and "not matching the package arch" not in line:
-            filemanager.push_file(line.strip())
+            # exclude blank lines from consideration...
+            file = line.strip()
+            if file:
+                filemanager.push_file(file)
 
         if line.startswith("Sorry: TabError: inconsistent use of tabs and spaces in indentation"):
             print(line)


### PR DESCRIPTION
If blank lines appear in the file list from the build log, skip them.