### PR TITLE
download: Increase pycurl timeouts to 30 seconds

### DIFF
--- a/autospec/download.py
+++ b/autospec/download.py
@@ -44,10 +44,10 @@ def do_curl(url, dest=None, post=None, is_fatal=False):
         c.setopt(c.POSTFIELDS, post)
     c.setopt(c.FOLLOWLOCATION, True)
     c.setopt(c.FAILONERROR, True)
-    c.setopt(c.CONNECTTIMEOUT, 10)
-    c.setopt(c.TIMEOUT, 10)
+    c.setopt(c.CONNECTTIMEOUT, 30)
+    c.setopt(c.TIMEOUT, 30)
     c.setopt(c.LOW_SPEED_LIMIT, 1)
-    c.setopt(c.LOW_SPEED_TIME, 10)
+    c.setopt(c.LOW_SPEED_TIME, 30)
     buf = BytesIO()
     c.setopt(c.WRITEDATA, buf)
     try:

--- a/autospec/download.py
+++ b/autospec/download.py
@@ -44,10 +44,10 @@ def do_curl(url, dest=None, post=None, is_fatal=False):
         c.setopt(c.POSTFIELDS, post)
     c.setopt(c.FOLLOWLOCATION, True)
     c.setopt(c.FAILONERROR, True)
-    c.setopt(c.CONNECTTIMEOUT, 30)
+    c.setopt(c.CONNECTTIMEOUT, 10)
     c.setopt(c.TIMEOUT, 30)
     c.setopt(c.LOW_SPEED_LIMIT, 1)
-    c.setopt(c.LOW_SPEED_TIME, 30)
+    c.setopt(c.LOW_SPEED_TIME, 10)
     buf = BytesIO()
     c.setopt(c.WRITEDATA, buf)
     try:


### PR DESCRIPTION
Increased connection timeout, request timeout and speed limit timeout
window to 30 seconds from 10 seconds

Fixes #429 

Signed-off-by: Mandar Thorat <mandar.chandrakant.thorat@intel.com>