### PR TITLE
meson_pattern: remove explicit install_append call

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1838,7 +1838,6 @@ class Specfile(object):
 
         self._write_strip("DESTDIR=%{buildroot} ninja -C builddir install")
         self.write_find_lang()
-        self.write_install_append()
 
     def write_phpize_pattern(self):
         """Write phpize build pattern to spec file."""


### PR DESCRIPTION
the install_append function is executed implicit from the
write_buildpattern function, so no need to generate duplicated
install_append instructions.

Fixes https://github.com/clearlinux/autospec/issues/500

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>