### PR TITLE
Add `nginx` ecosystem autospec for nginx modules.

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -775,6 +775,8 @@ def scan_for_configure(dirn):
         parse_r_description(os.path.join(dirn, "DESCRIPTION"))
     elif buildpattern.default_pattern == "phpize":
         add_buildreq("buildreq-php")
+    elif buildpattern.default_pattern == "nginx":
+        add_buildreq("buildreq-nginx")
 
     count = 0
     for dirpath, _, files in os.walk(dirn):

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1762,6 +1762,20 @@ class Specfile(object):
         self._write_strip("%make_install")
         self._write_strip("\n")
 
+    def write_nginx_pattern(self):
+        """Write nginx build pattern to spec file."""
+        self.write_prep()
+        self._write_strip("%build")
+        self.write_build_prepend()
+        self.write_proxy_exports()
+        self._write_strip("nginx-module configure")
+        self._write_strip("nginx-module build")
+        self._write_strip("\n")
+        self._write_strip("%install")
+        self.write_install_prepend()
+        self._write_strip("nginx-module install %{buildroot}")
+        self._write_strip("\n")
+
     def write_find_lang(self):
         """Write %find_lang macro to spec file."""
         for lang in self.locales:


### PR DESCRIPTION
This adds the capacity for autospec to autopackage nginx dynamic modules
out of tree using the out-of-tree headers and build files that nginx-mainline
has. This will make it easy to package a large ecosystem of nginx modules
automatically.