### PR TITLE
Move get_contents() and get_sha1sum() to util.py

### DIFF
--- a/autospec/license.py
+++ b/autospec/license.py
@@ -21,7 +21,6 @@
 # exact matches on hashes of the COPYING file
 #
 
-import hashlib
 import os
 import re
 import shlex
@@ -33,7 +32,7 @@ import config
 import download
 
 import tarball
-from util import print_fatal, print_warning
+from util import get_contents, get_sha1sum, print_fatal, print_warning
 
 default_license = "TO BE DETERMINED"
 
@@ -99,20 +98,17 @@ def decode_license(license):
 
 def license_from_copying_hash(copying, srcdir):
     """Add licenses based on the hash of the copying file."""
-    data = tarball.get_contents(copying)
+    data = get_contents(copying)
+
     if data.startswith(b'#!'):
         # Not a license if this is a script
         return
-
-    raw_data = data
 
     data = decode_license(data)
     if not data:
         return
 
-    sh = hashlib.sha1()
-    sh.update(raw_data)
-    hash_sum = sh.hexdigest()
+    hash_sum = get_sha1sum(copying)
 
     if config.license_fetch:
         values = {'hash': hash_sum, 'text': data, 'package': tarball.name}

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -19,7 +19,6 @@
 
 import configparser
 import glob
-import hashlib
 import os
 import re
 import shutil
@@ -33,7 +32,7 @@ import buildpattern
 import buildreq
 import config
 import download
-from util import call, print_fatal, write_out, do_regex
+from util import call, do_regex, get_sha1sum, print_fatal, write_out
 
 name = ""
 rawname = ""
@@ -72,20 +71,6 @@ def process_go_dependency(url, target):
         pass
     for ver in list(multi_version.keys()):
         get_go_artifacts(base_url, target, ver)
-
-
-def get_contents(filename):
-    """Get contents of filename (tar file)."""
-    with open(filename, "rb") as f:
-        return f.read()
-    return None
-
-
-def get_sha1sum(filename):
-    """Get sha1 sum of filename (tar file)."""
-    sh = hashlib.sha1()
-    sh.update(get_contents(filename))
-    return sh.hexdigest()
 
 
 def check_or_get_file(upstream_url, tarfile, mode="w"):

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import hashlib
 import os
 import re
 import shlex
@@ -72,6 +73,20 @@ def do_regex(patterns, re_str):
         match = re.search(p, re_str)
         if match:
             return match
+
+
+def get_contents(filename):
+    """Get contents of filename."""
+    with open(filename, "rb") as f:
+        return f.read()
+    return None
+
+
+def get_sha1sum(filename):
+    """Get sha1 sum of filename."""
+    sh = hashlib.sha1()
+    sh.update(get_contents(filename))
+    return sh.hexdigest()
 
 
 def print_fatal(message):


### PR DESCRIPTION
Both are general-use functions so moving to util.py.

Signed-off-by: Athenas Jimenez <athenas.jimenez.gonzalez@intel.com>