### PR TITLE
[specfiles.py] - update re.compile hostname support

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -668,6 +668,7 @@ class Specfile(object):
             re.compile(r"maven.apache.org/maven2/([a-zA-Z\-\_]+)/([a-zA-Z\-\_]+)/([\d.]+)/[a-z-\_.\d]*\.(?:pom|jar|xml|signature)"),
             re.compile(r"maven.*org/maven2/([a-zA-Z-\_.\d/]+)/([a-zA-Z-\_.\d]*)/([a-zA-Z\d\.\_\-]+)/(?:[a-zA-Z-\_.\d]*)\.(?:pom|jar|xml|signature)"),
             re.compile(r"repository.mapr.com/maven/([a-zA-Z\-\_/]+)/([a-zA-Z\-\_]+)/([a-zA-Z-\_\d.]+)/[a-zA-Z-\_\d.]*\.(?:pom|jar|xml|signature)"),
+            re.compile(r"packages.confluent.io/maven/([a-zA-Z\-\_/]+)/([a-zA-Z\-\_]+)/([a-zA-Z-\_\d.]+)/[a-zA-Z-\_\d.]*\.(?:pom|jar|xml|signature)"),
             re.compile(r"gradle.org/gradle/libs-releases/([a-zA-Z-\_.\d/]+)/([a-zA-Z-\_.\d]*)/([a-zA-Z\d\.\_\-]+)/(?:[a-zA-Z-\_.\d]*)\.(?:pom|jar)"),
             re.compile(r"gradle.org/m2/([a-zA-Z-\_.\d/]+)/([a-zA-Z-\_.\d]*)/([a-zA-Z\d\.\_\-]+)/(?:[a-zA-Z-\_.\d]*)\.(?:pom|jar)")]
         mvn_sources = [self.url] + sorted(self.sources["archive"])


### PR DESCRIPTION
Added URL pattern with host repository.mapr.com.
There are some binary jar is located outside of repo.maven
hostname.

Signed-off-by: Choong Yin Thong <yin.thong.choong@intel.com>