### PR TITLE
Set profile-payload env variables for 'make' pattern

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -601,6 +601,9 @@ class Specfile(object):
             use_subdir = False
             init = f"{self.get_profile_generate_flags()}"
             post = f"{self.get_profile_use_flags()}"
+        elif pattern == "make":
+            init = f"{self.get_profile_generate_flags()}"
+            post = f"{self.get_profile_use_flags()}"
         if use_subdir and self.subdir:
             self._write_strip("pushd " + self.subdir)
         if init:
@@ -1026,7 +1029,7 @@ class Specfile(object):
         self.write_prep()
         self.write_lang_c(export_epoch=True)
         self.write_variables()
-        self.write_profile_payload()
+        self.write_profile_payload("make")
         if self.subdir:
             self._write_strip("pushd " + self.subdir)
         self.write_make_line()


### PR DESCRIPTION
Similarly to the 'cmake' pattern, the 'make' pattern should also
manually set the toolchain env variables for profile payloads, since
there is no other configuration step to set them.