### PR TITLE
download.py: increase curl timeout to 60 seconds

### DIFF
--- a/autospec/download.py
+++ b/autospec/download.py
@@ -45,7 +45,7 @@ def do_curl(url, dest=None, post=None, is_fatal=False):
     c.setopt(c.FOLLOWLOCATION, True)
     c.setopt(c.FAILONERROR, True)
     c.setopt(c.CONNECTTIMEOUT, 10)
-    c.setopt(c.TIMEOUT, 30)
+    c.setopt(c.TIMEOUT, 600)
     c.setopt(c.LOW_SPEED_LIMIT, 1)
     c.setopt(c.LOW_SPEED_TIME, 10)
     buf = BytesIO()


### PR DESCRIPTION
Avoid errors such as:
"Unable to fetch xxx: Operation timed out after 29973 millisecond"

30 seconds may not be enough to download a large file
even with a fast connection or a smaller file with a slower
connection.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>