### PR TITLE
Miscellaneous fixes

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -360,6 +360,7 @@ def package(filemanager, mockconfig, mockopts, cleanup=False):
         "--enable-plugin=ccache",
         f"--uniqueext={uniqueext}",
         cleanup_flag,
+        mockopts,
     ]
     ret = util.call(" ".join(cmd_args),
                     logfile=f"{download_path}/results/mock_build.log",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -165,8 +165,8 @@ class TestTest(unittest.TestCase):
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
         self.assertEqual(check.tests_config,
-                         'PYTHONPATH=%{buildroot}/usr/lib/python3.7/site-packages '
-                         'python3 setup.py test')
+                         'PYTHONPATH=%{buildroot}$(python -c "import sys; print(sys.path[-1])") '
+                         'python setup.py test')
 
     def test_scan_for_tests_cmake(self):
         """


### PR DESCRIPTION
- Fix a failing unit test. It needed an update with the recent changes to python test suite handling.
- Pass `--mock-opts` value for second mock call. (I did some cleanup to build.py in the second commit, so I recommend looking at the second and third commits separately.)