### PR TITLE
Only verify the first GPG signature

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -123,10 +123,10 @@ class GPGCli(object):
             args = self.args + ['--dearmor', '--output', '-', signature]
             output, err, code = self.exec_cmd(args)
             if code != 0:
-                return None
+                return GPGCliStatus(f'Failed to convert {signature} to binary format')
             num_bytes = packets[0].get("length")
             if not num_bytes:
-                return None
+                return GPGCliStatus(f'Cannot verify first signature from {signature}')
             first_sig = output[:num_bytes]
             with tempfile.NamedTemporaryFile(prefix="newsig-", dir=self._home, delete=False) as new_sig_file:
                 new_sig_file.write(first_sig)

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -124,7 +124,9 @@ class GPGCli(object):
             output, err, code = self.exec_cmd(args)
             if code != 0:
                 return None
-            num_bytes = packets[0]["length"]
+            num_bytes = packets[0].get("length")
+            if not num_bytes:
+                return None
             first_sig = output[:num_bytes]
             with tempfile.NamedTemporaryFile(prefix="newsig-", dir=self._home, delete=False) as new_sig_file:
                 new_sig_file.write(first_sig)

--- a/tests/test_pkg_integrity.py
+++ b/tests/test_pkg_integrity.py
@@ -287,7 +287,7 @@ class TestUtils(unittest.TestCase):
                 self.assertEqual(packets[packet_with_val]["keyid"], key_id)
                 tmpf.close()
 
-        check_packets(KEY_ALGO17, '8AFAFCD242818A52', 9, 2)
+        check_packets(KEY_ALGO17, '8AFAFCD242818A52', 6, 1)
         check_packets(KEY_ALGO1, '330239C1C4DAFEE1', 1, 0)
 
     def test_get_keyid(self):
@@ -345,7 +345,7 @@ class TestUtils(unittest.TestCase):
                     self.assertEqual(packets[packet_with_val]["email"], email)
                 tmpf.close()
 
-        check_packets(KEY_ALGO17, 'kislyuk@gmail.com', 9, 1)
+        check_packets(KEY_ALGO17, 'kislyuk@gmail.com', 6, 0)
         check_packets(KEY_ALGO1, None, 1, None)
 
     def test_get_email(self):


### PR DESCRIPTION
The only package in Clear Linux OS that (occasionally) has its source archive signed by multiple keys is `gnupg`, so to unblock updates for it, only verify the first signature from the .sig file.

When only one signature is present in the sig file (the common case), pass the entire sig file to `gpg --verify ...`, keeping the existing behavior.

For the implementation, I refactored `parse_key` into a more generic `parse_gpg_packets` function, and also updated tests.

Note that supporting verification of multiple signatures is much more involved, so I opened an enhancement request yesterday for that (#567).