### PR TITLE
Enable container-based Action/Workflow for testing CI

### DIFF
--- a/.github/actions/clearlinux-latest-action/Dockerfile
+++ b/.github/actions/clearlinux-latest-action/Dockerfile
@@ -1,0 +1,4 @@
+FROM clearlinux:latest
+RUN swupd bundle-add package-builder python-extras
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/clearlinux-latest-action/action.yml
+++ b/.github/actions/clearlinux-latest-action/action.yml
@@ -1,0 +1,10 @@
+name: 'Clear in Docker'
+description: 'Run commands in the latest Clear Linux OS Docker image'
+inputs:
+  testfunc:
+    description: 'Test function to run'
+    required: true
+    default: 'run_flake8'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/clearlinux-latest-action/entrypoint.sh
+++ b/.github/actions/clearlinux-latest-action/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -lx
+
+run_flake8() {
+	make check
+}
+
+run_unittests() {
+	make unittests
+}
+
+if t=$(type -t "$INPUT_TESTFUNC"); then
+	if [ "$t" = "function" ]; then
+		$INPUT_TESTFUNC
+	fi
+fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Autospec Tests
+
+on: [push, pull_request]
+
+jobs:
+  test_job:
+    runs-on: ubuntu-latest
+    name: Autospec Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Create Docker Image
+        uses: ./.github/actions/clearlinux-latest-action
+      - name: Run flake8
+        uses: ./.github/actions/clearlinux-latest-action
+        with:
+          testfunc: run_flake8
+      - name: Run unit tests
+        uses: ./.github/actions/clearlinux-latest-action
+        with:
+          testfunc: run_unittests


### PR DESCRIPTION
This commit sets up an in-tree, container-based Github Action and associated workflow for running `make check` and `make unittests` within a Clear Linux OS Docker container.

The most appropriate bundles to install in the container to satisfy all test dependencies are `python-extras` (includes `python3-basic` bundle and the `flake8` tool) and `package-builder` (includes `make`, and the `pycurl` package).