### PR TITLE
Add new pattern for 'vala'

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -184,6 +184,7 @@ simple_pats = [
     (r"configure: error: glib2", "glib-dev"),
     (r"C library 'efivar' not found", "efivar-dev"),
     (r"Has header \"efi.h\": NO", "gnu-efi-dev"),
+    (r"ERROR: Could not execute Vala compiler", "vala"),
     (r".*: error: HAVE_INTROSPECTION does not appear in AM_CONDITIONAL", 'gobject-introspection-dev')]
 
 # failed_pattern patterns


### PR DESCRIPTION
Autospec fails for several gnome packages with:
meson.build:1:0: ERROR: Could not execute Vala compiler "valac"
This had to be fixed by manually adding "vala" to
buildreq_add file.
This patch adds "BuildRequires : vala" to the spec file if the
pattern "ERROR: Could not execute Vala compiler" is detected.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>