### PR TITLE
cmake_modules: Set openjdk11 as default.

### DIFF
--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -37,9 +37,9 @@ ICU, icu4c-dev
 Iconv, glibc-dev
 Inotify, extra-cmake-modules
 Intl, glibc-dev
-JNI, openjdk9-dev
+JNI, openjdk11-dev
 JPEG, libjpeg-turbo-dev
-Java, openjdk9
+Java, openjdk11
 #KF5, extra-cmake-modules # parsed by Autospec
 LATEX, texlive
 LibArchive, libarchive-dev


### PR DESCRIPTION
Openjdk9 is no longer under development and would be deprecated on July
26 of 2019 on Clear Linux. So, it would be replaced by Openjdk11
which is the current LTS.

Signed-off-by: Athenas Jimenez <athenas.jimenez.gonzalez@intel.com>