### PR TITLE
Move Perl content to -perl subpackage

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -318,7 +318,7 @@ class FileManager(object):
             (r"^/usr/lib/sysusers.d", "config"),
             (r"^/usr/lib/sysctl.d", "config"),
             (r"^/usr/share/", "data"),
-            (r"^/usr/lib/perl5/", "data"),
+            (r"^/usr/lib/perl5/", "perl"),
             # finally move any dynamically loadable plugins (not
             # perl/python/ruby/etc.. extensions) into lib package
             (r"^/usr/lib/.*/[a-zA-Z0-9._+-]*\.so", "lib"),

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -315,6 +315,9 @@ class Specfile(object):
             if pkg == "legacypython":
                 self._write("Requires: python-core\n")
 
+            if pkg == "perl":
+                self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))
+
             self._write("\n%description {}\n".format(pkg))
             self._write("{} components for the {} package.\n".format(pkg, self.name))
             self._write("\n")


### PR DESCRIPTION
Also make the subpackage depend on the parent package. This should close
the loop between top-level Requires on perl() virtuals and Provides on
perl() virtuals in the subpackage.