### PR TITLE
Add open_auto helper function

### DIFF
--- a/autospec/abireport.py
+++ b/autospec/abireport.py
@@ -197,7 +197,7 @@ def truncate_file(path):
     """Zero file content."""
     if not os.path.exists(path):
         return
-    with open(path, "r+", encoding="utf-8") as trunc:
+    with util.open_auto(path, "r+") as trunc:
         trunc.truncate()
 
 
@@ -297,7 +297,7 @@ def examine_abi_fallback(download_path, results_dir):
 
     if len(abi_report) > 0:
         # Finally, write the report
-        report = open(report_file, "w", encoding="utf-8")
+        report = util.open_auto(report_file, "w")
         for soname in sorted(abi_report.keys()):
             for symbol in sorted(abi_report[soname]):
                 report.write("{}:{}\n".format(soname, symbol))
@@ -310,7 +310,7 @@ def examine_abi_fallback(download_path, results_dir):
     lib_deps = get_all_dependencies(extract_dir)
     report_file = os.path.join(download_path, "used_libs")
     if len(lib_deps) > 0:
-        report = open(report_file, "w", encoding="utf-8")
+        report = util.open_auto(report_file, "w")
         for soname in sorted(lib_deps):
             report.write("{}\n".format(soname))
         report.close()

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -166,7 +166,7 @@ def parse_buildroot_log(filename, returncode):
     must_restart = 0
     is_clean = True
     util.call("sync")
-    with open(filename, "r", encoding="latin-1") as rootlog:
+    with util.open_auto(filename, "r") as rootlog:
         loglines = rootlog.readlines()
 
     missing_pat = re.compile(r"^.*No matching package to install: '(.*)'$")
@@ -199,7 +199,7 @@ def parse_build_results(filename, returncode, filemanager):
 
     # Flush the build-log to disk, before reading it
     util.call("sync")
-    with open(filename, "r", encoding="latin-1") as buildlog:
+    with util.open_auto(filename, "r") as buildlog:
         loglines = buildlog.readlines()
 
     for line in loglines:

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -223,7 +223,7 @@ def parse_configure_ac(filename):
     depth = 0
     # print("Configure parse: ", filename)
     buildpattern.set_build_pattern("configure_ac", 1)
-    f = open(filename, "r", encoding="latin-1")
+    f = util.open_auto(filename, "r")
     while 1:
         c = f.read(1)
         if not c:
@@ -250,7 +250,7 @@ def parse_cargo_toml(filename):
     global cargo_bin
     buildpattern.set_build_pattern("cargo", 1)
     add_buildreq("rustc")
-    with open(filename, "r", encoding="latin-1") as ctoml:
+    with util.open_auto(filename, "r") as ctoml:
         cargo = toml.loads(ctoml.read())
     if cargo.get("bin") or os.path.exists(os.path.join(os.path.dirname(filename), "src/main.rs")):
         cargo_bin = True
@@ -309,7 +309,7 @@ def set_build_req():
 
 def rakefile(filename):
     """Scan Rakefile for build requirements."""
-    with open(filename, "r", encoding="latin-1") as f:
+    with util.open_auto(filename, "r") as f:
         lines = f.readlines()
 
     pat = re.compile(r"^require '(.*)'$")
@@ -332,7 +332,7 @@ def parse_cmake(filename):
                             'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
     extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')
 
-    with open(filename, "r", encoding="latin-1") as f:
+    with util.open_auto(filename, "r") as f:
         lines = f.readlines()
     for line in lines:
         match = findpackage.search(line)
@@ -365,7 +365,7 @@ def parse_cmake(filename):
 
 def qmake_profile(filename):
     """Scan .pro file for build requirements."""
-    with open(filename, "r", encoding="latin-1") as f:
+    with util.open_auto(filename, "r") as f:
         lines = f.readlines()
 
     pat = re.compile(r"(QT|QT_PRIVATE|QT_FOR_CONFIG).*=\s*(.*)\s*")
@@ -434,7 +434,7 @@ def grab_python_requirements(descfile):
     if "/tests/" in descfile:
         return
 
-    with open(descfile, "r", encoding="latin-1") as f:
+    with util.open_auto(descfile, "r") as f:
         lines = f.readlines()
 
     for line in lines:
@@ -479,7 +479,7 @@ def get_python_build_version_from_classifier(filename):
     Uses "Programming Language :: Python :: [2,3] :: Only" classifiers in the
     setup.py file.  Defaults to distutils3 if no such classifiers are found.
     """
-    with open(filename) as setup_file:
+    with util.open_auto(filename) as setup_file:
         data = setup_file.read()
 
     if "Programming Language :: Python :: 3 :: Only" in data:
@@ -513,7 +513,7 @@ def add_setup_py_requires(filename):
     Does not evaluate variables for security purposes
     """
     multiline = False
-    with open(filename) as f:
+    with util.open_auto(filename) as f:
         lines = f.readlines()
 
     for line in lines:
@@ -595,7 +595,7 @@ def add_setup_py_requires(filename):
 
 def parse_catkin_deps(cmakelists_file):
     """Determine requirements for catkin packages."""
-    f = open(cmakelists_file, "r", encoding="latin-1")
+    f = util.open_auto(cmakelists_file, "r")
     lines = f.readlines()
     pat = re.compile(r"^find_package.*\(.*(catkin)(?: REQUIRED *)?(?:COMPONENTS (?P<comp>.*))?\)$")
     catkin = False

--- a/autospec/check.py
+++ b/autospec/check.py
@@ -52,7 +52,7 @@ def check_regression(pkg_dir):
                     print("{}: {}".format(title[1], s_line[idx]))
                 res_str += "{} : {}\n".format(title[0], s_line[idx])
 
-    util.write_out(os.path.join(pkg_dir, "testresults"), res_str, encode="utf-8")
+    util.write_out(os.path.join(pkg_dir, "testresults"), res_str)
 
 
 def scan_for_tests(src_dir):
@@ -98,13 +98,13 @@ def scan_for_tests(src_dir):
         if not os.path.isfile(makefile_path):
             return
 
-        if "enable_testing" in open(makefile_path, encoding='latin-1').read():
+        if "enable_testing" in util.open_auto(makefile_path).read():
             tests_config = testsuites["cmake"]
 
     elif buildpattern.default_pattern in ["cpan", "configure", "configure_ac", "autogen"] and "Makefile.in" in files:
         makefile_path = os.path.join(src_dir, "Makefile.in")
         if os.path.isfile(makefile_path):
-            with open(makefile_path, 'r', encoding="latin-1") as make_fp:
+            with util.open_auto(makefile_path, 'r') as make_fp:
                 lines = make_fp.readlines()
             for line in lines:
                 if line.startswith("check:"):
@@ -121,9 +121,7 @@ def scan_for_tests(src_dir):
         tests_config = testsuites["perlcheck"]
 
     elif buildpattern.default_pattern in ["distutils3", "distutils23"] and "setup.py" in files:
-        with open(os.path.join(src_dir, "setup.py"), 'r',
-                  encoding="ascii",
-                  errors="surrogateescape") as setup_fp:
+        with util.open_auto(os.path.join(src_dir, "setup.py"), 'r') as setup_fp:
             setup_contents = setup_fp.read()
 
         if "test_suite" in setup_contents or "pbr=True" in setup_contents:

--- a/autospec/commitmessage.py
+++ b/autospec/commitmessage.py
@@ -104,7 +104,7 @@ def process_NEWS(newsfile):
         return commitmessage, cves
 
     try:
-        with open(os.path.join(build.download_path, newsfile), encoding="latin-1") as f:
+        with util.open_auto(os.path.join(build.download_path, newsfile)) as f:
             newslines = f.readlines()
     except EnvironmentError:
         return commitmessage, cves

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -32,6 +32,7 @@ import check
 import license
 import tarball
 from util import call, print_warning, write_out
+from util import open_auto
 
 extra_configure = ""
 extra_configure32 = ""
@@ -505,7 +506,7 @@ def parse_existing_spec(path, name):
     if not os.path.exists(spec):
         return
 
-    with open(spec, "r", encoding="latin-1") as inp:
+    with open_auto(spec, "r") as inp:
         for line in inp.readlines():
             line = line.strip().replace("\r", "").replace("\n", "")
             if "Source0 file verified with key" in line:

--- a/autospec/count.py
+++ b/autospec/count.py
@@ -18,6 +18,7 @@
 
 import argparse
 import re
+import util
 
 testcount = {}
 testpass = {}
@@ -170,7 +171,7 @@ def parse_log(log, pkgname=''):
 
     name = pkgname
     incheck = False
-    with open(log, 'r') as logf:
+    with util.open_auto(log, 'r') as logf:
         lines = logf.readlines()
 
     zero_lines = ["Executing(%check)",

--- a/autospec/specdescription.py
+++ b/autospec/specdescription.py
@@ -31,6 +31,7 @@ import re
 
 import config
 import license
+import util
 
 default_description = "No detailed description available"
 default_description_score = 0
@@ -86,7 +87,7 @@ def assign_description(description, score):
 def description_from_spec(specfile):
     """Parse any existing RPM specfiles."""
     try:
-        with open(specfile, 'r', encoding="latin-1") as specfd:
+        with util.open_auto(specfile, 'r') as specfd:
             lines = specfd.readlines()
     except FileNotFoundError:
         return
@@ -130,7 +131,7 @@ def description_from_spec(specfile):
 def description_from_pkginfo(pkginfo):
     """Parse existing package info files."""
     try:
-        with open(pkginfo, 'r', encoding="latin-1") as pkgfd:
+        with util.open_auto(pkginfo, 'r') as pkgfd:
             lines = pkgfd.readlines()
     except FileNotFoundError:
         return
@@ -170,7 +171,7 @@ def description_from_pkginfo(pkginfo):
 def summary_from_pkgconfig(pkgfile, package):
     """Parse pkgconfig files for Description: lines."""
     try:
-        with open(pkgfile, "r", encoding="latin-1") as pkgfd:
+        with util.open_auto(pkgfile, "r") as pkgfd:
             lines = pkgfd.readlines()
     except FileNotFoundError:
         return
@@ -186,7 +187,7 @@ def summary_from_pkgconfig(pkgfile, package):
 def summary_from_R(pkgfile):
     """Parse DESCRIPTION file for Title: lines."""
     try:
-        with open(pkgfile, "r", encoding="latin-1") as pkgfd:
+        with util.open_auto(pkgfile, "r") as pkgfd:
             lines = pkgfd.readlines()
     except FileNotFoundError:
         return
@@ -216,7 +217,7 @@ def skipline(line):
 def description_from_readme(readmefile):
     """Try to pick the first paragraph or two from the readme file."""
     try:
-        with open(readmefile, "r", encoding="latin-1") as readmefd:
+        with util.open_auto(readmefile, "r") as readmefd:
             lines = readmefd.readlines()
     except FileNotFoundError:
         return

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -28,6 +28,7 @@ from collections import OrderedDict
 import buildreq
 import config
 from util import _file_write
+from util import open_auto
 
 
 class Specfile(object):
@@ -87,8 +88,7 @@ class Specfile(object):
 
     def write_spec(self, path):
         """Write spec file."""
-        self.specfile = open("{}/{}.spec".format(path, self.name),
-                             "w", encoding="utf-8")
+        self.specfile = open_auto("{}/{}.spec".format(path, self.name), "w")
         self.specfile.write_strip = types.MethodType(_file_write, self.specfile)
 
         # spec file comment header

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -96,3 +96,16 @@ def write_out(filename, content, mode="w", encode=None):
     """File.write convenience wrapper."""
     with open(filename, mode, encoding=encode) as require_f:
         require_f.write(content)
+
+
+def open_auto(*args, **kwargs):
+    """
+    Open a file with UTF-8 encoding, and "surrogate" escape characters that are
+    not valid UTF-8 to avoid data corruption.
+    """
+    # 'encoding' and 'errors' are fourth and fifth positional arguments, so
+    # restrict the args tuple to (file, mode, buffering) at most
+    assert len(args) <= 3
+    assert 'encoding' not in kwargs
+    assert 'errors' not in kwargs
+    return open(*args, encoding="utf-8", errors="surrogateescape", **kwargs)

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -92,9 +92,9 @@ def binary_in_path(binary):
     return False
 
 
-def write_out(filename, content, mode="w", encode=None):
+def write_out(filename, content, mode="w"):
     """File.write convenience wrapper."""
-    with open(filename, mode, encoding=encode) as require_f:
+    with open_auto(filename, mode) as require_f:
         require_f.write(content)
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -249,7 +249,7 @@ class TestBuildpattern(unittest.TestCase):
         call_backup = build.util.call
         build.util.call = mock_util_call
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = "line1\nDEBUG util.py:399:  No matching package to install: 'foobar'\nDEBUG util.py:399:  No matching package to install: 'foobarbaz'\nline 4"
         m_open = mock_open(read_data=content)
 
@@ -274,7 +274,7 @@ class TestBuildpattern(unittest.TestCase):
         call_backup = build.util.call
         build.util.call = mock_util_call
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = "line 1\nline 2\nline 3\nline 4"
         m_open = mock_open(read_data=content)
 
@@ -300,7 +300,7 @@ class TestBuildpattern(unittest.TestCase):
         call_backup = build.util.call
         build.util.call = mock_util_call
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = "line 1\nline 2\nline 3\nline 4"
         m_open = mock_open(read_data=content)
 
@@ -326,7 +326,7 @@ class TestBuildpattern(unittest.TestCase):
         build.util.call = mock_util_call
         fm = files.FileManager()
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = 'line 1\nwhich: no qmake\nexiting'
         m_open = mock_open(read_data=content)
 
@@ -352,7 +352,7 @@ class TestBuildpattern(unittest.TestCase):
         build.util.call = mock_util_call
         fm = files.FileManager()
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = 'line 1\nchecking for Apache test module support\nexiting'
         m_open = mock_open(read_data=content)
 
@@ -378,7 +378,7 @@ class TestBuildpattern(unittest.TestCase):
         build.util.call = mock_util_call
         fm = files.FileManager()
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = 'line 1\nImportError: No module named testpkg\nexiting'
         m_open = mock_open(read_data=content)
 
@@ -402,7 +402,7 @@ class TestBuildpattern(unittest.TestCase):
         build.util.call = mock_util_call
         fm = files.FileManager()
 
-        open_name = 'build.open'
+        open_name = 'build.util.open_auto'
         content = 'line 1\n' \
                   'Installed (but unpackaged) file(s) found:\n' \
                   '/usr/testdir/file\n' \

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -129,7 +129,7 @@ class TestBuildreq(unittest.TestCase):
         Test parse_configure_ac with changing () depths and package
         requirements
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = 'AC_CHECK_FUNC([tgetent])\n'                   \
                   'XDT_CHECK_PACKAGE(prefix, '                   \
                   '[module = 2 module2 > 9], '                   \
@@ -168,7 +168,7 @@ class TestBuildreq(unittest.TestCase):
         buildreq.os.path.exists = mock_exists
         buildreq.toml.loads = mock_loads
 
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = 'does not matter, let us mock'
         m_open = mock_open(read_data=content)
         with patch(open_name, m_open, create=True):
@@ -216,7 +216,7 @@ class TestBuildreq(unittest.TestCase):
         """
         Test rakefile parsing with both configured gems and unconfigured gems
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "line1\nrequire 'bundler/gem_tasks'\nline3\nrequire 'nope'"
         m_open = mock_open(read_data=content)
         with patch(open_name, m_open, create=True):
@@ -252,7 +252,7 @@ class TestBuildreq(unittest.TestCase):
         """
         # buildreqs must include the requires also
         buildreq.buildreqs = set(['req1', 'req2', 'req7'])
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = 'req1 <= 1.2.3\n' \
                   'req2 >= 1.55\n'  \
                   'req7 == 3.3.3\n'
@@ -268,7 +268,7 @@ class TestBuildreq(unittest.TestCase):
         """
         # buildreqs must include the requires also
         buildreq.buildreqs = set(['req1', 'req2', 'req7'])
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = '    req1 <= 1.2.3\n   ' \
                   'req2    >= 1.55   \n'   \
                   '   req7 == 3.3.3\n    '
@@ -283,7 +283,7 @@ class TestBuildreq(unittest.TestCase):
         Test add_setup_py_requires with a single item in install_requires and
         setup_requires
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=['req1']\n" \
                   "setup_requires=['req2']"
         m_open = mock_open(read_data=content)
@@ -297,7 +297,7 @@ class TestBuildreq(unittest.TestCase):
         """
         Test add_setup_py_requires with a multiline item in install_requires
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=['req1',\n" \
                   "'req2',\n"                   \
                   "'req3']\n"
@@ -313,7 +313,7 @@ class TestBuildreq(unittest.TestCase):
         Test add_setup_py_requires with a multiline item in install_requires
         with brackets on their own lines.
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=[\n "  \
                   "'req1',\n"              \
                   "'req2',\n"              \
@@ -331,7 +331,7 @@ class TestBuildreq(unittest.TestCase):
         Test add_setup_py_requires with multiline item in install_requires that
         contains a non-literal object.
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=[\n" \
                   "reqvar,\n"            \
                   "'req1',\n"            \
@@ -348,7 +348,7 @@ class TestBuildreq(unittest.TestCase):
         """
         Test add_setup_py_requires that contains a non-literal object.
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=[reqname, 'req1', 'req2']\n"
         m_open = mock_open(read_data=content)
         with patch(open_name, m_open, create=True):
@@ -361,7 +361,7 @@ class TestBuildreq(unittest.TestCase):
         """
         Test add_setup_py_requires with a single non-literal object
         """
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = "install_requires=reqname"
         m_open = mock_open(read_data=content)
         with patch(open_name, m_open, create=True):
@@ -375,7 +375,7 @@ class TestBuildreq(unittest.TestCase):
         test detection of python version from setup.py classifier
         """
 
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = """classifiers = [
                     'Programming Language :: Python :: 3 :: Only',
                 ]"""
@@ -391,7 +391,7 @@ class TestBuildreq(unittest.TestCase):
         test detection of python version from setup.py classifier
         """
 
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = """classifiers = [
                     'Programming Language :: Python :: 2 :: Only',
                 ]"""
@@ -407,7 +407,7 @@ class TestBuildreq(unittest.TestCase):
         test detection of python version from setup.py classifier
         """
 
-        open_name = 'buildreq.open'
+        open_name = 'buildreq.util.open_auto'
         content = """classifiers = [
                     'Programming Language :: Python :: 3',
                 ]"""

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -18,7 +18,7 @@ class TestTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.open_name = 'check.open'
+        self.open_name = 'check.util.open_auto'
         check.config.config_opts['skip_tests'] = False
         check.config.config_opts['allow_test_failures'] = False
         check.config.config_opts['32bit'] = False

--- a/tests/test_commitmessage.py
+++ b/tests/test_commitmessage.py
@@ -126,7 +126,7 @@ class TestCommitmessage(unittest.TestCase):
                     set(['cve1', 'cve2']))
 
         commitmessage.process_NEWS = mock_process_NEWS
-        open_name = 'util.open'
+        open_name = 'util.open_auto'
         with mock.patch(open_name, create=True) as mock_open:
             mock_open.return_value = mock.MagicMock()
             commitmessage.guess_commit_message("")
@@ -156,7 +156,7 @@ class TestCommitmessage(unittest.TestCase):
         commitmessage.process_NEWS = mock_process_NEWS
         commitmessage.config.cves = set(['CVE-1234-5678'])
         commitmessage.config.old_version = None  # Allow cve title to be set
-        open_name = 'util.open'
+        open_name = 'util.open_auto'
         with mock.patch(open_name, create=True) as mock_open:
             mock_open.return_value = mock.MagicMock()
             commitmessage.guess_commit_message("")
@@ -187,7 +187,7 @@ class TestCommitmessage(unittest.TestCase):
         commitmessage.process_NEWS = mock_process_NEWS
         commitmessage.config.cves = set(['CVE-1234-5678'])
         commitmessage.config.old_version = None  # Allow cve title to be set
-        open_name = 'util.open'
+        open_name = 'util.open_auto'
         with mock.patch(open_name, create=True) as mock_open:
             mock_open.return_value = mock.MagicMock()
             commitmessage.guess_commit_message("keyinfo content")

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -490,7 +490,7 @@ def test_generator(line, expected):
         """
         content = '+ make check\n' + line
         m_open = mock_open(read_data=content)
-        with patch('count.open', m_open, create=True):
+        with patch('count.util.open_auto', m_open, create=True):
             count.zero_test_data = mock_zero_test_data
             count.parse_log('log')
             count.zero_test_data = backup_zero_test_data

--- a/tests/test_specdescription.py
+++ b/tests/test_specdescription.py
@@ -7,7 +7,7 @@ class TestSpecdescription(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.open_name = 'specdescription.open'
+        self.open_name = 'specdescription.util.open_auto'
 
     def setUp(self):
         specdescription.default_description = "No detailed description available"


### PR DESCRIPTION
This helper function is meant to be used throughout autospec as a replacement for most uses of open(), especially whenever reading arbitrary data from upstream sources.

It reads/writes data in UTF-8 always, with invalid UTF-8 characters escaped with Python's "surrogate" escaping mechanism. This ensures that any Latin-1 or other non-UTF-8 compatible encoded data can successfully be read in and later written out without data corruption.