### PR TITLE
build: only record files when they are first listed

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -232,11 +232,11 @@ def parse_build_results(filename, returncode, filemanager):
 
         check_for_warning_pattern(line)
 
-        # search for files to add to the %files section
-        # track with infiles. If infiles == 1 we found the header
-        # "Installed (but unpackaged) file(s) found" in the build log
-        # This tells us to look in the next line. Increment infiles if we don't
-        # find a file in the next line.
+        # Search for files to add to the %files section.
+        # * infiles == 0 before we reach the files listing
+        # * infiles == 1 for the "Installed (but unpackaged) file(s) found" header
+        #     and for the entirety of the files listing
+        # * infiles == 2 after the files listing has ended
         if infiles == 1:
             for search in ["RPM build errors", "Childreturncodewas",
                            "Child returncode", "Empty %files file"]:
@@ -246,7 +246,7 @@ def parse_build_results(filename, returncode, filemanager):
                 if line.startswith(start):
                     infiles = 2
 
-        if "Installed (but unpackaged) file(s) found:" in line:
+        if infiles == 0 and "Installed (but unpackaged) file(s) found:" in line:
             infiles = 1
         elif infiles == 1 and "not matching the package arch" not in line:
             # exclude blank lines from consideration...


### PR DESCRIPTION
Because rpmbuild dumps a list of build errors after the build has
stopped and any errors have occurred, the "Installed (but unpackaged)
file(s) found" line is repeated, and thus autospec will always parse the
list of unpackaged files twice. Also, the repeated listing of unpackaged
files is sometimes truncated, possibly due to a bug in rpmbuild.

Since autospec already understands how to locate the end of the initial
unpackaged file listing, it can avoid the duplicate parsing and any
possible truncation issues by ensuring that the `infiles` variable is
set to `1` exactly once. Then, `infiles` will continue to have value `2`
from the end of the first file listing until parsing stops.