### PR TITLE
Special-case "kxmlgui" package: don't make it auto-require buildreq-kde

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -471,7 +471,8 @@ def name_and_version(name_arg, version_arg, filemanager):
         buildreq.add_buildreq("buildreq-gnome")
 
     if "kde.org" in url or "https://github.com/KDE" in url:
-        buildreq.add_buildreq("buildreq-kde")
+        if "kxmlgui" not in url:
+            buildreq.add_buildreq("buildreq-kde")
 
     # SQLite tarballs use 7 digit versions, e.g 3290000 = 3.29.0, 3081002 = 3.8.10.2
     if "sqlite.org" in url:


### PR DESCRIPTION
Fixes #487, by way of a hacky workaround.