### PR TITLE
Introduce "build_append" and fix missing write_xxx_{prepend,append}

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -53,6 +53,7 @@ install_macro = "%make_install"
 disable_static = "--disable-static"
 prep_prepend = []
 build_prepend = []
+build_append = []
 make_prepend = []
 install_prepend = []
 install_append = []
@@ -584,6 +585,7 @@ def parse_config_files(path, bump, filemanager, version):
     global disable_static
     global prep_prepend
     global build_prepend
+    global build_append
     global make_prepend
     global install_prepend
     global install_append
@@ -874,6 +876,7 @@ def parse_config_files(path, bump, filemanager, version):
         os.rename(os.path.join(path, "prep_append"), os.path.join(path, "build_prepend"))
     make_prepend = read_conf_file(os.path.join(path, "make_prepend"))
     build_prepend = read_conf_file(os.path.join(path, "build_prepend"))
+    build_append = read_conf_file(os.path.join(path, "build_append"))
     install_prepend = read_conf_file(os.path.join(path, "install_prepend"))
     if os.path.isfile(os.path.join(path, "make_install_append")):
         os.rename(os.path.join(path, "make_install_append"), os.path.join(path, "install_append"))
@@ -902,6 +905,7 @@ def load_specfile(specfile):
     specfile.disable_static = disable_static
     specfile.prep_prepend = prep_prepend
     specfile.build_prepend = build_prepend
+    specfile.build_append = build_append
     specfile.make_prepend = make_prepend
     specfile.install_prepend = install_prepend
     specfile.install_append = install_append


### PR DESCRIPTION
Turns out there's a difference between build_append and install_prepend:
since they run from different shell scripts, environment variables set
at the beginning of %build will not be set in the snippets added by
install_prepend. Notably, that includes CFLAGS and SOURCE_DATE_EPOCH.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>