### PR TITLE
specfile.py: fix incorrect install folder for AVX/AVX512

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -726,18 +726,18 @@ class Specfile(object):
             self._write_strip("fi")
             self._write_strip("popd")
 
-        if self.subdir:
-            self._write_strip("pushd " + self.subdir)
-
         if config.config_opts['use_avx512']:
-            self._write_strip("pushd ../buildavx512/")
+            self._write_strip("pushd ../buildavx512/" + self.subdir)
             self._write_strip("%s_avx512 %s\n" % (self.install_macro, self.extra_make_install))
             self._write_strip("popd")
 
         if config.config_opts['use_avx2']:
-            self._write_strip("pushd ../buildavx2/")
+            self._write_strip("pushd ../buildavx2/" + self.subdir)
             self._write_strip("%s_avx2 %s\n" % (self.install_macro, self.extra_make_install))
             self._write_strip("popd")
+
+        if self.subdir:
+            self._write_strip("pushd " + self.subdir)
 
         self._write_strip("%s %s\n" % (self.install_macro, self.extra_make_install))
 


### PR DESCRIPTION
The combined usage of "subdir" and AVX2/AVX512 builds fails to install
for certain build patterns (notably for "configure").

This can be verified, for example,  by trying to build the package "ntl" with:
    use_avx2 = true
    use_avx512 = true

This will fail with an error during install, similar to this:
    pushd: ../buildavx512/: No such file or directory

This patch fixes this by descending to the correct folder:
    pushd ../buildavx512/src

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>