### PR TITLE
Add new domain field to options.conf

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -329,6 +329,7 @@ def get_metadata_conf():
         metadata['archives'] = " ".join(tarball.archives)
 
     metadata['giturl'] = tarball.giturl
+    metadata['domain'] = tarball.domain
     return metadata
 
 

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -43,6 +43,7 @@ tarball_prefix = ""
 gcov_file = ""
 archives = []
 giturl = ""
+domain = ""
 
 
 def get_go_artifacts(url, target, ver):
@@ -282,6 +283,7 @@ def create_download_path(target_dir):
     Also set giturl from the config (needs config refactor).
     """
     global giturl
+    global domain
 
     target = os.path.join(os.getcwd(), name)
     if os.path.exists(os.path.join(os.getcwd(), 'options.conf')):
@@ -292,6 +294,8 @@ def create_download_path(target_dir):
                 target = os.getcwd()
             if "giturl" in config_f["package"]:
                 giturl = config_f["package"].get("giturl")
+            if "domain" in config_f["package"]:
+                domain = config_f["package"].get("domain")
 
     if target_dir:
         target = target_dir


### PR DESCRIPTION
This field's purpose is to classify a package according to a "domain", useful for tooling that wraps autospec to operate on any/all packages that belong to the domain.