### PR TITLE
Add more characters to Perl module name matching

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -275,11 +275,11 @@ failed_pats = [
     (r"Error: package ['‘]([a-zA-Z0-9\-\.]*)['’] required by", 0, 'R'),
     (r"Error: Unable to find (.*)", 0, None),
     (r"there is no package called ['‘]([a-zA-Z0-9\-\.]*)['’]", 0, 'R'),
-    (r"you may need to install the ([a-zA-Z0-9\-:\.]*) module", 0, 'perl'),
+    (r"you may need to install the ([a-zA-Z0-9_\-:\.]*) module", 0, 'perl'),
     (r"    !  ([a-zA-Z:]+) is not installed", 0, 'perl'),
     (r"Warning: prerequisite ([a-zA-Z:]+) [0-9\.]+ not found.", 0, 'perl'),
-    (r"Can't locate [a-zA-Z\/\.]+ in @INC "
-     r"\(you may need to install the ([a-zA-Z:]+) module\)", 0, 'perl'),
+    (r"Can't locate [a-zA-Z0-9_\-\/\.]+ in @INC "
+     r"\(you may need to install the ([a-zA-Z0-9_\-:]+) module\)", 0, 'perl'),
     (r"checking for perl module ([a-zA-Z:]+) [0-9\.]+... no", 0, 'perl'),
     (r"Download error on https://pypi.python.org/simple/([a-zA-Z0-9\-\._:]+)/", 0, 'pypi'),
     (r"No matching distribution found for ([a-zA-Z0-9\-\._]+)", 0, 'pypi'),


### PR DESCRIPTION
Perl modules can also contain underscores and digits in their names.
Extend the pattern matching to make sure we don't miss anything.
Previously, we missed this one:
```
#     Error:  Can't locate PerlIO/utf8_strict.pm in @INC (you may need to install the PerlIO::utf8_strict module)
```