### PR TITLE
license_translation: CPL->EPL-1.0

### DIFF
--- a/autospec/license_translations
+++ b/autospec/license_translations
@@ -23,6 +23,7 @@ BSD_2_clause, BSD-2-Clause
 BSD_3_clause, BSD-3-Clause
 Boost, BSL-1.0
 CC0, CC0-1.0
+CPL, CPL-1.0
 Expat, MIT
 GFDL1.1, GFDL-1.1
 GPL(>=-2), GPL-2.0+


### PR DESCRIPTION
If CPL license is found by autospec, we end up with an
error:
ERROR: License 'CPL' is not an allowed SPDX license ID

CPL license was superseded by Eclipse Public License:
https://spdx.org/licenses/CPL-1.0.html

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>