### PR TITLE
Only add files that begin with slash

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -251,7 +251,7 @@ def parse_build_results(filename, returncode, filemanager):
         elif infiles == 1 and "not matching the package arch" not in line:
             # exclude blank lines from consideration...
             file = line.strip()
-            if file:
+            if file and file[0] == "/":
                 filemanager.push_file(file)
 
         if line.startswith("Sorry: TabError: inconsistent use of tabs and spaces in indentation"):


### PR DESCRIPTION
In the section of the mock build.log that lists unpackaged files, rpm 4.14 will print warnings if any files have build ID issues.

Because file names must begin with a forward slash, it's easy to filter out these warnings, since the warnings themselves do not begin with a forward slash.

Fixes #547