### PR TITLE
Avoid adding extra newlines to script files

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -495,7 +495,9 @@ def read_script_file(path, track=True):
     lines = read_file(path, track=track)
     if len(lines) > 0 and (lines[0].startswith('#!') or lines[0].startswith('# -*- ')):
         lines = lines[1:]
-    return lines
+    # Remove any trailing whitespace and newlines. The newlines are later
+    # restored by writer functions.
+    return [line.rstrip() for line in lines]
 
 
 def read_pattern_conf(filename, dest, list_format=False, path=None):


### PR DESCRIPTION
The recently added `read_script_file` function preserves newline characters, and because the specfile writer functions already add newlines, extra blank lines were being written to spec files.

Avoid the extra newline characters by stripping them with `rstrip`. Note that any trailing whitespace is also stripped.