### PR TITLE
pkg_integrity: fix handling of pubkey export error

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -690,6 +690,7 @@ def attempt_key_import(keyid, key_fullpath):
         err, key_content = ctx.export_key(keyid)
         if err is not None:
             print_error(err.strerror)
+            return False
         util.write_out(key_fullpath, key_content)
         print('\n')
         print_success('Public key id: {} was imported'.format(keyid))


### PR DESCRIPTION
The function should return early when the export fails.

Fixes #431.