### PR TITLE
Remove buildreq_cache when the version has changed

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -804,8 +804,8 @@ def parse_config_files(path, bump, filemanager, version):
     else:
         try:
             os.unlink(cache_file)
-        except Exception:
-            pass
+        except Exception as e:
+            print_warning(f"Unable to remove buildreq_cache file: {e}")
 
     content = read_conf_file(os.path.join(path, "pkgconfig_add"))
     for extra in content:

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -795,11 +795,17 @@ def parse_config_files(path, bump, filemanager, version):
         print("Adding additional build requirement: %s." % extra)
         buildreq.add_buildreq(extra)
 
-    content = read_conf_file(os.path.join(path, "buildreq_cache"))
+    cache_file = os.path.join(path, "buildreq_cache")
+    content = read_conf_file(cache_file)
     if content and content[0] == version:
         for extra in content[1:]:
             print("Adding additional build (cache) requirement: %s." % extra)
             buildreq.add_buildreq(extra)
+    else:
+        try:
+            os.unlink(cache_file)
+        except Exception:
+            pass
 
     content = read_conf_file(os.path.join(path, "pkgconfig_add"))
     for extra in content:


### PR DESCRIPTION
The buildreq_cache is only meant to apply when re-packaging the same version. To prevent the cache from becoming stale during version changes, remove it initially. If the new version has cached buildreqs, the file will be written later.

Fixes #481