### PR TITLE
Apply -mstackrealign to all 32-bit builds.

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -442,9 +442,9 @@ class Specfile(object):
         """Write 32bit only env exports."""
         self._write_strip('export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"')
         self._write_strip('export ASFLAGS="${ASFLAGS}${ASFLAGS:+ }--32"')
-        self._write_strip('export CFLAGS="${CFLAGS}${CFLAGS:+ }-m32"')
-        self._write_strip('export CXXFLAGS="${CXXFLAGS}${CXXFLAGS:+ }-m32"')
-        self._write_strip('export LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-m32"')
+        self._write_strip('export CFLAGS="${CFLAGS}${CFLAGS:+ }-m32 -mstackrealign"')
+        self._write_strip('export CXXFLAGS="${CXXFLAGS}${CXXFLAGS:+ }-m32 -mstackrealign"')
+        self._write_strip('export LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-m32 -mstackrealign"')
 
     def write_variables(self):
         """Write variable exports to spec file."""


### PR DESCRIPTION
Since our 32-bit builds are for compatibility with old software that
hasn't been updated in ages, it's reasonable to add this flag so that we
also support software that simply hasn't been recompiled in nearly 15
years (the -mstackrealign flag was added in 2006, but the ABI change
happened some time before that).

Addresses distribution#1152.