### PR TITLE
Remove unresolvable names from buildreq_cache

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -191,7 +191,10 @@ def parse_buildroot_log(filename, returncode):
     for line in loglines:
         match = missing_pat.match(line)
         if match is not None:
-            util.print_fatal("Cannot resolve dependency name: {}".format(match.group(1)))
+            name = match.group(1)
+            util.print_fatal("Cannot resolve dependency name: {}".format(name))
+            # Avoid adding the dependency name to the buildreq cache
+            buildreq.remove_buildreq(name)
             is_clean = False
 
     return is_clean

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -77,6 +77,23 @@ def add_buildreq(req, cache=False):
     return new
 
 
+def remove_buildreq(req):
+    """Remove req from the global buildreqs and buildreqs_cache sets."""
+    global buildreqs
+    global buildreqs_cache
+
+    req = req.strip()
+
+    try:
+        buildreqs.remove(req)
+    except KeyError:
+        pass
+    try:
+        buildreqs_cache.remove(req)
+    except KeyError:
+        pass
+
+
 def add_requires(req, override=False):
     """Add req to the global requires set if it is present in buildreqs and os_packages and is not banned."""
     global buildreqs
@@ -116,6 +133,18 @@ def add_requires(req, override=False):
         # print("Adding requirement:", req)
         requires.add(req)
     return new
+
+
+def remove_requires(req):
+    """Remove req from the global requires set."""
+    global requires
+
+    req = req.strip()
+
+    try:
+        requires.remove(req)
+    except KeyError:
+        pass
 
 
 def add_pkgconfig_buildreq(preq, cache=False):

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -748,22 +748,20 @@ def parse_config_files(path, bump, filemanager, version):
     for banned in content:
         print("Banning build requirement: %s." % banned)
         buildreq.banned_buildreqs.add(banned)
-        buildreq.buildreqs.discard(banned)
-        buildreq.buildreqs_cache.discard(banned)
+        buildreq.remove_buildreq(banned)
 
     content = read_conf_file(os.path.join(path, "pkgconfig_ban"))
     for banned in content:
         banned = "pkgconfig(%s)" % banned
         print("Banning build requirement: %s." % banned)
         buildreq.banned_buildreqs.add(banned)
-        buildreq.buildreqs.discard(banned)
-        buildreq.buildreqs_cache.discard(banned)
+        buildreq.remove_buildreq(banned)
 
     content = read_conf_file(os.path.join(path, "requires_ban"))
     for banned in content:
         print("Banning runtime requirement: %s." % banned)
         buildreq.banned_requires.add(banned)
-        buildreq.requires.discard(banned)
+        buildreq.remove_requires(banned)
 
     content = read_conf_file(os.path.join(path, "buildreq_add"))
     for extra in content:


### PR DESCRIPTION
Fixes #480 

- Add a couple of helper functions to remove dependency names from the global sets
- Start using the helper functions for `buildreq_ban`, `pkgconfig_ban`, and `requires_ban`
- The root.log scan may reveal some unresolvable names, so remove those names from the sets as well.