### PR TITLE
specfiles.py: fix build_prepend for avx512

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1118,8 +1118,8 @@ class Specfile(object):
 
         if config.config_opts['use_avx512']:
             self._write_strip("unset PKG_CONFIG_PATH")
-            self.write_build_prepend()
             self._write_strip("pushd ../buildavx512/" + self.subdir)
+            self.write_build_prepend()
             self._write_strip("export CFLAGS=\"$CFLAGS -m64 -march=skylake-avx512 -mprefer-vector-width=512\"")
             self._write_strip("export CXXFLAGS=\"$CXXFLAGS -m64 -march=skylake-avx512 -mprefer-vector-width=512\"")
             self._write_strip("export LDFLAGS=\"$LDFLAGS -m64 -march=skylake-avx512\"")


### PR DESCRIPTION
write_configure_pattern: for avx512 the user defined
"build_prepend" was executed outside of the avx512 build
folder.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>