### PR TITLE
Create ant buildpattern

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -847,6 +847,13 @@ def scan_for_configure(dirn):
             add_buildreq("apache-ant")
             add_buildreq("buildreq-mvn")
             buildpattern.set_build_pattern("ant", default_score)
+            # But wait, this might use maven!
+            for f in files:
+                if f.endswith('/build.xml'):
+                    for line in open(f):
+                        if "<artifact:mvn>" in line:
+                            buildpattern.set_build_pattern("maven", default_score)
+                            break
 
         for name in files:
             if name.lower() == "cargo.toml" and dirpath == dirn:

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -305,7 +305,9 @@ failed_pats = [
     (r"^.*Could not find a package configuration file provided by \"(.*)\".*$", 0, None),
     (r"^.*By not providing \"Find(.*).cmake\" in CMAKE_MODULE_PATH this.*$", 0, None),
     (r"Add the installation prefix of \"(.*)\" to CMAKE_PREFIX_PATH", 0, None),
-    (r"^.*\"(.*)\" with any of the following names.*$", 0, None)]
+    (r"^.*\"(.*)\" with any of the following names.*$", 0, None),
+    (r"module not found: .*#(.*);(?:.*)", 0, 'maven'),
+    (r"-- artifact (?:.*)#(?:.*);(?:.*)!(.*).jar", 0, 'maven')]
 
 
 def get_metadata_conf():

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1558,7 +1558,6 @@ class Specfile(object):
         self._write_strip("ant -d -v " + self.extra_make)
         self._write_strip("%install")
         self.write_install_prepend()
-        jar_dir = os.path.join("%{buildroot}/usr/share/jar", self.name)
         self._write_strip("")
 
     def write_maven_pattern(self):

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1555,12 +1555,10 @@ class Specfile(object):
         self.write_build_prepend()
         self.write_proxy_exports()
         self._write_strip("export ANT_HOME=/usr/share/ant")
-        self._write_strip("ant -d -v {}".format(self.extra_make))
+        self._write_strip("ant -d -v " + self.extra_make)
         self._write_strip("%install")
         self.write_install_prepend()
         jar_dir = os.path.join("%{buildroot}/usr/share/jar", self.name)
-        self._write_strip(f"mkdir -p {jar_dir}")
-        self._write_strip(f"install -m 0644 dist/*.jar {jar_dir}")
         self._write_strip("")
 
     def write_maven_pattern(self):

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1555,7 +1555,7 @@ class Specfile(object):
         self.write_build_prepend()
         self.write_proxy_exports()
         self._write_strip("export ANT_HOME=/usr/share/ant")
-        self._write_strip("ant dist")
+        self._write_strip("ant -d -v {}".format(self.extra_make))
         self._write_strip("%install")
         self.write_install_prepend()
         jar_dir = os.path.join("%{buildroot}/usr/share/jar", self.name)

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -18,6 +18,7 @@
 #
 
 import configparser
+import errno
 import glob
 import hashlib
 import os
@@ -126,6 +127,25 @@ def build_untar(tarball_path):
         exit(1)
 
     return extract_cmd, tar_prefix
+
+
+def build_unjar(jar_path):
+    """Return correct unjar command and the prefix folder name of the contents of zip file.
+
+    JAR files should just be copied to the requested destination, not actually unpacked
+    """
+    (root, ext) = os.path.splitext(jar_path)
+    prefix = root
+    newdir = os.path.normpath(os.path.join(build.base_path, root))
+    try:
+        os.mkdir(newdir)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+        pass
+
+    extract_cmd = "cp -p -t {} {}".format(newdir, jar_path)
+    return extract_cmd, prefix
 
 
 def build_unzip(zip_path):
@@ -613,17 +633,24 @@ def process_archives(archives):
             extract_cmd, source_tarball_prefix = build_unzip(source_tarball_path)
         elif source_tarball_path.lower().endswith('.7z'):
             extract_cmd, source_tarball_prefix = build_un7z(source_tarball_path)
+        elif source_tarball_path.lower().endswith('.jar'):
+            extract_cmd, source_tarball_prefix = build_unjar(source_tarball_path)
         else:
             extract_cmd, source_tarball_prefix = build_untar(source_tarball_path)
         buildpattern.archive_details[archive + "prefix"] = source_tarball_prefix
+        print("BTW: extract_cmd: {}".format(extract_cmd))
+        call('pwd')
         call(extract_cmd)
         tar_path = os.path.join(build.base_path, source_tarball_prefix)
+        print("BTW: tar_path: {}".format(tar_path))
+        call("ls -l {}".format(tar_path))
         tar_files = glob.glob("{}/*".format(tar_path))
+        print("BTW: tar_files: {}".format(tar_files))
         if tar_path == path:
             print("Archive {} already unpacked in main path {}; ignoring destination"
                   .format(archive, path))
         else:
-            move_cmd = "mv "
+            move_cmd = "cp "
             for tar_file in tar_files:
                 move_cmd += '"{}"'.format(tar_file) + " "
             move_cmd += '"{0}/{1}"'.format(path, destination)
@@ -633,6 +660,7 @@ def process_archives(archives):
 
             print("mkdir " + mkdir_cmd)
             call(mkdir_cmd)
+            print("BTW: move_cmd: {}".format(move_cmd))
             call(move_cmd)
 
 


### PR DESCRIPTION
I think we're ready for review now. Any ant package will have to have the target specified in `make_args` and the installation completely written in `install_append`. There's just no dependable pattern beyond that.