### PR TITLE
Fix builds with clang: don't use the integrated as if -Wa in use

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -541,6 +541,8 @@ class Specfile(object):
             self._write_strip("export CC=clang\n")
             self._write_strip("export CXX=clang++\n")
             self._write_strip("export LD=ld.gold\n")
+            self._write_strip("CFLAGS=${CFLAGS/ -Wa,/ -fno-integrated-as -Wa,/}")
+            self._write_strip("CXXFLAGS=${CXXFLAGS/ -Wa,/ -fno-integrated-as -Wa,/}")
             lto = "-flto"
         else:
             lto = "-flto=4"


### PR DESCRIPTION
(but don't confuse with -Wall)

You get things like:

    Building C object CMakeFiles/cmTC_d3b87.dir/testCCompiler.c.o
    /usr/lib64/ccache/bin/clang   -O2 -g -feliminate-unused-debug-types -pipe -Wall  -fexceptions -fstack-protector --param=ssp-buffer-size=32 -Wformat -Wformat-security -Wno-error -ftree-vectorize -ftree-slp-vectorize -fcf-protection=return -Wa,-mbranches-within-32B-boundaries -m64 -march=westmere -mtune=haswell -fasynchronous-unwind-tables -fno-omit-frame-pointer -Wp,-D_REENTRANT -fno-lto    -o CMakeFiles/cmTC_d3b87.dir/testCCompiler.c.o   -c /builddir/build/BUILD/lldb-9.0.0.src/clr-build/CMakeFiles/CMakeTmp/testCCompiler.c
    clang-9: error: unsupported argument '-mbranches-within-32B-boundaries' to option 'Wa,'