### PR TITLE
Add 'dev_requires_staticdev' option to Autospec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -538,6 +538,10 @@ so_to_lib
   This option causes package ``.so`` files to be added to the ``lib`` subpackage
   instead of the ``dev`` subpackage.
 
+dev_requires_staticdev
+  If this option is set, the ``-staticdev`` package is required by the ``-dev``
+  package.
+
 autoupdate
   This option indicates that the package is trusted enough to be automatically
   update to its newest available version when set to ``true``. This flag is

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -127,6 +127,7 @@ config_options = {
     "security_sensitive": "set flags for security-sensitive builds",
     "so_to_lib": "add .so files to the lib package instead of dev",
     "dev_requires_extras": "dev package requires the extras to be installed",
+    "dev_requires_staticdev": "dev package requires the staticdev to be installed",
     "autoupdate": "this package is trusted enough to automatically update "
                   "(used by other tools)",
     "compat": "this package is a library compatability package and only "

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -248,6 +248,8 @@ class Specfile(object):
         deps["python"] = ["python3"]
         if config.config_opts['dev_requires_extras']:
             deps["dev"].append("extras")
+        if config.config_opts['dev_requires_staticdev']:
+            deps["dev"].append("staticdev")
         for k, v in self.custom_extras.items():
             if "requires" in v:
                 deps[k] = v['requires']


### PR DESCRIPTION
Add a new option called 'dev_requires_staticdev" that can be set via the package
`options.conf` file. Its purpose and behaviour is to make the `-staticdev`
subpackage be a required package by the `-dev` subpackage.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>