### PR TITLE
maven pattern: Improve the resolution for fail patterns

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -159,7 +159,10 @@ def failed_pattern(line, pattern, verbose, buildtool=None):
                 org = match.group(1)
                 name = match.group(2)
                 ver = match.group(3).replace('-', '.')
-                mvn_provide = f'mvn({org}:{name}:jar) = {ver}'
+                if re.search("-(parent|pom|bom)$", name):
+                    mvn_provide = f'mvn({org}:{name}:pom) = {ver}'
+                else:
+                    mvn_provide = f'mvn({org}:{name}:jar) = {ver}'
                 must_restart += buildreq.add_buildreq(mvn_provide, cache=True)
             else:
                 # Fallback to mvn-ARTIFACTID package name


### PR DESCRIPTION
Adding the resolution for "parent" or "pom" artifacts when a
corresponding jar doesn't exists.

Signed-off-by: Athenas Jimenez <athenas.jimenez.gonzalez@intel.com>