### PR TITLE
Avoid overwriting giturl if it is already set

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -464,7 +464,8 @@ def name_and_version(name_arg, version_arg, filemanager):
                 if "archive" not in pattern:
                     version = re.sub(r"^[-_.a-zA-Z]+", "", version)
                 version = convert_version(version, name)
-                giturl = "https://github.com/" + m.group(1).strip() + "/" + repo + ".git"
+                if not giturl:
+                    giturl = "https://github.com/" + m.group(1).strip() + "/" + repo + ".git"
                 break
 
     if "gnome.org" in url:


### PR DESCRIPTION
When the source URL is from github.com, autospec was overwriting the
giturl in options.conf by mistake. It should only set a value if no
current value exists.

Fixes https://github.com/clearlinux/autospec/issues/477