### PR TITLE
Remove capability for dynamic reserving of buildroots

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -491,31 +491,6 @@ class TestBuildpattern(unittest.TestCase):
 
         self.assertEqual(mock_cmd, '/usr/bin/mock')
 
-    def test_get_uniqueext_first(self):
-        """
-        Test get_uniqueext() with no collisions
-        """
-        with tempfile.TemporaryDirectory() as tmpd:
-            self.assertEqual(build.get_uniqueext(tmpd, "test", "pkg"), "pkg")
-
-    def test_get_uniqueext_second(self):
-        """
-        Test get_uniqueext() with one collision
-        """
-        with tempfile.TemporaryDirectory() as tmpd:
-            os.mkdir(os.path.join(tmpd, "test-pkg"))
-            self.assertEqual(build.get_uniqueext(tmpd, "test", "pkg"), "pkg-1")
-
-    def test_get_uniqueext_third(self):
-        """
-        Test get_uniqueext() with two collisions
-        """
-        with tempfile.TemporaryDirectory() as tmpd:
-            os.mkdir(os.path.join(tmpd, "test-pkg"))
-            os.mkdir(os.path.join(tmpd, "test-pkg-1"))
-            self.assertEqual(build.get_uniqueext(tmpd, "test", "pkg"), "pkg-2")
-
-
 
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
Instead of autospec reserving buildroots on-the-fly to not collide with buildroots that already exist, I would prefer for the developer (or automation) running autospec to explicitly modify mock's `basedir` config option whenever more control is needed, possibly combined with other config options that modify state locations (like `cache_topdir`, `root`, etc).

Considering only the `basedir` option, a developer could run these three commands simultaneously to build the package `foo` and also avoid buildroot collisions:
```
$ make autospec MOCK_OPTS="--config-opts=basedir=/var/lib/mock/dir1"
$ make autospec MOCK_OPTS="--config-opts=basedir=/var/lib/mock/dir2"
$ make autospec MOCK_OPTS="--config-opts=basedir=/var/lib/mock/dir3"
```
The build root names would be (assuming that `config_opts['root']='clear'`, as it is by default):
```
/var/lib/mock/dir1/clear-foo
/var/lib/mock/dir2/clear-foo
/var/lib/mock/dir3/clear-foo
```
(Note that a side-effect of this change is that all autospec unit tests now pass in Github Actions; tests were failing because `sudo` was not installed by default, and the unit tests required `sudo` via the `reserve_path()` function.)