### PR TITLE
Parsing fix for R package descriptions

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -277,7 +277,7 @@ def _get_desc_field(field, desc):
         val = re.split(r"\s*,\s*", joined)
         # Also omit any version constraints
         # For example, translate "stringr (>= 1.2.0)" -> "stringr"
-        val = [v.split()[0] for v in val]
+        val = [re.split(r'\s*\(', v)[0] for v in val]
     return val
 
 


### PR DESCRIPTION
We cannot split on whitespace alone, because dependencies may be specified like `igraph(>= 1.0.1)`, with no intervening space between the package name and the open parenthesis.