### PR TITLE
support for openmpi sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,6 +235,10 @@ configure
   ``./configure`` for an autootools based tarball would result in ``%configure
   --disable-static`` being emitted in the ``.spec``.
 
+configure_openmpi
+  This file contains configuration flags to pass to the ``%configure`` macro for
+  autotools based tarballs to configure openmpi builds.
+
 configure32, configure64, configure_avx2, configure_avx512
   These files are appended to the ``%configure'' macro after the
   contents of the ``configure'' file above. They are used for 32-bit,
@@ -245,6 +249,10 @@ cmake_args
   CMake based tarballs. As an example, adding ``-DUSE_LIB64=ON`` to
   ``./cmake_args`` would result in ``%cmake -DUSE_LIB64=ON`` being emitted in
   the ``.spec``.
+
+cmake_args_openmpi
+  This file contains arguments that should be passed to the ``%cmake`` macro for
+  CMake based tarballs for openmpi builds.
 
 make_args
   The contents of this file are appended to the ``make`` invocation. This may be
@@ -507,6 +515,9 @@ use_avx2
 
 use_avx512
   If this option is set, an additional set of libraries, for AVX512, is built.
+
+openmpi
+  If this option is set, an additional openmpi package is built.
 
 fast-math
   If this option is set, -ffast-math is passed to the compiler.

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -38,6 +38,7 @@ buildreqs = set()
 buildreqs_cache = set()
 requires = set()
 extra_cmake = set()
+extra_cmake_openmpi = set()
 verbose = False
 cargo_bin = False
 pypi_provides = None
@@ -954,3 +955,4 @@ def load_specfile(specfile):
     specfile.extra_cmake += " " + " ".join(extra_cmake)
     specfile.pypi_provides = pypi_provides
     specfile.pypi_requires = sorted(pypi_requires)
+    specfile.extra_cmake_openmpi += " " + " ".join(extra_cmake_openmpi)

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -229,6 +229,7 @@ class FileManager(object):
         # the dev package. THis is useful for packages with a plugin
         # architecture like elfutils and mesa.
         so_dest = 'lib' if config.config_opts.get('so_to_lib') else 'dev'
+        so_dest_ompi = 'openmpi' if config.config_opts.get('so_to_lib') else 'dev'
 
         patterns = [
             # Patterns for matching files, format is a tuple as follows:
@@ -241,6 +242,13 @@ class FileManager(object):
             (r"^/usr/share/info/", "info"),
             (r"^/usr/share/abi/", "abi"),
             (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
+            (r"^/usr/lib64/openmpi/bin/", "openmpi"),
+            (r"^/usr/lib64/openmpi/share", "openmpi"),
+            (r"^/usr/lib64/openmpi/include/", "dev"),
+            (r"^/usr/lib64/openmpi/lib/[a-zA-Z0-9._+-]*\.so$", so_dest_ompi),
+            (r"^/usr/lib64/openmpi/lib/[a-zA-Z0-9._+-]*\.a$", "staticdev"),
+            (r"^/usr/lib64/openmpi/lib/[a-zA-Z0-9._+-]*\.so\.", "openmpi"),
+            (r"^/usr/lib64/openmpi/lib/", "dev"),
             (r"^/usr/lib/[a-zA-Z0-9._+-]*\.so\.", "plugins"),
             (r"^/usr/lib64/[a-zA-Z0-9._+-]*\.so\.", "lib"),
             (r"^/usr/lib32/[a-zA-Z0-9._+-]*\.so\.", "lib32"),

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -24,6 +24,7 @@ class TestTest(unittest.TestCase):
         check.config.config_opts['32bit'] = False
         check.config.config_opts['use_avx2'] = False
         check.config.config_opts['use_avx512'] = False
+        check.config.config_opts['openmpi'] = False
         check.os.path.isfile = mock_generator(True)
 
     @classmethod


### PR DESCRIPTION
Initial support for concurrent serial and parallel build.
Parallel MPI build enabled via a new setting in "options.conf":
    openmpi = false|true (false is default)

 * Serial builds remain unaffected.
 * Parallel build: Only OpenMPI is supported.
 * Parallel builds always assume AVX2.
 * Build patterns implemented: "configure" and "cmake".
   The build process is controlled by additional files:
   "cmake_arg_openmpi": same functionality as "cmake_args"
   "configure_openmpi": same functionality as "configure"

The openmpi (configure, build, check, install) sections follow these steps:

module load openmpi
...[configure,build,install,check]
module unload openmpi

Once "openmpi=true", the packages "openmpi-dev", "modules" and "openssh"
are automatically added to BuildRequires. ("openssh" is generally required
to run any MPI test suites).

Packages created:
   foo-openmpi:    binaries, libraries, docs, ...
   foo-dev :       contains both serial and MPI devel. files
   foo-staticdev:  contains both serial and MPI devel. files