### PR TITLE
Fix PECL builds.

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -867,10 +867,6 @@ def scan_for_configure(dirn):
             add_buildreq("buildreq-meson")
             buildpattern.set_build_pattern("meson", default_score)
 
-        if "config.m4" in files:
-            add_buildreq("buildreq-php")
-            buildpattern.set_build_pattern("phpize", 1)
-
         if "pom.xml" in files:
             # Pretty straightforward maven source package
             add_buildreq("apache-maven")

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -98,6 +98,8 @@ def build_untar(tarball_path):
                 print_fatal("Tar file doesn't appear to have any content")
                 exit(1)
             elif len(lines) > 1:
+                if 'package.xml' in lines and buildpattern.default_pattern in ['phpize']:
+                    lines.remove('package.xml')
                 prefix = os.path.commonpath(lines)
     else:
         print_fatal("Not a valid tar file.")
@@ -348,6 +350,10 @@ def detect_build_from_url(url):
     # go dependency
     if "proxy.golang.org" in url:
         buildpattern.set_build_pattern("godep", 10)
+
+    # php modules from PECL
+    if "pecl.php.net" in url:
+        buildpattern.set_build_pattern("phpize", 10)
 
 
 def set_multi_version(ver):


### PR DESCRIPTION
PECL tarballs have an annoying `package.xml` in the toplevel. We detect PECL by URL and eliminate this file from the files list so that we do not need to compensate for path magic. This fixes all the PECL builds. Thanks to Athenas for coming up with the magic bit :).