### PR TITLE
Fix bug with R description file parsing

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -315,7 +315,7 @@ def _get_desc_field(field, desc):
     """
     val = []
     # Values may span multiple lines...
-    pat = re.compile(r"^" + field + r": *(.*?)(?=\n\w+:)", re.MULTILINE | re.DOTALL)
+    pat = re.compile(r"^" + field + r":\s*(.*?)(?=\n\w+:)", re.MULTILINE | re.DOTALL)
     match = pat.search(desc)
     if match:
         joined = match.group(1).replace("\n", " ")


### PR DESCRIPTION
If `Imports:` or `Depends:` is immediately followed by a newline, then the regexp fails to match. See the R-psych package (version 1.8.12) for an example.

Fix the issue by adjusting the regexp to greedily match additional whitespace characters, as represented by the `\s` metacharacter.