### PR TITLE
license.py: Fix a misleading error message

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -845,7 +845,8 @@ def parse_config_files(path, bump, filemanager, version):
         words = content[0].split()
         for word in words:
             if word.find(":") < 0:
-                license.add_license(word)
+                if not license.add_license(word):
+                    print_warning("{}: blacklisted license {} ignored.".format(tarball.name + ".license", word))
 
     content = read_conf_file(os.path.join(path, "golang_libpath"))
     if content and content[0]:

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -67,8 +67,10 @@ def add_license(lic):
     real_lic_str = config.license_translations.get(lic, lic)
     real_lics = real_lic_str.split()
     for real_lic in real_lics:
-        if real_lic in licenses or real_lic in config.license_blacklist:
+        if real_lic in config.license_blacklist:
             continue
+        elif real_lic in licenses:
+            result = True
         else:
             result = True
             licenses.append(real_lic)
@@ -161,7 +163,7 @@ def scan_for_licenses(srcdir):
                 license_from_copying_hash(os.path.join(dirpath, name), srcdir)
 
     if not licenses:
-        print_fatal(" Cannot find any license or {}.license file!\n".format(tarball.name))
+        print_fatal(" Cannot find any license or a valid {}.license file!\n".format(tarball.name))
         sys.exit(1)
 
     print("Licenses    : ", " ".join(sorted(licenses)))

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -32,11 +32,11 @@ class TestLicense(unittest.TestCase):
     def test_add_license_present(self):
         """
         Test add_license from valid string, but license is already present in
-        the licenses list. Should return False and should not modify the
+        the licenses list. Should return True and should not modify the
         licenses list. GPL-3 translates to GPL-3.0.
         """
         license.licenses.append('GPL-3.0')
-        self.assertFalse(license.add_license('GPL-3'))
+        self.assertTrue(license.add_license('GPL-3'))
         self.assertEqual(['GPL-3.0'], license.licenses)
 
     def test_add_license_blacklisted(self):


### PR DESCRIPTION
We may get a message "<package>.license not found" even
if the file exists.

The <package>.license file is manually created but the
licenses in the file may be silently rejected due to being
blacklisted.
For example adding "GPL" or "BSD" to abc.license while autospecing
a package "abc" can produce the error:

"[FATAL]  Cannot find any license or abc.license file!"

eventhough the abc.license manifestly exists.

This patch modifies the original error message and also prints out
some additional messages, such as:

[WARNING] lapack.license: ambiguous license GPL ignored.
[WARNING] lapack.license: ambiguous license BSD ignored.
...
[FATAL]  Cannot find any license or a valid lapack.license file!

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>