### PR TITLE
build: reset success flag before starting build round

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -292,7 +292,9 @@ def package(filemanager, mockconfig, mockopts, cleanup=False):
     """Run main package build routine."""
     global round
     global uniqueext
+    global success
     round = round + 1
+    success = 0
     mock_cmd = get_mock_cmd()
     print("Building package " + tarball.name + " round", round)
 


### PR DESCRIPTION
Occasionally, within a build round, rpmbuild may succeed *and* new build dependencies are detected, thus requiring another build round. But if one or more of those new dependencies does not yet exist in the repo, the root log scan returns an error and autospec falls through, commits the result, and returns success.

Avoid this issue by resetting the success flag at the beginning of every build round.

Fixes #419