### PR TITLE
Use the pypi api for distutils3 builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -457,6 +457,13 @@ summary
   Provides the main Summary: value of the package, overriding any automatically
   found values. Only the first line is used.
 
+pypi.json
+  Provides an alternative to reading the pypi api url for package metadata.
+  provides, requires, summary, description and license information could be
+  sourced from this file (see https://wiki.python.org/moin/PyPIJSON) for more
+  details on the structure.
+
+
 Controlling flags and optimization
 ----------------------------------
 Further control of the build can be achieved through the use of the

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -276,7 +276,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
         exit(0)
 
     buildreq.set_build_req()
-    buildreq.scan_for_configure(_dir)
+    buildreq.scan_for_configure(_dir, tarball.name, tarball.version, build.download_path)
     specdescription.scan_for_description(tarball.name, _dir)
     # Start one directory higher so we scan *all* versions for licenses
     license.scan_for_licenses(os.path.dirname(_dir))

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -51,6 +51,7 @@ def commit_to_git(path):
     call("bash -c 'shopt -s failglob; git add *.spec'", cwd=path)
     call("git add %s.tmpfiles" % tarball.name, check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add prep_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add pypi.json", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add build_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add make_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add install_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -54,6 +54,7 @@ class Specfile(object):
         self.packages = OrderedDict()
         self.requires = set()
         self.buildreqs = []
+        self.pypi_provides = None
         self.extra_sources = []
         self.patches = []
         self.verpatches = OrderedDict()
@@ -317,6 +318,8 @@ class Specfile(object):
 
             if pkg == "python3":
                 self._write("Requires: python3-core\n")
+                if self.pypi_provides:
+                    self._write(f"Provides: pypi({self.pypi_provides})\n")
 
             if pkg == "perl":
                 self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -2,6 +2,8 @@ import unittest
 import tempfile
 import os
 from unittest.mock import mock_open, patch
+import json
+import io
 import buildreq
 
 
@@ -431,10 +433,79 @@ class TestBuildreq(unittest.TestCase):
             open(os.path.join(tmpd, 'SConstruct'), 'w').close()
             open(os.path.join(tmpd, 'meson.build'), 'w').close()
 
-            buildreq.scan_for_configure(tmpd)
+            buildreq.scan_for_configure(tmpd, "", "", "")
 
         self.assertEqual(buildreq.buildreqs,
                          set(['buildreq-golang', 'buildreq-cmake', 'buildreq-scons', 'buildreq-distutils3', 'buildreq-meson']))
+
+    def test_scan_for_configure_pypi(self):
+        """
+        Test scan_for_configure when distutils is being used for the build
+        pattern to test pypi metadata handling.
+        """
+        do_curl_name = 'buildreq.download.do_curl'
+        orig_description = buildreq.specdescription.default_description
+        orig_dscore = buildreq.specdescription.default_description_score
+        orig_summary = buildreq.specdescription.default_summary
+        orig_sscore = buildreq.specdescription.default_summary_score
+        name = "name"
+        summary = "summary"
+        description = "description"
+        content = json.dumps({"info": {"name": name,
+                                       "summary": summary,
+                                       "description": description}})
+        m_do_curl = lambda _: io.BytesIO(content.encode('utf-8'))
+        with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, 'subdir'))
+            open(os.path.join(tmpd, 'subdir', 'setup.py'), 'w').close()
+            with patch(do_curl_name, m_do_curl):
+                buildreq.scan_for_configure(os.path.join(tmpd, 'subdir'), "", "", tmpd)
+
+        sdescription = buildreq.specdescription.default_description
+        buildreq.specdescription.default_description = orig_description
+        ssummary = buildreq.specdescription.default_summary
+        buildreq.specdescription.default_summary = orig_summary
+        buildreq.specdescription.default_summary_score = orig_sscore
+        buildreq.specdescription.default_description_score = orig_dscore
+
+        self.assertEqual(buildreq.pypi_provides, name)
+        self.assertEqual(ssummary, summary)
+        self.assertEqual(sdescription, description)
+
+    def test_scan_for_configure_pypi_override(self):
+        """
+        Test scan_for_configure when distutils is being used for the build
+        pattern to test pypi metadata file override handling.
+        """
+        open_name = 'buildreq.open'
+        orig_description = buildreq.specdescription.default_description
+        orig_dscore = buildreq.specdescription.default_description_score
+        orig_summary = buildreq.specdescription.default_summary
+        orig_sscore = buildreq.specdescription.default_summary_score
+        name = "name"
+        summary = "summary"
+        description = "description"
+        content = json.dumps({"info": {"name": name,
+                                       "summary": summary,
+                                       "description": description}})
+        m_open = mock_open(read_data=content)
+        with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, 'subdir'))
+            open(os.path.join(tmpd, 'subdir', 'setup.py'), 'w').close()
+            open(os.path.join(tmpd, 'pypi.json'), 'w').close()
+            with patch(open_name, m_open, create=True):
+                buildreq.scan_for_configure(os.path.join(tmpd, 'subdir'), "", "", tmpd)
+
+        sdescription = buildreq.specdescription.default_description
+        buildreq.specdescription.default_description = orig_description
+        ssummary = buildreq.specdescription.default_summary
+        buildreq.specdescription.default_summary = orig_summary
+        buildreq.specdescription.default_summary_score = orig_sscore
+        buildreq.specdescription.default_description_score = orig_dscore
+
+        self.assertEqual(buildreq.pypi_provides, name)
+        self.assertEqual(ssummary, summary)
+        self.assertEqual(sdescription, description)
 
     def test_parse_cmake_pkg_check_modules(self):
         """


### PR DESCRIPTION
Get metadata about the package from pypi for distutils3 build patterns
then use that metadata to get summary, description and provides
information (license and requires maybe leveraged in the future).

The description isn't always very useful (often too long) so only use
it if there isn't one already.