### PR TITLE
Handle SQLite versions

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -473,6 +473,15 @@ def name_and_version(name_arg, version_arg, filemanager):
     if "kde.org" in url or "https://github.com/KDE" in url:
         buildreq.add_buildreq("buildreq-kde")
 
+    # SQLite tarballs use 7 digit versions, e.g 3290000 = 3.29.0, 3081002 = 3.8.10.2
+    if "sqlite.org" in url:
+        major = version[0]
+        minor = version[1:3].lstrip("0").zfill(1)
+        patch = version[3:5].lstrip("0").zfill(1)
+        build = version[5:7].lstrip("0")
+        version = major + "." + minor + "." + patch + "." + build
+        version = version.strip(".")
+
     # construct github giturl from gnome projects
     if not giturl and "download.gnome.org" in url:
         giturl = "https://github.com/GNOME/{}.git".format(name)

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1658,7 +1658,8 @@ http://www.spice-space.org/download/releases/spice-protocol-0.12.13.tar.bz2,spic
 http://pypi.debian.net/SQLAlchemy/SQLAlchemy-1.0.16.tar.gz,SQLAlchemy,1.0.16
 http://pypi.debian.net/sqlalchemy-migrate/sqlalchemy-migrate-0.10.0.tar.gz,sqlalchemy-migrate,0.10.0
 http://pypi.debian.net/SQLAlchemy-Utils/SQLAlchemy-Utils-0.32.9.tar.gz,SQLAlchemy-Utils,0.32.9
-http://sqlite.org/2017/sqlite-autoconf-3200100.tar.gz,sqlite-autoconf,3200100
+https://sqlite.org/2017/sqlite-autoconf-3200100.tar.gz,sqlite-autoconf,3.20.1
+https://sqlite.org/2015/sqlite-autoconf-3081002.tar.gz,sqlite-autoconf,3.8.10.2
 http://pypi.debian.net/sqlparse/sqlparse-0.2.4.tar.gz,sqlparse,0.2.4
 https://github.com/libfuse/sshfs/archive/sshfs-3.3.0.tar.gz,sshfs,3.3.0
 https://github.com/commercialhaskell/stack/releases/download/v1.5.0/stack-1.5.0-linux-x86_64.tar.gz,stack,1.5.0


### PR DESCRIPTION
SQLite publishes release tarballs with 7 digit versions like 3290000,
which maps to 3.29.0; or 3081002 for 3.8.10.2.

This will help tools to correctly correlate the version reported by
other data sources with the value in spec's version field.