### PR TITLE
Allow generic TODO in test failures

### DIFF
--- a/autospec/count.py
+++ b/autospec/count.py
@@ -649,7 +649,7 @@ def parse_log(log, pkgname=''):
 
         match = re.search(r"^not ok [0-9]+ \-", line)
         if match and incheck:
-            if re.search(r"# TODO known breakage", line):
+            if re.search(r"# TODO\b", line):
                 counted_xfail += 1
             else:
                 counted_fail += 1


### PR DESCRIPTION
When parsing TAP, reduce the match pattern for expected failures to just
through "TODO", instead of "TODO known breakage".

https://testanything.org/tap-version-13-specification.html#todo-tests