### PR TITLE
download: set pycurl timeouts

### DIFF
--- a/autospec/download.py
+++ b/autospec/download.py
@@ -44,6 +44,10 @@ def do_curl(url, dest=None, post=None, is_fatal=False):
         c.setopt(c.POSTFIELDS, post)
     c.setopt(c.FOLLOWLOCATION, True)
     c.setopt(c.FAILONERROR, True)
+    c.setopt(c.CONNECTTIMEOUT, 10)
+    c.setopt(c.TIMEOUT, 10)
+    c.setopt(c.LOW_SPEED_LIMIT, 1)
+    c.setopt(c.LOW_SPEED_TIME, 10)
     buf = BytesIO()
     c.setopt(c.WRITEDATA, buf)
     try:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -13,6 +13,10 @@ class MockOpts(Enum):
     POSTFIELDS = auto()
     FOLLOWLOCATION = auto()
     FAILONERROR = auto()
+    CONNECTTIMEOUT = auto()
+    TIMEOUT = auto()
+    LOW_SPEED_LIMIT = auto()
+    LOW_SPEED_TIME = auto()
 
 
 def init_curl_instance(mock_curl):

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -121,6 +121,10 @@ class TestLicense(unittest.TestCase):
             POSTFIELDS = None
             FOLLOWLOCATION = 0
             FAILONERROR = False
+            CONNECTTIMEOUT = 0
+            TIMEOUT = 0
+            LOW_SPEED_LIMIT = 0
+            LOW_SPEED_TIME = 0
             def setopt(_, __, ___):
                 pass
 
@@ -176,6 +180,10 @@ class TestLicense(unittest.TestCase):
             POSTFIELDS = None
             FOLLOWLOCATION = 0
             FAILONERROR = False
+            CONNECTTIMEOUT = 0
+            TIMEOUT = 0
+            LOW_SPEED_LIMIT = 0
+            LOW_SPEED_TIME = 0
             def setopt(_, __, ___):
                 pass
 


### PR DESCRIPTION
To start with, try setting the following timeouts:

- connection timeout of 10 seconds
- request timeout of 10 seconds
- speed limit timeout of 1 byte/sec in a 10-second window

Feel free to suggest different defaults.