### PR TITLE
Implement new config for clr-service-restart units

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,12 @@ golang_libpath
   This could be easily fixed by placing ``gopkg.in/yaml.v`` in this file,
   changing where the go bits will be placed.
 
+service_restart
+  Each line in the file specifies the full path to a systemd unit file
+  installed by this package that should be restarted by clr-service-restart_.
+
+.. _clr-service-restart: https://github.com/clearlinux/clr-service-restart
+
 Controlling files and subpackages
 ---------------------------------
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -56,6 +56,7 @@ build_prepend = []
 make_prepend = []
 install_prepend = []
 install_append = []
+service_restart = []
 patches = []
 autoreconf = False
 custom_desc = ""
@@ -564,6 +565,7 @@ def parse_config_files(path, bump, filemanager, version):
     global make_prepend
     global install_prepend
     global install_append
+    global service_restart
     global patches
     global autoreconf
     global set_gopath
@@ -856,6 +858,7 @@ def parse_config_files(path, bump, filemanager, version):
     if os.path.isfile(os.path.join(path, "make_install_append")):
         os.rename(os.path.join(path, "make_install_append"), os.path.join(path, "install_append"))
     install_append = read_conf_file(os.path.join(path, "install_append"))
+    service_restart = read_conf_file(os.path.join(path, "service_restart"))
 
     profile_payload = read_conf_file(os.path.join(path, "profile_payload"))
 
@@ -881,6 +884,7 @@ def load_specfile(specfile):
     specfile.make_prepend = make_prepend
     specfile.install_prepend = install_prepend
     specfile.install_append = install_append
+    specfile.service_restart = service_restart
     specfile.patches = patches
     specfile.autoreconf = autoreconf
     specfile.set_gopath = set_gopath

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -80,6 +80,7 @@ class Specfile(object):
         self.make_prepend = []
         self.install_prepend = []
         self.install_append = []
+        self.service_restart = []
         self.excludes = []
         self.custom_extras = {}
         self.keyid = ""
@@ -303,6 +304,7 @@ class Specfile(object):
             pattern_method()
 
         self.write_source_installs()
+        self.write_service_restart()
         self.write_install_append()
         # self.write_systemd_units()
 
@@ -643,6 +645,17 @@ class Specfile(object):
             for line in self.install_append:
                 self._write_strip("{}\n".format(line))
             self._write_strip("## install_append end")
+
+    def write_service_restart(self):
+        """Enable configured units to be restarted with clr-service-restart."""
+        if self.service_restart:
+            self._write_strip("## service_restart content")
+            installdir = "%{buildroot}/usr/share/clr-service-restart"
+            self._write_strip("mkdir -p {}".format(installdir))
+            for unit in self.service_restart:
+                basename = os.path.basename(unit)
+                self._write_strip("ln -s {} {}".format(unit, os.path.join(installdir, basename)))
+            self._write_strip("## service_restart end")
 
     def write_source_installs(self):
         """Write out installs from SourceX lines."""

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -19,6 +19,7 @@ class TestSpecfileWrite(unittest.TestCase):
             self.WRITES.append(string)
 
         self.specfile._write = mock_write
+        self.specfile._write_strip = mock_write
         self.WRITES = []
 
     def test_write_nvr_no_urlban(self):
@@ -417,6 +418,25 @@ class TestSpecfileWrite(unittest.TestCase):
         """
         self.specfile.write_lang_files()
         self.assertEqual([], self.WRITES)
+
+    def test_write_service_restart(self):
+        """
+        Validate that service_restart configuration is written to the spec file
+        correctly.
+        """
+        self.specfile.service_restart = [
+                "/usr/lib/systemd/system/foo.service",
+                "/usr/lib/systemd/system/bar.service",
+        ]
+        self.specfile.write_service_restart()
+        expect = [
+            "## service_restart content",
+            "mkdir -p %{buildroot}/usr/share/clr-service-restart",
+            "ln -s /usr/lib/systemd/system/foo.service %{buildroot}/usr/share/clr-service-restart/foo.service",
+            "ln -s /usr/lib/systemd/system/bar.service %{buildroot}/usr/share/clr-service-restart/bar.service",
+            "## service_restart end",
+        ]
+        self.assertEqual(expect, self.WRITES)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
To improve tracking of units that are enabled for restart by clr-service-restart, add a new config file `service_restart`. It lists one or more unit names (with full path), one unit per line. The %install section is updated accordingly.