### PR TITLE
Rework exclude feature

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -714,7 +714,6 @@ def parse_config_files(path, bump, filemanager, version):
     for extra in content:
         print("extras for  : %s." % extra)
     filemanager.extras += content
-    filemanager.excludes += content
 
     for fname in os.listdir(path):
         if not re.search('.+_extras$', fname) or fname == "dev_extras":
@@ -730,19 +729,16 @@ def parse_config_files(path, bump, filemanager, version):
         name = fname[:-len("_extras")]
         print(f"extras-{name} for {content['files']}")
         filemanager.custom_extras["extras-" + f"{name}"] = content
-        filemanager.excludes += content['files']
 
     content = read_conf_file(os.path.join(path, "dev_extras"))
     for extra in content:
         print("dev for     : %s." % extra)
     filemanager.dev_extras += content
-    filemanager.excludes += content
 
     content = read_conf_file(os.path.join(path, "setuid"))
     for suid in content:
         print("setuid for  : %s." % suid)
     filemanager.setuid += content
-    filemanager.excludes += content
 
     content = read_conf_file(os.path.join(path, "attrs"))
     for line in content:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -305,6 +305,7 @@ class Specfile(object):
 
         self.write_source_installs()
         self.write_service_restart()
+        self.write_exclude_deletes()
         self.write_install_append()
         # self.write_systemd_units()
 
@@ -645,6 +646,13 @@ class Specfile(object):
             for line in self.install_append:
                 self._write_strip("{}\n".format(line))
             self._write_strip("## install_append end")
+
+    def write_exclude_deletes(self):
+        """Write out deletes for excluded files."""
+        if self.excludes:
+            self._write_strip("## Remove excluded files")
+        for exclude in self.excludes:
+            self._write_strip(f"rm -f %{{buildroot}}{exclude}")
 
     def write_service_restart(self):
         """Enable configured units to be restarted with clr-service-restart."""

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -78,7 +78,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.excludes.append('test-fn')
         self.assertTrue(self.fm.file_pat_match('test-fn', r'test-fn', 'main'))
-        self.fm.push_package_file.assert_called_with('%exclude test-fn', 'main')
+        self.fm.push_package_file.assert_not_called()
 
     def test_file_pat_match_replacement(self):
         """
@@ -133,27 +133,25 @@ class TestFiles(unittest.TestCase):
 
     def test_push_file_extras(self):
         """
-        Test push_file to extras package, this excludes the file
+        Test push_file to extras package
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.extras.append('test')
-        self.fm.excludes.append("test")
         self.fm.push_file('test')
-        calls = [call('test', 'extras'), call('%exclude test')]
+        calls = [call('test', 'extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
 
     def test_push_file_custom_extras(self):
         """
-        Test push_file to a custom extras package, this excludes the file
+        Test push_file to a custom extras package
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.custom_extras = {'test-extras': {'files': ["test"]}}
-        self.fm.excludes.append("test")
         self.fm.push_file('test')
-        calls = [call('test', 'test-extras'), call('%exclude test')]
+        calls = [call('test', 'test-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
 
@@ -164,9 +162,8 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.setuid.append('test')
-        self.fm.excludes.append("test")
         self.fm.push_file('test')
-        calls = [call('%attr(4755, root, root) test', 'setuid'), call('%exclude test')]
+        calls = [call('%attr(4755, root, root) test', 'setuid')]
         self.fm.push_package_file.assert_has_calls(calls)
 
 

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -438,6 +438,22 @@ class TestSpecfileWrite(unittest.TestCase):
         ]
         self.assertEqual(expect, self.WRITES)
 
+    def test_write_exclude_deletes(self):
+        """
+        Validate that excludes configuration is written to the spec file correctly.
+        """
+        self.specfile.excludes = [
+                "/usr/bin/bar",
+                "/usr/bin/foo",
+        ]
+        self.specfile.write_exclude_deletes()
+        expect = [
+            "## Remove excluded files",
+            "rm -f %{buildroot}/usr/bin/bar",
+            "rm -f %{buildroot}/usr/bin/foo",
+        ]
+        self.assertEqual(expect, self.WRITES)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead of the excludes file adding '%exclude' macros for files that
are not being shipped in the binary rpms, they cause the file to be
deleted entirely.

This causes a few ripple effects in other parts of the subpackage file
manipulation code where excludes were used to avoid files being added
to multiple subpackages. To work around this, don't allow calls that
add files to a specific subpackage to fall through into the general
push_package_file fallthrough or file_pat_match calls. Also don't add
files that are still intended to be shipped to show up on the excludes
list.