### PR TITLE
maven pattern: do not install_append twice

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -658,9 +658,6 @@ class Specfile(object):
         # Install the POM file
         self._write_strip("cp -p pom.xml ${DEPLOY_PATH}/${ARTIFACT_ID}-${VERSION}.pom")
 
-        # Continue with user-provided installation steps
-        self.write_install_append()
-
     def write_prep_prepend(self):
         """Write out any custom supplied commands at the start of the %prep section."""
         if self.prep_prepend:


### PR DESCRIPTION
write_install_append() is already called by write_buildpattern(), so it should not be called in pattern-specific code.