### PR TITLE
Ban a few percent-encoded characters

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -292,7 +292,7 @@ def convert_version(ver_str, name):
     # them out with expensive regular expressions
     banned_subs = ["x86.64", "source", "src", "all", "bin", "release", "rh",
                    "ga", ".ce", "lcms", "onig", "linux", "gc", "sdk", "orig",
-                   "jurko"]
+                   "jurko", "%2f", "%2F", "%20"]
 
     # package names may be modified in the version string by adding "lib" for
     # example. Remove these from the name before trying to remove the name from


### PR DESCRIPTION
These characters should never appear in version strings, because rpm
complains. If there are additional percent-encoded characters to add in
the future, we can update the list.