### PR TITLE
Fix version "1" fallback handling

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -418,7 +418,7 @@ def set_multi_version(ver):
     elif not multi_version:
         # Fall back to ensure a version is always set
         # (otherwise the last known version will be used)
-        multi_version[1] = ""
+        multi_version["1"] = ""
     latest = sorted(multi_version.keys())[-1]
     return latest
 


### PR DESCRIPTION
When no version is detected from the URL, autospec sets the version to `1`, but it needs to be a string, `"1"`, instead, because `str.lower()` is later called on it in `convert_version()`.