### PR TITLE
add LDFLAGS for PGO enabled spec file

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -524,7 +524,7 @@ class Specfile(object):
         if config.config_opts['fast-math']:
             flags.extend(["-ffast-math", "-ftree-loop-vectorize"])
         if config.config_opts['pgo']:
-            flags.extend(["-O3", "-fprofile-use", "-fprofile-dir=/var/tmp/pgo", "-fprofile-correction"])
+            flags.extend(["-O3"])
         if self.gcov_file:
             flags = list(filter((lto).__ne__, flags))
             flags.extend(["-O3", "-fauto-profile=%{{SOURCE{0}}}".format(self.source_index[self.sources["gcov"][0]])])
@@ -550,11 +550,13 @@ class Specfile(object):
             self._write_strip('export FCFLAGS_GENERATE="$FCFLAGS {0} "\n'.format(" ".join(genflags)))
             self._write_strip('export FFLAGS_GENERATE="$FFLAGS {0} "\n'.format(" ".join(genflags)))
             self._write_strip('export CXXFLAGS_GENERATE="$CXXFLAGS {0} "\n'.format(" ".join(genflags)))
+            self._write_strip('export LDFLAGS_GENERATE="$LDFLAGS {0} "\n'.format(" ".join(genflags)))
 
             self._write_strip('export CFLAGS_USE="$CFLAGS {0} "\n'.format(" ".join(useflags)))
             self._write_strip('export FCFLAGS_USE="$FCFLAGS {0} "\n'.format(" ".join(useflags)))
             self._write_strip('export FFLAGS_USE="$FFLAGS {0} "\n'.format(" ".join(useflags)))
             self._write_strip('export CXXFLAGS_USE="$CXXFLAGS {0} "\n'.format(" ".join(useflags)))
+            self._write_strip('export LDFLAGS_USE="$LDFLAGS {0} "\n'.format(" ".join(useflags)))
 
     def write_check(self):
         """Write check section to spec file."""
@@ -909,6 +911,7 @@ class Specfile(object):
                 'CXXFLAGS="${CXXFLAGS_GENERATE}" '
                 'FFLAGS="${FFLAGS_GENERATE}" '
                 'FCFLAGS="${FCFLAGS_GENERATE}" '
+                'LDFLAGS="${LDFLAGS_GENERATE}" '
 
         otherwise an empty string is returned.
         """
@@ -916,7 +919,8 @@ class Specfile(object):
             return 'CFLAGS="${CFLAGS_GENERATE}" '     \
                    'CXXFLAGS="${CXXFLAGS_GENERATE}" ' \
                    'FFLAGS="${FFLAGS_GENERATE}" '     \
-                   'FCFLAGS="${FCFLAGS_GENERATE}" '
+                   'FCFLAGS="${FCFLAGS_GENERATE}" '   \
+                   'LDFLAGS="${LDFLAGS_GENERATE}" '
         return ""
 
     @staticmethod
@@ -928,6 +932,7 @@ class Specfile(object):
                 'CXXFLAGS="${CXXFLAGS_USE}" '
                 'FFLAGS="${FFLAGS_USE}" '
                 'FCFLAGS="${FCFLAGS_USE}" '
+                'LDFLAGS="${LDFLAGS_USE}" '
 
         otherwise an empty string is returned.
         """
@@ -935,7 +940,8 @@ class Specfile(object):
             return 'CFLAGS="${CFLAGS_USE}" '     \
                    'CXXFLAGS="${CXXFLAGS_USE}" ' \
                    'FFLAGS="${FFLAGS_USE}" '     \
-                   'FCFLAGS="${FCFLAGS_USE}" '
+                   'FCFLAGS="${FCFLAGS_USE}" '   \
+                   'LDFLAGS="${LDFLAGS_USE}" '
         return ""
 
     def get_systemd_units(self):


### PR DESCRIPTION
Signed-off-by: Mi, Dapeng1 <dapeng1.mi@intel.com>

I tried to generate PGO enabled pigz package automatically via autospec. Whereas the PGO enabled pigz package can’t be generated successfully. Checked the new generated SPEC file, it looks the failure is caused by the following two issues.

1.	PGO “generate” or “use” compiling options are not added to environment variable “LDFLAGS” in the new SPEC file. It leads to the PGO related functions “__gcov_xxxx” can’t be found when linking.
2.	The PGO “use” options “-fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction” would be append to “CFLAGS” and exported by default. Whereas the subsequent variable “CFLAGS_GENERATE” contains “CFLAGS” and PGO “generate” options simultaneously, thus “CFLAGS_GENERATE” contains PGO “generate” and “use” options simultaneously. I’m not sure why does this, but it looks unnecessary and weird.

The new generated spec file looks like this.

export CFLAGS="$CFLAGS -O3 -falign-functions=32 -ffat-lto-objects -flto=4 -fno-math-errno -fno-semantic-interposition -fno-trapping-math -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export FCFLAGS="$CFLAGS -O3 -falign-functions=32 -ffat-lto-objects -flto=4 -fno-math-errno -fno-semantic-interposition -fno-trapping-math -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export FFLAGS="$CFLAGS -O3 -falign-functions=32 -ffat-lto-objects -flto=4 -fno-math-errno -fno-semantic-interposition -fno-trapping-math -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export CXXFLAGS="$CXXFLAGS -O3 -falign-functions=32 -ffat-lto-objects -flto=4 -fno-math-errno -fno-semantic-interposition -fno-trapping-math -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export CFLAGS_GENERATE="$CFLAGS -fprofile-generate -fprofile-dir=/var/tmp/pgo -fprofile-update=atomic "
export FCFLAGS_GENERATE="$FCFLAGS -fprofile-generate -fprofile-dir=/var/tmp/pgo -fprofile-update=atomic "
export FFLAGS_GENERATE="$FFLAGS -fprofile-generate -fprofile-dir=/var/tmp/pgo -fprofile-update=atomic "
export CXXFLAGS_GENERATE="$CXXFLAGS -fprofile-generate -fprofile-dir=/var/tmp/pgo -fprofile-update=atomic "
export CFLAGS_USE="$CFLAGS -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export FCFLAGS_USE="$FCFLAGS -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export FFLAGS_USE="$FFLAGS -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
export CXXFLAGS_USE="$CXXFLAGS -fprofile-use -fprofile-dir=/var/tmp/pgo -fprofile-correction "
CFLAGS="${CFLAGS_GENERATE}" CXXFLAGS="${CXXFLAGS_GENERATE}" FFLAGS="${FFLAGS_GENERATE}" FCFLAGS="${FCFLAGS_GENERATE}"
make  %{?_smp_mflags}

This patch fixes these two issues, 1) add two new variables “LDFLAGS_GENERATE” and “LDFLAGS_USE” and export them to LDFLAGS when building 2) remove the PGO “use” options from the default variable “CFLAGS”. After applying this patch, the PGO enabled pigz package can be generated successfully.
