### PR TITLE
count.py: Fix false positive FAIL

### DIFF
--- a/autospec/count.py
+++ b/autospec/count.py
@@ -1250,7 +1250,7 @@ def parse_log(log, pkgname=''):
             total_pass += 1
             continue
 
-        match = re.search(r"(---\s+)?FAIL:?\s*", line)
+        match = re.search(r"(---\s+)?(?<!X)FAIL:?\s*", line)
         if match and incheck:
             total_tests += 1
             total_fail += 1


### PR DESCRIPTION
The following pattern match expression:
    match = re.search(r"(---\s+)?FAIL:?\s*", line)

would match both XFAIL and FAIL.
In the case of XFAIL in the line, the match would be interpreted as FAIL.

Remedy: use this instead:
   match = re.search(r"(---\s+)?(?<!X)FAIL:?\s*", line).

Kudos to phmccarty.