### PR TITLE
Add `info` subrpms.

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -238,6 +238,7 @@ class FileManager(object):
             (r"^/usr/share/man/man2", "dev"),
             (r"^/usr/share/man/man3", "dev"),
             (r"^/usr/share/man/", "man"),
+            (r"^/usr/share/info/", "info"),
             (r"^/usr/share/abi/", "abi"),
             (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
             (r"^/usr/lib/[a-zA-Z0-9._+-]*\.so\.", "plugins"),

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -255,7 +255,7 @@ class Specfile(object):
 
         deps = {}
         deps["dev"] = ["lib", "bin", "data"]
-        deps["doc"] = ["man"]
+        deps["doc"] = ["man", "info"]
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
         deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "services"]
         deps["lib"] = ["data", "libexec", "license"]
@@ -363,7 +363,7 @@ class Specfile(object):
                 continue
 
             self._write("\n%files {}\n".format(pkg))
-            if pkg in ["doc", "license", "man"]:
+            if pkg in ["doc", "license", "man", "info"]:
                 self._write("%defattr(0644,root,root,0755)\n")
             else:
                 self._write("%defattr(-,root,root,-)\n")


### PR DESCRIPTION
Tested on `autoconf` - succesfully moved all -doc files to a new -info subrpm.