### PR TITLE
failed_commands: Add pattern for libuv

### DIFF
--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -394,6 +394,7 @@ LIBRSVG, librsvg-dev
 LIBTASN1, libtasn1-dev
 LIBUSB, libusb-dev
 LIBUSB1, libusb-dev
+LIBUV, libuv-dev
 LIBXML, libxml2-dev
 LMDB, lmdb-dev
 LUA, lua-dev


### PR DESCRIPTION
This handles looking at logs failing when asking for LIBUV (e.g: cmake:
-- Could NOT find LIBUV (missing: LIBUV_LIBRARIES LIBUV_INCLUDE_DIR)
)

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>