### PR TITLE
Install /usr/lib/perl5 content to -data

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -318,6 +318,7 @@ class FileManager(object):
             (r"^/usr/lib/sysusers.d", "config"),
             (r"^/usr/lib/sysctl.d", "config"),
             (r"^/usr/share/", "data"),
+            (r"^/usr/lib/perl5/", "data"),
             # finally move any dynamically loadable plugins (not
             # perl/python/ruby/etc.. extensions) into lib package
             (r"^/usr/lib/.*/[a-zA-Z0-9._+-]*\.so", "lib"),


### PR DESCRIPTION
Because implicit requires of '/usr/bin/perl' exist for many packages,
perl-bin will be installed as a build dependency, but not the perl
package's modules; the modules currently live in the base package, and
-bin does not require that package.

The easiest solution for now is to ship the modules in -data, since -bin
requires -data. So, add a files pattern to ship all content matching
/usr/lib/perl5 in -data.