### PR TITLE
Update config.py

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -935,7 +935,7 @@ def parse_config_files(path, bump, filemanager, version):
 
     content = read_script_file(os.path.join(path, "make_check_command"))
     if content:
-        check.tests_config = '\n'.join(content)
+        check.tests_config = ''.join(content)
 
     content = read_conf_file(os.path.join(path, tarball.name + ".license"))
     if content and content[0]:


### PR DESCRIPTION
prevent extra \n being inserted in the spec file

example:
https://gist.github.com/hnanni/45eaa81e7a42b982611b85390e743c38