### PR TITLE
Refactor the config into a class

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -612,23 +612,6 @@ def grab_python_requirements(descfile):
         add_requires(clean_python_req(line))
 
 
-def grab_pip_requirements(pkgname):
-    """Determine python requirements for pkgname using pip show."""
-    try:
-        pipeout = subprocess.check_output(['/usr/bin/pip3', 'show', pkgname])
-    except Exception:
-        return
-    lines = pipeout.decode("utf-8").split('\n')
-    for line in lines:
-        words = line.split(" ")
-        if words[0] == "Requires:":
-            for w in words[1:]:
-                w2 = w.replace(",", "")
-                if len(w2) > 2:
-                    print("Suggesting python requirement ", w2)
-                    add_requires(w2)
-
-
 def get_python_build_version_from_classifier(filename):
     """Detect if setup should use distutils3 only.
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -35,452 +35,11 @@ import tarball
 from util import call, print_warning, write_out
 from util import open_auto
 
-extra_configure = ""
-extra_configure32 = ""
-extra_configure64 = ""
-extra_configure_avx2 = ""
-extra_configure_avx512 = ""
-config_files = set()
-parallel_build = " %{?_smp_mflags} "
-urlban = ""
-extra_make = ""
-extra32_make = ""
-extra_make_install = ""
-extra_make32_install = ""
-extra_cmake = ""
-extra_cmake_openmpi = ""
-cmake_srcdir = ""
-subdir = ""
-install_macro = "%make_install"
-disable_static = "--disable-static"
-prep_prepend = []
-build_prepend = []
-build_append = []
-make_prepend = []
-install_prepend = []
-install_append = []
-service_restart = []
-patches = []
-verpatches = OrderedDict()
-extra_sources = []
-autoreconf = False
-custom_desc = ""
-custom_summ = ""
-set_gopath = True
-
-license_fetch = None
-license_show = None
-git_uri = None
-os_packages = set()
-config_file = None
-old_version = None
-old_patches = list()
-old_keyid = None
-profile_payload = None
-signature = None
-yum_conf = None
-failed_pattern_dir = None
-alias = None
-
-failed_commands = {}
-ignored_commands = {}
-maven_jars = {}
-gems = {}
-license_hashes = {}
-license_translations = {}
-license_blacklist = {}
-qt_modules = {}
-cmake_modules = {}
-
-cves = []
-
-conf_args_openmpi = '--program-prefix=  --exec-prefix=$MPI_ROOT \\\n' \
-    '--libdir=$MPI_LIB --bindir=$MPI_BIN --sbindir=$MPI_BIN --includedir=$MPI_INCLUDE \\\n' \
-    '--datarootdir=$MPI_ROOT/share --mandir=$MPI_MAN -exec-prefix=$MPI_ROOT --sysconfdir=$MPI_SYSCONFIG \\\n' \
-    '--build=x86_64-generic-linux-gnu --host=x86_64-generic-linux-gnu --target=x86_64-clr-linux-gnu '
-
-# Keep track of the package versions
-versions = OrderedDict()
-# Only parse the versions file once, and save the result for later
-parsed_versions = OrderedDict()
-
-# defines which files to rename and copy to autospec directory,
-# used in commitmessage.py
-transforms = {
-    'changes': 'ChangeLog',
-    'changelog.txt': 'ChangeLog',
-    'changelog': 'ChangeLog',
-    'change.log': 'ChangeLog',
-    'ChangeLog.md': 'ChangeLog',
-    'changes.rst': 'ChangeLog',
-    'changes.txt': 'ChangeLog',
-    'news': 'NEWS',
-    'meson_options.txt': 'meson_options.txt'
-}
-
-config_opts = {}
-config_options = {
-    "broken_c++": "extend flags with '-std=gnu++98",
-    "use_lto": "configure build for lto",
-    "use_avx2": "configure build for avx2",
-    "use_avx512": "configure build for avx512",
-    "keepstatic": "do not remove static libraries",
-    "asneeded": "unset %build LD_AS_NEEDED variable",
-    "allow_test_failures": "allow package to build with test failures",
-    "skip_tests": "Do not run test suite",
-    "no_autostart": "do not require autostart subpackage",
-    "optimize_size": "optimize build for size over speed",
-    "funroll-loops": "optimize build for speed over size",
-    "fast-math": "pass -ffast-math to compiler",
-    "insecure_build": "set flags to smallest -02 flags possible",
-    "conservative_flags": "set conservative build flags",
-    "broken_parallel_build": "disable parallelization during build",
-    "pgo": "set profile for pgo",
-    "use_clang": "add clang flags",
-    "32bit": "build 32 bit libraries",
-    "nostrip": "disable stripping binaries",
-    "verify_required": "require package verification for build",
-    "security_sensitive": "set flags for security-sensitive builds",
-    "so_to_lib": "add .so files to the lib package instead of dev",
-    "dev_requires_extras": "dev package requires the extras to be installed",
-    "autoupdate": "this package is trusted enough to automatically update "
-                  "(used by other tools)",
-    "compat": "this package is a library compatibility package and only "
-              "ships versioned library files",
-    "nodebug": "do not generate debuginfo for this package",
-    "openmpi": "configure build also for openmpi"}
-
-# simple_pattern_pkgconfig patterns
-# contains patterns for parsing build.log for missing dependencies
-pkgconfig_pats = [
-    (r"which: no qmake", "Qt"),
-    (r"XInput2 extension not found", "xi"),
-    (r"checking for UDEV\.\.\. no", "udev"),
-    (r"checking for UDEV\.\.\. no", "libudev"),
-    (r"XMLLINT not set and xmllint not found in path", "libxml-2.0"),
-    (r"error\: xml2-config not found", "libxml-2.0"),
-    (r"error: must install xorg-macros", "xorg-macros")]
-
-# simple_pattern patterns
-# contains patterns for parsing build.log for missing dependencies
-simple_pats = [
-    (r'warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/.*"', "docbook-xml"),
-    (r"gobject-introspection dependency was not found, gir cannot be generated.", "gobject-introspection-dev"),
-    (r"gobject-introspection dependency was not found, gir cannot be generated.", "glibc-bin"),
-    (r"Cannot find development files for any supported version of libnl", "libnl-dev"),
-    (r"/<http:\/\/www.cmake.org>", "cmake"),
-    (r"\-\- Boost libraries:", "boost-dev"),
-    (r"XInput2 extension not found", "inputproto"),
-    (r"^WARNING: could not find 'runtest'$", "dejagnu"),
-    (r"^WARNING: could not find 'runtest'$", "expect"),
-    (r"^WARNING: could not find 'runtest'$", "tcl"),
-    (r"VignetteBuilder package required for checking but installed:", "R-knitr"),
-    (r"You must have XML::Parser installed", "perl(XML::Parser)"),
-    (r"checking for Apache .* module support", "httpd-dev"),
-    (r"checking for.*in -ljpeg... no", "libjpeg-turbo-dev"),
-    (r"fatal error\: zlib\.h\: No such file or directory", "zlib-dev"),
-    (r"\* tclsh failed", "tcl"),
-    (r"\/usr\/include\/python3\.[0-9]+m\/pyconfig.h", "python3-dev"),
-    (r"checking \"location of ncurses\.h file\"", "ncurses-dev"),
-    (r"Can't exec \"aclocal\"", "automake"),
-    (r"Can't exec \"aclocal\"", "libtool"),
-    (r"configure: error: no suitable Python interpreter found", "python3-dev"),
-    (r"Checking for header Python.h", "python3-dev"),
-    (r"configure: error: No curses header-files found", "ncurses-dev"),
-    (r" \/usr\/include\/python3\.", "python3-dev"),
-    (r"to compile python extensions", "python3-dev"),
-    (r"testing autoconf... not found", "autoconf"),
-    (r"configure\: error\: could not find Python headers", "python3-dev"),
-    (r"checking for libxml libraries", "libxml2-dev"),
-    (r"checking for slang.h... no", "slang-dev"),
-    (r"configure: error: no suitable Python interpreter found", "python3"),
-    (r"configure: error: pcre-config for libpcre not found", "pcre"),
-    (r"checking for OpenSSL", "openssl-dev"),
-    (r"Package systemd was not found in the pkg-config search path.", "systemd-dev"),
-    (r"Unable to find the requested Boost libraries.", "boost-dev"),
-    (r"libproc not found. Please configure without procps", "procps-ng-dev"),
-    (r"configure: error: glib2", "glib-dev"),
-    (r"C library 'efivar' not found", "efivar-dev"),
-    (r"Has header \"efi.h\": NO", "gnu-efi-dev"),
-    (r"ERROR: Could not execute Vala compiler", "vala"),
-    (r".*: error: HAVE_INTROSPECTION does not appear in AM_CONDITIONAL", 'gobject-introspection-dev')]
-
-# failed_pattern patterns
-# contains patterns for parsing build.log for missing dependencies
-failed_pats = [
-    (r"    !  ([a-zA-Z:]+) is not installed", 0, 'perl'),
-    (r"    ([a-zA-Z]+\:\:[a-zA-Z]+) not installed", 1, None),
-    (r"(?:Could|Did) (?:NOT|not) find ([a-zA-Z0-9]+)", 0, None),
-    (r" ([a-zA-Z0-9\-]*\.m4) not found", 0, None),
-    (r" exec: ([a-zA-Z0-9\-]+): not found", 0, None),
-    (r"([a-zA-Z0-9\-\_\.]*)\: command not found", 1, None),
-    (r"([a-zA-Z\-]*) (?:validation )?tool not found or not executable", 0, None),
-    (r"([a-zA-Z\-]+) [0-9\.]+ is required to configure this module; "
-     r"please install it or upgrade your CPAN\/CPANPLUS shell.", 0, None),
-    (r"-- (.*) not found.", 1, None),
-    (r".* /usr/bin/([a-zA-Z0-9-_]*).*not found", 0, None),
-    (r".*\.go:.*cannot find package \"(.*)\" in any of:", 0, 'go'),
-    (r"/usr/bin/env\: (.*)\: No such file or directory", 0, None),
-    (r"/usr/bin/python.*\: No module named (.*)", 0, None),
-    (r":in `require': cannot load such file -- ([a-zA-Z0-9\-\_:\/]+)", 0, 'ruby table'),
-    (r":in `require': cannot load such file -- ([a-zA-Z0-9\-\_:]+) ", 0, 'ruby'),
-    (r"Add the installation prefix of \"(.*)\" to CMAKE_PREFIX_PATH", 0, None),
-    (r"By not providing \"([a-zA-Z0-9]+).cmake\" in CMAKE_MODULE_PATH this project", 0, None),
-    (r"C library '(.*)' not found", 0, None),
-    (r"CMake Error at cmake\/modules\/([a-zA-Z0-9]+).cmake", 0, None),
-    (r"Can't locate [a-zA-Z0-9_\-\/\.]+ in @INC " r"\(you may need to install the ([a-zA-Z0-9_\-:]+) module\)", 0, 'perl'),
-    (r"Cannot find ([a-zA-Z0-9\-_\.]*)", 1, None),
-    (r"Checking for (.*?)\.\.\.no", 0, None),
-    (r"Checking for (.*?)\s*: not found", 0, None),
-    (r"Checking for (.*?)\s>=.*\s*: not found", 0, None),
-    (r"Could not find '([a-zA-Z0-9\-\_]*)' \([~<>=]+ ([0-9.]+).*\) among [0-9]+ total gem", 0, 'ruby'),
-    (r"Could not find gem '([a-zA-Z0-9\-\_]+) \([~<>=0-9\.\, ]+\) ruby'", 0, 'ruby'),
-    (r"Could not find suitable distribution for Requirement.parse\('([a-zA-Z\-\.]*)", 0, None),
-    (r"Download error on https://pypi.python.org/simple/([a-zA-Z0-9\-\._:]+)/", 0, 'pypi'),
-    (r"Downloading https?://.*\.python\.org/packages/.*/.?/([A-Za-z]*)/.*", 0, None),
-    (r"ERROR:  Could not find a valid gem '([a-zA-Z0-9\-\_\:]*)' \([>=]+ ([0-9.]+).*\)", 0, 'ruby'),
-    (r"ERROR: dependencies ['‘]([a-zA-Z0-9\-\.]*)['’].* are not available for package ['‘].*['’]", 0, 'R'),
-    (r"ERROR: dependencies ['‘].*['’], ['‘]([a-zA-Z0-9\-\.]*)['’],.* are not available for package ['‘].*['’]", 0, 'R'),
-    (r"ERROR: dependencies.*['‘]([a-zA-Z0-9\-\.]*)['’] are not available for package ['‘].*['’]", 0, 'R'),
-    (r"ERROR: dependency ['‘]([a-zA-Z0-9\-\.]*)['’] is not available for package ['‘].*['’]", 0, 'R'),
-    (r"Error: Unable to find (.*)", 0, None),
-    (r"Error: package ['‘]([a-zA-Z0-9\-\.]*)['’] required by", 0, 'R'),
-    (r"Gem::LoadError: Could not find '([a-zA-Z0-9\-\_]*)'", 0, 'ruby'),
-    (r"ImportError:.* No module named '?([a-zA-Z0-9\-\._]+)'?", 0, 'pypi'),
-    (r"ImportError\: ([a-zA-Z]+) module missing", 0, None),
-    (r"ImportError\: (?:No module|cannot import) named? (.*)", 0, None),
-    (r"LoadError: cannot load such file -- ([a-zA-Z0-9\-:\/\_]+)", 0, 'ruby table'),
-    (r"LoadError: cannot load such file -- ([a-zA-Z0-9\-:]+)/.*", 0, 'ruby'),
-    (r"ModuleNotFoundError.*No module named (.*)", 0, None),
-    (r"Native dependency '(.*)' not found", 0, "pkgconfig"),
-    (r"No library found for -l([a-zA-Z\-])", 0, None),
-    (r"No (?:matching distribution|local packages or working download links) found for ([a-zA-Z0-9\-\.\_]+)", 0, 'pypi'),
-    (r"No package '([a-zA-Z0-9\-:]*)' found", 0, 'pkgconfig'),
-    (r"No rule to make target `(.*)',", 0, None),
-    (r"Package '([a-zA-Z0-9\-:]*)', required by '.*', not found", 0, 'pkgconfig'),
-    (r"Package which this enhances but not available for checking: ['‘]([a-zA-Z0-9\-]*)['’]", 0, 'R'),
-    (r"Perhaps you should add the directory containing `([a-zA-Z0-9\-:]*)\.pc'", 0, 'pkgconfig'),
-    (r"Program (.*) found: NO", 0, None),
-    (r"Target '[a-zA-Z0-9\-]' can't be generated as '(.*)' could not be found", 0, None),
-    (r"Unable to `import (.*)`", 0, None),
-    (r"Unable to find '(.*)'", 0, None),
-    (r"Unknown packages? ['‘]([a-zA-Z0-9\-]*)['’].* in Rd xrefs", 0, 'R'),
-    (r"WARNING:  [a-zA-Z\-\_]+ dependency on ([a-zA-Z0-9\-\_:]*) \([<>=~]+ ([0-9.]+).*\) .*", 0, 'ruby'),
-    (r"Warning: prerequisite ([a-zA-Z:]+) [0-9\.]+ not found.", 0, 'perl'),
-    (r"Warning\: no usable ([a-zA-Z0-9]+) found", 0, None),
-    (r"You need ([a-zA-Z0-9\-\_]*) to build this program.", 1, None),
-    (r"[Dd]ependency (.*) found: NO \(tried pkgconfig(?: and cmake)?\)", 0, 'pkgconfig'),
-    (r"[Dd]ependency (.*) found: NO", 0, None),
-    (r"[a-zA-Z0-9\-:]* is not installed: cannot load such file -- rdoc/([a-zA-Z0-9\-:]*)", 0, 'ruby'),
-    (r"\-\- Could NOT find ([a-zA-Z0-9]+)", 0, None),
-    (r"\/bin\/ld: cannot find (-l[a-zA-Z0-9\_]+)", 0, None),
-    (r"^.*By not providing \"Find(.*).cmake\" in CMAKE_MODULE_PATH this.*$", 0, None),
-    (r"^.*Could not find a package configuration file provided by \"(.*)\".*$", 0, None),
-    (r"^.*\"(.*)\" with any of the following names.*$", 0, None),
-    (r"[Cc]hecking for (.*) (?:support|development files|with pkg-config)?\.\.\. [Nn]o", 0, None),
-    (r"checking (.*?)\.\.\. no", 0, None),
-    (r"checking for (.*) in default path\.\.\. not found", 0, None),
-    (r"checking for (.*)... configure: error", 0, None),
-    (r"checking for (.*?)\.\.\. no", 0, None),
-    (r"checking for [a-zA-Z0-9\_\-]+ in (.*?)\.\.\. no", 0, None),
-    (r"checking for library containing (.*)... no", 0, None),
-    (r"checking for perl module ([a-zA-Z:]+) [0-9\.]+... no", 0, 'perl'),
-    (r"configure: error: (?:pkg-config missing|Unable to locate) (.*)", 0, None),
-    (r"configure: error: ([a-zA-Z0-9]+) (?:is required to build|not found)", 0, None),
-    (r"configure: error: Cannot find (.*)\. Make sure", 0, None),
-    (r"fatal error\: (.*)\: No such file or directory", 0, None),
-    (r"make: ([a-zA-Z0-9].+): Command not found", 0, None),
-    (r"meson\.build\:[\d]+\:[\d]+\: ERROR: C library \'(.*)\' not found", 0, None),
-    (r"there is no package called ['‘]([a-zA-Z0-9\-\.]*)['’]", 0, 'R'),
-    (r"unable to execute '([a-zA-Z\-]*)': No such file or directory", 0, None),
-    (r"warning: failed to load external entity " r"\"(/usr/share/sgml/docbook/xsl-stylesheets)/.*\"", 0, None),
-    (r"which\: no ([a-zA-Z\-]*) in \(", 0, None),
-    (r"you may need to install the ([a-zA-Z0-9_\-:\.]*) module", 0, 'perl'),
-]
-
-
-def get_metadata_conf():
-    """Gather package metadata from the tarball module."""
-    metadata = {}
-    metadata['name'] = tarball.name
-    if urlban:
-        metadata['url'] = re.sub(urlban, "localhost", tarball.url)
-        metadata['archives'] = re.sub(urlban, "localhost", " ".join(tarball.archives))
-    else:
-        metadata['url'] = tarball.url
-        metadata['archives'] = " ".join(tarball.archives)
-
-    metadata['giturl'] = tarball.giturl
-    metadata['domain'] = tarball.domain
-
-    if alias:
-        metadata['alias'] = alias
-    else:
-        metadata['alias'] = ""
-
-    return metadata
-
-
-def create_conf(path):
-    """Create options.conf file and use deprecated configuration files or defaults to populate."""
-    config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
-
-    # first the metadata
-    config_f['package'] = get_metadata_conf()
-
-    # next the options
-    config_f['autospec'] = {}
-    for fname, comment in sorted(config_options.items()):
-        config_f.set('autospec', '# {}'.format(comment))
-        if os.path.exists(fname):
-            config_f['autospec'][fname] = 'true'
-            os.remove(fname)
-        else:
-            config_f['autospec'][fname] = 'false'
-
-    # default lto to true for new things
-    config_f['autospec']['use_lto'] = 'true'
-
-    # renamed options need special care
-    if os.path.exists("skip_test_suite"):
-        config_f['autospec']['skip_tests'] = 'true'
-        os.remove("skip_test_suite")
-    write_config(config_f, path)
-
-
-def create_buildreq_cache(path, version):
-    """Make the buildreq_cache file."""
-    content = read_conf_file(os.path.join(path, "buildreq_cache"))
-    # don't create an empty cache file
-    if len(buildreq.buildreqs_cache) < 1:
-        try:
-            # file was possibly added to git so we should clean it up
-            os.unlink(content)
-        except Exception:
-            pass
-        return
-    if not content:
-        pkgs = sorted(buildreq.buildreqs_cache)
-    else:
-        pkgs = sorted(set(content[1:]).union(buildreq.buildreqs_cache))
-    with open(os.path.join(path, 'buildreq_cache'), "w") as cachefile:
-        cachefile.write("\n".join([version] + pkgs))
-    config_files.add('buildreq_cache')
-
-
-def create_versions(path, versions):
-    """Make versions file."""
-    with open(os.path.join(path, "versions"), 'w') as vfile:
-        for version in versions:
-            vfile.write(version)
-            if versions[version]:
-                vfile.write('\t' + versions[version])
-            vfile.write('\n')
-    config_files.add("versions")
-
 
 def write_config(config_f, path):
     """Write the config_f to configfile."""
     with open(os.path.join(path, 'options.conf'), 'w') as configfile:
         config_f.write(configfile)
-
-
-def read_config_opts(path):
-    """Read config options from path/options.conf."""
-    global config_opts
-    global transforms
-    global alias
-
-    opts_path = os.path.join(path, 'options.conf')
-    if not os.path.exists(opts_path):
-        create_conf(path)
-
-    config_f = configparser.ConfigParser(interpolation=None)
-    config_f.read(opts_path)
-    if "autospec" not in config_f.sections():
-        print("Missing autospec section in options.conf")
-        sys.exit(1)
-
-    if 'package' in config_f.sections() and config_f['package'].get('alias'):
-        alias = config_f['package']['alias']
-
-    for key in config_f['autospec']:
-        config_opts[key] = config_f['autospec'].getboolean(key)
-
-    # Rewrite the configuration file in case of formatting changes since a
-    # configuration file may exist without any comments (either due to an older
-    # version of autospec or if it was user-created)
-    rewrite_config_opts(path)
-
-    # Don't use the ChangeLog files if the giturl is set
-    # ChangeLog is just extra noise when we can already see the gitlog
-    if "package" in config_f.sections() and config_f['package'].get('giturl'):
-        keys = []
-        for k, v in transforms.items():
-            if v == "ChangeLog":
-                keys.append(k)
-        for k in keys:
-            transforms.pop(k)
-
-
-def rewrite_config_opts(path):
-    """Rewrite options.conf file when an option has changed (verify_required for example)."""
-    config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
-    config_f['package'] = get_metadata_conf()
-    config_f['autospec'] = {}
-
-    # Populate missing configuration options
-    # (in case of a user-created options.conf)
-    missing = set(config_options.keys()).difference(set(config_opts.keys()))
-    for option in missing:
-        config_opts[option] = False
-
-    for fname, comment in sorted(config_options.items()):
-        config_f.set('autospec', '# {}'.format(comment))
-        config_f['autospec'][fname] = 'true' if config_opts[fname] else 'false'
-
-    write_config(config_f, path)
-
-
-def read_file(path, track=True):
-    """Read full file at path.
-
-    If the file does not exist (or is not expected to exist)
-    in the package git repo, specify 'track=False'.
-    """
-    try:
-        with open(path, "r") as f:
-            if track:
-                config_files.add(os.path.basename(path))
-            return f.readlines()
-    except EnvironmentError:
-        return []
-
-
-def read_conf_file(path, track=True):
-    """Read configuration file at path.
-
-    If the config file does not exist (or is not expected to exist)
-    in the package git repo, specify 'track=False'.
-    """
-    lines = read_file(path, track=track)
-    return [l.strip() for l in lines if not l.strip().startswith("#") and l.split()]
-
-
-def read_script_file(path, track=True):
-    """Read RPM script snippet file at path.
-
-    Returns verbatim, except for possibly the first line.
-
-    If the config file does not exist (or is not expected to exist)
-    in the package git repo, specify 'track=False'.
-    """
-    lines = read_file(path, track=track)
-    if len(lines) > 0 and (lines[0].startswith('#!') or lines[0].startswith('# -*- ')):
-        lines = lines[1:]
-    # Remove any trailing whitespace and newlines. The newlines are later
-    # restored by writer functions.
-    return [line.rstrip() for line in lines]
 
 
 def read_pattern_conf(filename, dest, list_format=False, path=None):
@@ -513,531 +72,888 @@ def read_pattern_conf(filename, dest, list_format=False, path=None):
                 dest[pattern] = package.rstrip()
 
 
-def setup_patterns(path=None):
-    """Read each pattern configuration file and assign to the appropriate variable."""
-    global failed_commands
-    global ignored_commands
-    global maven_jars
-    global gems
-    global license_hashes
-    global license_translations
-    global license_blacklist
-    global qt_modules
-    global cmake_modules
+class Config(object):
+    """Class to handle autospec configuration."""
 
-    read_pattern_conf("ignored_commands", ignored_commands, list_format=True, path=path)
-    read_pattern_conf("failed_commands", failed_commands, path=path)
-    read_pattern_conf("maven_jars", maven_jars, path=path)
-    read_pattern_conf("gems", gems, path=path)
-    read_pattern_conf("license_hashes", license_hashes, path=path)
-    read_pattern_conf("license_translations", license_translations, path=path)
-    read_pattern_conf("license_blacklist", license_blacklist, list_format=True, path=path)
-    read_pattern_conf("qt_modules", qt_modules, path=path)
-    read_pattern_conf("cmake_modules", cmake_modules, path=path)
+    def __init__(self):
+        """Initialize Default configuration settings."""
+        self.extra_configure = ""
+        self.extra_configure32 = ""
+        self.extra_configure64 = ""
+        self.extra_configure_avx2 = ""
+        self.extra_configure_avx512 = ""
+        self.config_files = set()
+        self.parallel_build = " %{?_smp_mflags} "
+        self.urlban = ""
+        self.extra_make = ""
+        self.extra32_make = ""
+        self.extra_make_install = ""
+        self.extra_make32_install = ""
+        self.extra_cmake = ""
+        self.extra_cmake_openmpi = ""
+        self.cmake_srcdir = ""
+        self.subdir = ""
+        self.install_macro = "%make_install"
+        self.disable_static = "--disable-static"
+        self.prep_prepend = []
+        self.build_prepend = []
+        self.build_append = []
+        self.make_prepend = []
+        self.install_prepend = []
+        self.install_append = []
+        self.service_restart = []
+        self.patches = []
+        self.verpatches = OrderedDict()
+        self.extra_sources = []
+        self.autoreconf = False
+        self.custom_desc = ""
+        self.custom_summ = ""
+        self.set_gopath = True
+        self.license_fetch = None
+        self.license_show = None
+        self.git_uri = None
+        self.os_packages = set()
+        self.config_file = None
+        self.old_version = None
+        self.old_patches = list()
+        self.old_keyid = None
+        self.profile_payload = None
+        self.signature = None
+        self.yum_conf = None
+        self.failed_pattern_dir = None
+        self.alias = None
+        self.failed_commands = {}
+        self.ignored_commands = {}
+        self.maven_jars = {}
+        self.gems = {}
+        self.license_hashes = {}
+        self.license_translations = {}
+        self.license_blacklist = {}
+        self.qt_modules = {}
+        self.cmake_modules = {}
+        self.cves = []
+        self.conf_args_openmpi = '--program-prefix=  --exec-prefix=$MPI_ROOT \\\n' \
+            '--libdir=$MPI_LIB --bindir=$MPI_BIN --sbindir=$MPI_BIN --includedir=$MPI_INCLUDE \\\n' \
+            '--datarootdir=$MPI_ROOT/share --mandir=$MPI_MAN -exec-prefix=$MPI_ROOT --sysconfdir=$MPI_SYSCONFIG \\\n' \
+            '--build=x86_64-generic-linux-gnu --host=x86_64-generic-linux-gnu --target=x86_64-clr-linux-gnu '
+        # Keep track of the package versions
+        self.versions = OrderedDict()
+        # Only parse the versions file once, and save the result for later
+        self.parsed_versions = OrderedDict()
+        # defines which files to rename and copy to autospec directory,
+        # used in commitmessage.py
+        self.transforms = {
+            'changes': 'ChangeLog',
+            'changelog.txt': 'ChangeLog',
+            'changelog': 'ChangeLog',
+            'change.log': 'ChangeLog',
+            'ChangeLog.md': 'ChangeLog',
+            'changes.rst': 'ChangeLog',
+            'changes.txt': 'ChangeLog',
+            'news': 'NEWS',
+            'meson_options.txt': 'meson_options.txt'
+        }
+        self.config_opts = {}
+        self.config_options = {
+            "broken_c++": "extend flags with '-std=gnu++98",
+            "use_lto": "configure build for lto",
+            "use_avx2": "configure build for avx2",
+            "use_avx512": "configure build for avx512",
+            "keepstatic": "do not remove static libraries",
+            "asneeded": "unset %build LD_AS_NEEDED variable",
+            "allow_test_failures": "allow package to build with test failures",
+            "skip_tests": "Do not run test suite",
+            "no_autostart": "do not require autostart subpackage",
+            "optimize_size": "optimize build for size over speed",
+            "funroll-loops": "optimize build for speed over size",
+            "fast-math": "pass -ffast-math to compiler",
+            "insecure_build": "set flags to smallest -02 flags possible",
+            "conservative_flags": "set conservative build flags",
+            "broken_parallel_build": "disable parallelization during build",
+            "pgo": "set profile for pgo",
+            "use_clang": "add clang flags",
+            "32bit": "build 32 bit libraries",
+            "nostrip": "disable stripping binaries",
+            "verify_required": "require package verification for build",
+            "security_sensitive": "set flags for security-sensitive builds",
+            "so_to_lib": "add .so files to the lib package instead of dev",
+            "dev_requires_extras": "dev package requires the extras to be installed",
+            "autoupdate": "this package is trusted enough to automatically update (used by other tools)",
+            "compat": "this package is a library compatibility package and only ships versioned library files",
+            "nodebug": "do not generate debuginfo for this package",
+            "openmpi": "configure build also for openmpi"
+        }
+        # simple_pattern_pkgconfig patterns
+        # contains patterns for parsing build.log for missing dependencies
+        self.pkgconfig_pats = [
+            (r"which: no qmake", "Qt"),
+            (r"XInput2 extension not found", "xi"),
+            (r"checking for UDEV\.\.\. no", "udev"),
+            (r"checking for UDEV\.\.\. no", "libudev"),
+            (r"XMLLINT not set and xmllint not found in path", "libxml-2.0"),
+            (r"error\: xml2-config not found", "libxml-2.0"),
+            (r"error: must install xorg-macros", "xorg-macros")
+        ]
+        # simple_pattern patterns
+        # contains patterns for parsing build.log for missing dependencies
+        self.simple_pats = [
+            (r'warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/.*"', "docbook-xml"),
+            (r"gobject-introspection dependency was not found, gir cannot be generated.", "gobject-introspection-dev"),
+            (r"gobject-introspection dependency was not found, gir cannot be generated.", "glibc-bin"),
+            (r"Cannot find development files for any supported version of libnl", "libnl-dev"),
+            (r"/<http:\/\/www.cmake.org>", "cmake"),
+            (r"\-\- Boost libraries:", "boost-dev"),
+            (r"XInput2 extension not found", "inputproto"),
+            (r"^WARNING: could not find 'runtest'$", "dejagnu"),
+            (r"^WARNING: could not find 'runtest'$", "expect"),
+            (r"^WARNING: could not find 'runtest'$", "tcl"),
+            (r"VignetteBuilder package required for checking but installed:", "R-knitr"),
+            (r"You must have XML::Parser installed", "perl(XML::Parser)"),
+            (r"checking for Apache .* module support", "httpd-dev"),
+            (r"checking for.*in -ljpeg... no", "libjpeg-turbo-dev"),
+            (r"fatal error\: zlib\.h\: No such file or directory", "zlib-dev"),
+            (r"\* tclsh failed", "tcl"),
+            (r"\/usr\/include\/python3\.[0-9]+m\/pyconfig.h", "python3-dev"),
+            (r"checking \"location of ncurses\.h file\"", "ncurses-dev"),
+            (r"Can't exec \"aclocal\"", "automake"),
+            (r"Can't exec \"aclocal\"", "libtool"),
+            (r"configure: error: no suitable Python interpreter found", "python3-dev"),
+            (r"Checking for header Python.h", "python3-dev"),
+            (r"configure: error: No curses header-files found", "ncurses-dev"),
+            (r" \/usr\/include\/python3\.", "python3-dev"),
+            (r"to compile python extensions", "python3-dev"),
+            (r"testing autoconf... not found", "autoconf"),
+            (r"configure\: error\: could not find Python headers", "python3-dev"),
+            (r"checking for libxml libraries", "libxml2-dev"),
+            (r"checking for slang.h... no", "slang-dev"),
+            (r"configure: error: no suitable Python interpreter found", "python3"),
+            (r"configure: error: pcre-config for libpcre not found", "pcre"),
+            (r"checking for OpenSSL", "openssl-dev"),
+            (r"Package systemd was not found in the pkg-config search path.", "systemd-dev"),
+            (r"Unable to find the requested Boost libraries.", "boost-dev"),
+            (r"libproc not found. Please configure without procps", "procps-ng-dev"),
+            (r"configure: error: glib2", "glib-dev"),
+            (r"C library 'efivar' not found", "efivar-dev"),
+            (r"Has header \"efi.h\": NO", "gnu-efi-dev"),
+            (r"ERROR: Could not execute Vala compiler", "vala"),
+            (r".*: error: HAVE_INTROSPECTION does not appear in AM_CONDITIONAL", 'gobject-introspection-dev')
+        ]
+        # failed_pattern patterns
+        # contains patterns for parsing build.log for missing dependencies
+        self.failed_pats = [
+            (r"    !  ([a-zA-Z:]+) is not installed", 0, 'perl'),
+            (r"    ([a-zA-Z]+\:\:[a-zA-Z]+) not installed", 1, None),
+            (r"(?:Could|Did) (?:NOT|not) find ([a-zA-Z0-9]+)", 0, None),
+            (r" ([a-zA-Z0-9\-]*\.m4) not found", 0, None),
+            (r" exec: ([a-zA-Z0-9\-]+): not found", 0, None),
+            (r"([a-zA-Z0-9\-\_\.]*)\: command not found", 1, None),
+            (r"([a-zA-Z\-]*) (?:validation )?tool not found or not executable", 0, None),
+            (r"([a-zA-Z\-]+) [0-9\.]+ is required to configure this module; "
+             r"please install it or upgrade your CPAN\/CPANPLUS shell.", 0, None),
+            (r"-- (.*) not found.", 1, None),
+            (r".* /usr/bin/([a-zA-Z0-9-_]*).*not found", 0, None),
+            (r".*\.go:.*cannot find package \"(.*)\" in any of:", 0, 'go'),
+            (r"/usr/bin/env\: (.*)\: No such file or directory", 0, None),
+            (r"/usr/bin/python.*\: No module named (.*)", 0, None),
+            (r":in `require': cannot load such file -- ([a-zA-Z0-9\-\_:\/]+)", 0, 'ruby table'),
+            (r":in `require': cannot load such file -- ([a-zA-Z0-9\-\_:]+) ", 0, 'ruby'),
+            (r"Add the installation prefix of \"(.*)\" to CMAKE_PREFIX_PATH", 0, None),
+            (r"By not providing \"([a-zA-Z0-9]+).cmake\" in CMAKE_MODULE_PATH this project", 0, None),
+            (r"C library '(.*)' not found", 0, None),
+            (r"CMake Error at cmake\/modules\/([a-zA-Z0-9]+).cmake", 0, None),
+            (r"Can't locate [a-zA-Z0-9_\-\/\.]+ in @INC " r"\(you may need to install the ([a-zA-Z0-9_\-:]+) module\)", 0, 'perl'),
+            (r"Cannot find ([a-zA-Z0-9\-_\.]*)", 1, None),
+            (r"Checking for (.*?)\.\.\.no", 0, None),
+            (r"Checking for (.*?)\s*: not found", 0, None),
+            (r"Checking for (.*?)\s>=.*\s*: not found", 0, None),
+            (r"Could not find '([a-zA-Z0-9\-\_]*)' \([~<>=]+ ([0-9.]+).*\) among [0-9]+ total gem", 0, 'ruby'),
+            (r"Could not find gem '([a-zA-Z0-9\-\_]+) \([~<>=0-9\.\, ]+\) ruby'", 0, 'ruby'),
+            (r"Could not find suitable distribution for Requirement.parse\('([a-zA-Z\-\.]*)", 0, None),
+            (r"Download error on https://pypi.python.org/simple/([a-zA-Z0-9\-\._:]+)/", 0, 'pypi'),
+            (r"Downloading https?://.*\.python\.org/packages/.*/.?/([A-Za-z]*)/.*", 0, None),
+            (r"ERROR:  Could not find a valid gem '([a-zA-Z0-9\-\_\:]*)' \([>=]+ ([0-9.]+).*\)", 0, 'ruby'),
+            (r"ERROR: dependencies ['‘]([a-zA-Z0-9\-\.]*)['’].* are not available for package ['‘].*['’]", 0, 'R'),
+            (r"ERROR: dependencies ['‘].*['’], ['‘]([a-zA-Z0-9\-\.]*)['’],.* are not available for package ['‘].*['’]", 0, 'R'),
+            (r"ERROR: dependencies.*['‘]([a-zA-Z0-9\-\.]*)['’] are not available for package ['‘].*['’]", 0, 'R'),
+            (r"ERROR: dependency ['‘]([a-zA-Z0-9\-\.]*)['’] is not available for package ['‘].*['’]", 0, 'R'),
+            (r"Error: Unable to find (.*)", 0, None),
+            (r"Error: package ['‘]([a-zA-Z0-9\-\.]*)['’] required by", 0, 'R'),
+            (r"Gem::LoadError: Could not find '([a-zA-Z0-9\-\_]*)'", 0, 'ruby'),
+            (r"ImportError:.* No module named '?([a-zA-Z0-9\-\._]+)'?", 0, 'pypi'),
+            (r"ImportError\: ([a-zA-Z]+) module missing", 0, None),
+            (r"ImportError\: (?:No module|cannot import) named? (.*)", 0, None),
+            (r"LoadError: cannot load such file -- ([a-zA-Z0-9\-:\/\_]+)", 0, 'ruby table'),
+            (r"LoadError: cannot load such file -- ([a-zA-Z0-9\-:]+)/.*", 0, 'ruby'),
+            (r"ModuleNotFoundError.*No module named (.*)", 0, None),
+            (r"Native dependency '(.*)' not found", 0, "pkgconfig"),
+            (r"No library found for -l([a-zA-Z\-])", 0, None),
+            (r"No (?:matching distribution|local packages or working download links) found for ([a-zA-Z0-9\-\.\_]+)", 0, 'pypi'),
+            (r"No package '([a-zA-Z0-9\-:]*)' found", 0, 'pkgconfig'),
+            (r"No rule to make target `(.*)',", 0, None),
+            (r"Package '([a-zA-Z0-9\-:]*)', required by '.*', not found", 0, 'pkgconfig'),
+            (r"Package which this enhances but not available for checking: ['‘]([a-zA-Z0-9\-]*)['’]", 0, 'R'),
+            (r"Perhaps you should add the directory containing `([a-zA-Z0-9\-:]*)\.pc'", 0, 'pkgconfig'),
+            (r"Program (.*) found: NO", 0, None),
+            (r"Target '[a-zA-Z0-9\-]' can't be generated as '(.*)' could not be found", 0, None),
+            (r"Unable to `import (.*)`", 0, None),
+            (r"Unable to find '(.*)'", 0, None),
+            (r"Unknown packages? ['‘]([a-zA-Z0-9\-]*)['’].* in Rd xrefs", 0, 'R'),
+            (r"WARNING:  [a-zA-Z\-\_]+ dependency on ([a-zA-Z0-9\-\_:]*) \([<>=~]+ ([0-9.]+).*\) .*", 0, 'ruby'),
+            (r"Warning: prerequisite ([a-zA-Z:]+) [0-9\.]+ not found.", 0, 'perl'),
+            (r"Warning\: no usable ([a-zA-Z0-9]+) found", 0, None),
+            (r"You need ([a-zA-Z0-9\-\_]*) to build this program.", 1, None),
+            (r"[Dd]ependency (.*) found: NO \(tried pkgconfig(?: and cmake)?\)", 0, 'pkgconfig'),
+            (r"[Dd]ependency (.*) found: NO", 0, None),
+            (r"[a-zA-Z0-9\-:]* is not installed: cannot load such file -- rdoc/([a-zA-Z0-9\-:]*)", 0, 'ruby'),
+            (r"\-\- Could NOT find ([a-zA-Z0-9]+)", 0, None),
+            (r"\/bin\/ld: cannot find (-l[a-zA-Z0-9\_]+)", 0, None),
+            (r"^.*By not providing \"Find(.*).cmake\" in CMAKE_MODULE_PATH this.*$", 0, None),
+            (r"^.*Could not find a package configuration file provided by \"(.*)\".*$", 0, None),
+            (r"^.*\"(.*)\" with any of the following names.*$", 0, None),
+            (r"[Cc]hecking for (.*) (?:support|development files|with pkg-config)?\.\.\. [Nn]o", 0, None),
+            (r"checking (.*?)\.\.\. no", 0, None),
+            (r"checking for (.*) in default path\.\.\. not found", 0, None),
+            (r"checking for (.*)... configure: error", 0, None),
+            (r"checking for (.*?)\.\.\. no", 0, None),
+            (r"checking for [a-zA-Z0-9\_\-]+ in (.*?)\.\.\. no", 0, None),
+            (r"checking for library containing (.*)... no", 0, None),
+            (r"checking for perl module ([a-zA-Z:]+) [0-9\.]+... no", 0, 'perl'),
+            (r"configure: error: (?:pkg-config missing|Unable to locate) (.*)", 0, None),
+            (r"configure: error: ([a-zA-Z0-9]+) (?:is required to build|not found)", 0, None),
+            (r"configure: error: Cannot find (.*)\. Make sure", 0, None),
+            (r"fatal error\: (.*)\: No such file or directory", 0, None),
+            (r"make: ([a-zA-Z0-9].+): Command not found", 0, None),
+            (r"meson\.build\:[\d]+\:[\d]+\: ERROR: C library \'(.*)\' not found", 0, None),
+            (r"there is no package called ['‘]([a-zA-Z0-9\-\.]*)['’]", 0, 'R'),
+            (r"unable to execute '([a-zA-Z\-]*)': No such file or directory", 0, None),
+            (r"warning: failed to load external entity " r"\"(/usr/share/sgml/docbook/xsl-stylesheets)/.*\"", 0, None),
+            (r"which\: no ([a-zA-Z\-]*) in \(", 0, None),
+            (r"you may need to install the ([a-zA-Z0-9_\-:\.]*) module", 0, 'perl'),
+        ]
 
+    def get_metadata_conf(self):
+        """Gather package metadata from the tarball module."""
+        metadata = {}
+        metadata['name'] = tarball.name
+        if self.urlban:
+            metadata['url'] = re.sub(self.urlban, "localhost", tarball.url)
+            metadata['archives'] = re.sub(self.urlban, "localhost", " ".join(tarball.archives))
+        else:
+            metadata['url'] = tarball.url
+            metadata['archives'] = " ".join(tarball.archives)
 
-def parse_existing_spec(path, name):
-    """Determine the old version, old patch list, old keyid, and cves from old spec file."""
-    global old_version
-    global old_patches
-    global old_keyid
-    global cves
+        metadata['giturl'] = tarball.giturl
+        metadata['domain'] = tarball.domain
 
-    spec = os.path.join(path, "{}.spec".format(name))
-    if not os.path.exists(spec):
-        return
+        if self.alias:
+            metadata['alias'] = self.alias
+        else:
+            metadata['alias'] = ""
+        return metadata
 
-    found_old_version = False
-    found_old_patches = False
-    ver_regex = r"^Version *: *(.*) *$"
-    patch_regex = r"^Patch[0-9]* *: *(.*) *$"
+    def rewrite_config_opts(self, path):
+        """Rewrite options.conf file when an option has changed (verify_required for example)."""
+        config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
+        config_f['package'] = self.get_metadata_conf()
+        config_f['autospec'] = {}
 
-    # If git history exists, read the Version and Patch* spec header fields
-    # from the latest commit to take priority over the working copy.
-    cmd = ["git", "-C", path, "grep", "-E", "-h", ver_regex, "HEAD", spec]
-    result = subprocess.run(cmd, capture_output=True)
-    if result.returncode == 0:
-        # The first matching line is from the spec header (hopefully)
-        line = result.stdout.decode().split("\n")[0]
-        m = re.search(ver_regex, line)
-        if m:
-            old_version = m.group(1)
-            found_old_version = True
+        # Populate missing configuration options
+        # (in case of a user-created options.conf)
+        missing = set(self.config_options.keys()).difference(set(self.config_opts.keys()))
+        for option in missing:
+            self.config_opts[option] = False
 
-    cmd = ["git", "-C", path, "grep", "-E", "-h", patch_regex, "HEAD", spec]
-    result = subprocess.run(cmd, capture_output=True)
-    if result.returncode == 0:
-        lines = result.stdout.decode().split("\n")
-        for line in lines:
-            m = re.search(patch_regex, line)
-            if m:
-                old_patches.append(m.group(1).lower())
-                found_old_patches = True
+        for fname, comment in sorted(self.config_options.items()):
+            config_f.set('autospec', '# {}'.format(comment))
+            config_f['autospec'][fname] = 'true' if self.config_opts[fname] else 'false'
+        write_config(config_f, path)
 
-    with open_auto(spec, "r") as inp:
-        for line in inp.readlines():
-            line = line.strip().replace("\r", "").replace("\n", "")
-            if "Source0 file verified with key" in line:
-                keyidx = line.find('0x') + 2
-                old_keyid = line[keyidx:].split()[0] if keyidx > 2 else old_keyid
-            # As a fallback, read the Version and Patch* header fields from the
-            # working copy of the spec, in case a git repo does not exist.
-            m = re.search(ver_regex, line)
-            if m and not found_old_version:
-                old_version = m.group(1)
-                found_old_version = True
-            m = re.search(patch_regex, line)
-            if m and not found_old_patches:
-                old_patches.append(m.group(1).lower())
+    def create_conf(self, path):
+        """Create options.conf file and use deprecated configuration files or defaults to populate."""
+        config_f = configparser.ConfigParser(interpolation=None, allow_no_value=True)
 
-    # Ignore nopatch
-    for patch in patches:
-        patch = patch.lower()
-        if patch not in old_patches and patch.endswith(".patch") and patch.startswith("cve-"):
-            cves.append(patch.upper().split(".PATCH")[0])
+        # first the metadata
+        config_f['package'] = self.get_metadata_conf()
 
-
-def parse_config_versions(path):
-    """Parse the versions configuration file."""
-    global versions
-    global parsed_versions
-
-    # Only actually parse it the first time around
-    if not parsed_versions:
-        for line in read_conf_file(os.path.join(path, "versions")):
-            # Simply whitespace-separated fields
-            fields = line.split()
-            version = fields.pop(0)
-            if len(fields):
-                url = fields.pop(0)
+        # next the options
+        config_f['autospec'] = {}
+        for fname, comment in sorted(self.config_options.items()):
+            config_f.set('autospec', '# {}'.format(comment))
+            if os.path.exists(fname):
+                config_f['autospec'][fname] = 'true'
+                os.remove(fname)
             else:
-                url = ""
-            # Catch and report duplicate URLs in the versions file. Don't stop,
-            # but assume only the first one is valid and drop the rest.
-            if version in parsed_versions and url != parsed_versions[version]:
-                print_warning("Already have a URL defined for {}: {}"
-                              .format(version, parsed_versions[version]))
-                print_warning("Dropping {}, but you should check my work"
-                              .format(url))
-            else:
-                parsed_versions[version] = url
-            if len(fields):
-                print_warning("Extra fields detected in `versions` file entry:\n{}"
-                              .format(line))
-                print_warning("I'll delete them, but you should check my work")
+                config_f['autospec'][fname] = 'false'
 
-    # We'll combine what we just parsed from the versions file with any other
-    # versions that have already been defined, most likely the version actually
-    # provided in the Makefile's URL variable, so we don't drop any.
-    for version in parsed_versions:
-        versions[version] = parsed_versions[version]
+        # default lto to true for new things
+        config_f['autospec']['use_lto'] = 'true'
 
-    return versions
+        # renamed options need special care
+        if os.path.exists("skip_test_suite"):
+            config_f['autospec']['skip_tests'] = 'true'
+            os.remove("skip_test_suite")
+        write_config(config_f, path)
 
+    def create_buildreq_cache(self, path, version):
+        """Make the buildreq_cache file."""
+        content = self.read_conf_file(os.path.join(path, "buildreq_cache"))
+        # don't create an empty cache file
+        if len(buildreq.buildreqs_cache) < 1:
+            try:
+                # file was possibly added to git so we should clean it up
+                os.unlink(content)
+            except Exception:
+                pass
+            return
+        if not content:
+            pkgs = sorted(buildreq.buildreqs_cache)
+        else:
+            pkgs = sorted(set(content[1:]).union(buildreq.buildreqs_cache))
+        with open(os.path.join(path, 'buildreq_cache'), "w") as cachefile:
+            cachefile.write("\n".join([version] + pkgs))
+        self.config_files.add('buildreq_cache')
 
-def parse_config_files(path, bump, filemanager, version):
-    """Parse the various configuration files that may exist in the package directory."""
-    global extra_configure
-    global extra_configure32
-    global extra_configure64
-    global extra_configure_avx2
-    global extra_configure_avx512
-    global extra_configure_openmpi
-    global config_files
-    global extra_sources
-    global parallel_build
-    global license_fetch
-    global license_show
-    global git_uri
-    global os_packages
-    global urlban
-    global config_file
-    global profile_payload
-    global config_opts
-    global extra_make
-    global extra32_make
-    global extra_make_install
-    global extra_make32_install
-    global extra_cmake
-    global extra_cmake_openmpi
-    global cmake_srcdir
-    global subdir
-    global install_macro
-    global disable_static
-    global prep_prepend
-    global build_prepend
-    global build_append
-    global make_prepend
-    global install_prepend
-    global install_append
-    global service_restart
-    global patches
-    global autoreconf
-    global set_gopath
-    global yum_conf
-    global custom_desc
-    global custom_summ
-    global failed_pattern_dir
-    global versions
+    def create_versions(self, path, versions):
+        """Make versions file."""
+        with open(os.path.join(path, "versions"), 'w') as vfile:
+            for version in versions:
+                vfile.write(version)
+                if versions[version]:
+                    vfile.write('\t' + versions[version])
+                vfile.write('\n')
+        self.config_files.add("versions")
 
-    packages_file = None
+    def read_config_opts(self, path):
+        """Read config options from path/options.conf."""
+        opts_path = os.path.join(path, 'options.conf')
+        if not os.path.exists(opts_path):
+            self.create_conf(path)
 
-    # Require autospec.conf for additional features
-    if os.path.exists(config_file):
-        config = configparser.ConfigParser(interpolation=None)
-        config.read(config_file)
-
-        if "autospec" not in config.sections():
-            print("Missing autospec section..")
+        config_f = configparser.ConfigParser(interpolation=None)
+        config_f.read(opts_path)
+        if "autospec" not in config_f.sections():
+            print("Missing autospec section in options.conf")
             sys.exit(1)
 
-        git_uri = config['autospec'].get('git', None)
-        license_fetch = config['autospec'].get('license_fetch', None)
-        license_show = config['autospec'].get('license_show', None)
-        packages_file = config['autospec'].get('packages_file', None)
-        yum_conf = config['autospec'].get('yum_conf', None)
-        failed_pattern_dir = config['autospec'].get('failed_pattern_dir', None)
+        if 'package' in config_f.sections() and config_f['package'].get('alias'):
+            self.alias = config_f['package']['alias']
 
-        # support reading the local files relative to config_file
-        if packages_file and not os.path.isabs(packages_file):
-            packages_file = os.path.join(os.path.dirname(config_file), packages_file)
-        if yum_conf and not os.path.isabs(yum_conf):
-            yum_conf = os.path.join(os.path.dirname(config_file), yum_conf)
-        if failed_pattern_dir and not os.path.isabs(failed_pattern_dir):
-            failed_pattern_dir = os.path.join(os.path.dirname(config_file), failed_pattern_dir)
+        for key in config_f['autospec']:
+            self.config_opts[key] = config_f['autospec'].getboolean(key)
 
-        if not packages_file:
-            print("Warning: Set [autospec][packages_file] path to package list file for "
-                  "requires validation")
-            packages_file = os.path.join(os.path.dirname(config_file), "packages")
+        # Rewrite the configuration file in case of formatting changes since a
+        # configuration file may exist without any comments (either due to an older
+        # version of autospec or if it was user-created)
+        self.rewrite_config_opts(path)
 
-        urlban = config['autospec'].get('urlban', None)
+        # Don't use the ChangeLog files if the giturl is set
+        # ChangeLog is just extra noise when we can already see the gitlog
+        if "package" in config_f.sections() and config_f['package'].get('giturl'):
+            keys = []
+            for k, v in self.transforms.items():
+                if v == "ChangeLog":
+                    keys.append(k)
+            for k in keys:
+                self.transforms.pop(k)
 
-    # Read values from options.conf (and deprecated files) and rewrite as necessary
-    read_config_opts(path)
+    def read_file(self, path, track=True):
+        """Read full file at path.
 
-    if not git_uri:
-        print("Warning: Set [autospec][git] upstream template for remote git URI configuration")
-    if not license_fetch:
-        print("Warning: Set [autospec][license_fetch] uri for license fetch support")
-    if not license_show:
-        print("Warning: Set [autospec][license_show] uri for license link check support")
-    if not yum_conf:
-        print("Warning: Set [autospec][yum_conf] path to yum.conf file for whatrequires validation")
-        yum_conf = os.path.join(os.path.dirname(config_file), "image-creator/yum.conf")
+        If the file does not exist (or is not expected to exist)
+        in the package git repo, specify 'track=False'.
+        """
+        try:
+            with open(path, "r") as f:
+                if track:
+                    self.config_files.add(os.path.basename(path))
+                return f.readlines()
+        except EnvironmentError:
+            return []
 
-    if packages_file:
-        os_packages = set(read_conf_file(packages_file, track=False))
-    else:
-        os_packages = set(read_conf_file("~/packages", track=False))
+    def read_conf_file(self, path, track=True):
+        """Read configuration file at path.
 
-    wrapper = textwrap.TextWrapper()
-    wrapper.initial_indent = "# "
-    wrapper.subsequent_indent = "# "
+        If the config file does not exist (or is not expected to exist)
+        in the package git repo, specify 'track=False'.
+        """
+        lines = self.read_file(path, track=track)
+        return [l.strip() for l in lines if not l.strip().startswith("#") and l.split()]
 
-    def write_default_conf_file(name, description):
+    def read_script_file(self, path, track=True):
+        """Read RPM script snippet file at path.
+
+        Returns verbatim, except for possibly the first line.
+
+        If the config file does not exist (or is not expected to exist)
+        in the package git repo, specify 'track=False'.
+        """
+        lines = self.read_file(path, track=track)
+        if len(lines) > 0 and (lines[0].startswith('#!') or lines[0].startswith('# -*- ')):
+            lines = lines[1:]
+        # Remove any trailing whitespace and newlines. The newlines are later
+        # restored by writer functions.
+        return [line.rstrip() for line in lines]
+
+    def setup_patterns(self, path=None):
+        """Read each pattern configuration file and assign to the appropriate variable."""
+        read_pattern_conf("ignored_commands", self.ignored_commands, list_format=True, path=path)
+        read_pattern_conf("failed_commands", self.failed_commands, path=path)
+        read_pattern_conf("maven_jars", self.maven_jars, path=path)
+        read_pattern_conf("gems", self.gems, path=path)
+        read_pattern_conf("license_hashes", self.license_hashes, path=path)
+        read_pattern_conf("license_translations", self.license_translations, path=path)
+        read_pattern_conf("license_blacklist", self.license_blacklist, list_format=True, path=path)
+        read_pattern_conf("qt_modules", self.qt_modules, path=path)
+        read_pattern_conf("cmake_modules", self.cmake_modules, path=path)
+
+    def parse_existing_spec(self, path, name):
+        """Determine the old version, old patch list, old keyid, and cves from old spec file."""
+        spec = os.path.join(path, "{}.spec".format(name))
+        if not os.path.exists(spec):
+            return
+
+        found_old_version = False
+        found_old_patches = False
+        ver_regex = r"^Version *: *(.*) *$"
+        patch_regex = r"^Patch[0-9]* *: *(.*) *$"
+
+        # If git history exists, read the Version and Patch* spec header fields
+        # from the latest commit to take priority over the working copy.
+        cmd = ["git", "-C", path, "grep", "-E", "-h", ver_regex, "HEAD", spec]
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode == 0:
+            # The first matching line is from the spec header (hopefully)
+            line = result.stdout.decode().split("\n")[0]
+            m = re.search(ver_regex, line)
+            if m:
+                self.old_version = m.group(1)
+                found_old_version = True
+
+        cmd = ["git", "-C", path, "grep", "-E", "-h", patch_regex, "HEAD", spec]
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode == 0:
+            lines = result.stdout.decode().split("\n")
+            for line in lines:
+                m = re.search(patch_regex, line)
+                if m:
+                    self.old_patches.append(m.group(1).lower())
+                    found_old_patches = True
+
+        with open_auto(spec, "r") as inp:
+            for line in inp.readlines():
+                line = line.strip().replace("\r", "").replace("\n", "")
+                if "Source0 file verified with key" in line:
+                    keyidx = line.find('0x') + 2
+                    self.old_keyid = line[keyidx:].split()[0] if keyidx > 2 else self.old_keyid
+                # As a fallback, read the Version and Patch* header fields from the
+                # working copy of the spec, in case a git repo does not exist.
+                m = re.search(ver_regex, line)
+                if m and not found_old_version:
+                    self.old_version = m.group(1)
+                    found_old_version = True
+                m = re.search(patch_regex, line)
+                if m and not found_old_patches:
+                    self.old_patches.append(m.group(1).lower())
+
+        # Ignore nopatch
+        for patch in self.patches:
+            patch = patch.lower()
+            if patch not in self.old_patches and patch.endswith(".patch") and patch.startswith("cve-"):
+                self.cves.append(patch.upper().split(".PATCH")[0])
+
+    def parse_config_versions(self, path):
+        """Parse the versions configuration file."""
+        # Only actually parse it the first time around
+        if not self.parsed_versions:
+            for line in self.read_conf_file(os.path.join(path, "versions")):
+                # Simply whitespace-separated fields
+                fields = line.split()
+                version = fields.pop(0)
+                if len(fields):
+                    url = fields.pop(0)
+                else:
+                    url = ""
+                # Catch and report duplicate URLs in the versions file. Don't stop,
+                # but assume only the first one is valid and drop the rest.
+                if version in self.parsed_versions and url != self.parsed_versions[version]:
+                    print_warning("Already have a URL defined for {}: {}"
+                                  .format(version, self.parsed_versions[version]))
+                    print_warning("Dropping {}, but you should check my work"
+                                  .format(url))
+                else:
+                    self.parsed_versions[version] = url
+                if len(fields):
+                    print_warning("Extra fields detected in `versions` file entry:\n{}"
+                                  .format(line))
+                    print_warning("I'll delete them, but you should check my work")
+
+        # We'll combine what we just parsed from the versions file with any other
+        # versions that have already been defined, most likely the version actually
+        # provided in the Makefile's URL variable, so we don't drop any.
+        for version in self.parsed_versions:
+            self.versions[version] = self.parsed_versions[version]
+
+        return self.versions
+
+    def write_default_conf_file(self, path, name, wrapper, description):
         """Write default configuration file with description to file name."""
-        config_files.add(name)
+        self.config_files.add(name)
         filename = os.path.join(path, name)
         if os.path.isfile(filename):
             return
 
         write_out(filename, wrapper.fill(description) + "\n")
 
-    write_default_conf_file("buildreq_ban",
-                            "This file contains build requirements that get picked up but are "
-                            "undesirable. One entry per line, no whitespace.")
-    write_default_conf_file("pkgconfig_ban",
-                            "This file contains pkgconfig build requirements that get picked up but"
-                            " are undesirable. One entry per line, no whitespace.")
-    write_default_conf_file("requires_ban",
-                            "This file contains runtime requirements that get picked up but are "
-                            "undesirable. One entry per line, no whitespace.")
-    write_default_conf_file("buildreq_add",
-                            "This file contains additional build requirements that did not get "
-                            "picked up automatically. One name per line, no whitespace.")
-    write_default_conf_file("pkgconfig_add",
-                            "This file contains additional pkgconfig build requirements that did "
-                            "not get picked up automatically. One name per line, no whitespace.")
-    write_default_conf_file("requires_add",
-                            "This file contains additional runtime requirements that did not get "
-                            "picked up automatically. One name per line, no whitespace.")
-    write_default_conf_file("excludes",
-                            "This file contains the output files that need %exclude. Full path "
-                            "names, one per line.")
+    def parse_config_files(self, path, bump, filemanager, version):
+        """Parse the various configuration files that may exist in the package directory."""
+        packages_file = None
 
-    content = read_conf_file(os.path.join(path, "release"))
-    if content and content[0]:
-        r = int(content[0])
-        if bump:
-            r += 1
-        tarball.release = str(r)
-        print("Release     :", tarball.release)
+        # Require autospec.conf for additional features
+        if os.path.exists(self.config_file):
+            config = configparser.ConfigParser(interpolation=None)
+            config.read(self.config_file)
 
-    content = read_conf_file(os.path.join(path, "extra_sources"))
-    for source in content:
-        fields = source.split(maxsplit=1)
-        print("Adding additional source file: %s" % fields[0])
-        config_files.add(os.path.basename(fields[0]))
-        extra_sources.append(fields)
+            if "autospec" not in config.sections():
+                print("Missing autospec section..")
+                sys.exit(1)
 
-    content = read_conf_file(os.path.join(path, "buildreq_ban"))
-    for banned in content:
-        print("Banning build requirement: %s." % banned)
-        buildreq.banned_buildreqs.add(banned)
-        buildreq.buildreqs.discard(banned)
-        buildreq.buildreqs_cache.discard(banned)
+            self.git_uri = config['autospec'].get('git', None)
+            self.license_fetch = config['autospec'].get('license_fetch', None)
+            self.license_show = config['autospec'].get('license_show', None)
+            packages_file = config['autospec'].get('packages_file', None)
+            self.yum_conf = config['autospec'].get('yum_conf', None)
+            self.failed_pattern_dir = config['autospec'].get('failed_pattern_dir', None)
 
-    content = read_conf_file(os.path.join(path, "pkgconfig_ban"))
-    for banned in content:
-        banned = "pkgconfig(%s)" % banned
-        print("Banning build requirement: %s." % banned)
-        buildreq.banned_buildreqs.add(banned)
-        buildreq.buildreqs.discard(banned)
-        buildreq.buildreqs_cache.discard(banned)
+            # support reading the local files relative to config_file
+            if packages_file and not os.path.isabs(packages_file):
+                packages_file = os.path.join(os.path.dirname(self.config_file), packages_file)
+            if self.yum_conf and not os.path.isabs(self.yum_conf):
+                self.yum_conf = os.path.join(os.path.dirname(self.config_file), self.yum_conf)
+            if self.failed_pattern_dir and not os.path.isabs(self.failed_pattern_dir):
+                self.failed_pattern_dir = os.path.join(os.path.dirname(self.config_file), self.failed_pattern_dir)
 
-    content = read_conf_file(os.path.join(path, "requires_ban"))
-    for banned in content:
-        print("Banning runtime requirement: %s." % banned)
-        buildreq.banned_requires.add(banned)
-        buildreq.requires.discard(banned)
+            if not packages_file:
+                print("Warning: Set [autospec][packages_file] path to package list file for "
+                      "requires validation")
+                packages_file = os.path.join(os.path.dirname(self.config_file), "packages")
 
-    content = read_conf_file(os.path.join(path, "buildreq_add"))
-    for extra in content:
-        print("Adding additional build requirement: %s." % extra)
-        buildreq.add_buildreq(extra)
+            self.urlban = config['autospec'].get('urlban', None)
 
-    cache_file = os.path.join(path, "buildreq_cache")
-    content = read_conf_file(cache_file)
-    if content and content[0] == version:
-        for extra in content[1:]:
-            print("Adding additional build (cache) requirement: %s." % extra)
+        # Read values from options.conf (and deprecated files) and rewrite as necessary
+        self.read_config_opts(path)
+
+        if not self.git_uri:
+            print("Warning: Set [autospec][git] upstream template for remote git URI configuration")
+        if not self.license_fetch:
+            print("Warning: Set [autospec][license_fetch] uri for license fetch support")
+        if not self.license_show:
+            print("Warning: Set [autospec][license_show] uri for license link check support")
+        if not self.yum_conf:
+            print("Warning: Set [autospec][yum_conf] path to yum.conf file for whatrequires validation")
+            self.yum_conf = os.path.join(os.path.dirname(self.config_file), "image-creator/yum.conf")
+
+        if packages_file:
+            self.os_packages = set(self.read_conf_file(packages_file, track=False))
+        else:
+            self.os_packages = set(self.read_conf_file("~/packages", track=False))
+
+        wrapper = textwrap.TextWrapper()
+        wrapper.initial_indent = "# "
+        wrapper.subsequent_indent = "# "
+
+        self.write_default_conf_file(path, "buildreq_ban", wrapper,
+                                     "This file contains build requirements that get picked up but are "
+                                     "undesirable. One entry per line, no whitespace.")
+        self.write_default_conf_file(path, "pkgconfig_ban", wrapper,
+                                     "This file contains pkgconfig build requirements that get picked up but"
+                                     " are undesirable. One entry per line, no whitespace.")
+        self.write_default_conf_file(path, "requires_ban", wrapper,
+                                     "This file contains runtime requirements that get picked up but are "
+                                     "undesirable. One entry per line, no whitespace.")
+        self.write_default_conf_file(path, "buildreq_add", wrapper,
+                                     "This file contains additional build requirements that did not get "
+                                     "picked up automatically. One name per line, no whitespace.")
+        self.write_default_conf_file(path, "pkgconfig_add", wrapper,
+                                     "This file contains additional pkgconfig build requirements that did "
+                                     "not get picked up automatically. One name per line, no whitespace.")
+        self.write_default_conf_file(path, "requires_add", wrapper,
+                                     "This file contains additional runtime requirements that did not get "
+                                     "picked up automatically. One name per line, no whitespace.")
+        self.write_default_conf_file(path, "excludes", wrapper,
+                                     "This file contains the output files that need %exclude. Full path "
+                                     "names, one per line.")
+
+        content = self.read_conf_file(os.path.join(path, "release"))
+        if content and content[0]:
+            r = int(content[0])
+            if bump:
+                r += 1
+            tarball.release = str(r)
+            print("Release     :", tarball.release)
+
+        content = self.read_conf_file(os.path.join(path, "extra_sources"))
+        for source in content:
+            fields = source.split(maxsplit=1)
+            print("Adding additional source file: %s" % fields[0])
+            self.config_files.add(os.path.basename(fields[0]))
+            self.extra_sources.append(fields)
+
+        content = self.read_conf_file(os.path.join(path, "buildreq_ban"))
+        for banned in content:
+            print("Banning build requirement: %s." % banned)
+            buildreq.banned_buildreqs.add(banned)
+            buildreq.buildreqs.discard(banned)
+            buildreq.buildreqs_cache.discard(banned)
+
+        content = self.read_conf_file(os.path.join(path, "pkgconfig_ban"))
+        for banned in content:
+            banned = "pkgconfig(%s)" % banned
+            print("Banning build requirement: %s." % banned)
+            buildreq.banned_buildreqs.add(banned)
+            buildreq.buildreqs.discard(banned)
+            buildreq.buildreqs_cache.discard(banned)
+
+        content = self.read_conf_file(os.path.join(path, "requires_ban"))
+        for banned in content:
+            print("Banning runtime requirement: %s." % banned)
+            buildreq.banned_requires.add(banned)
+            buildreq.requires.discard(banned)
+
+        content = self.read_conf_file(os.path.join(path, "buildreq_add"))
+        for extra in content:
+            print("Adding additional build requirement: %s." % extra)
             buildreq.add_buildreq(extra)
-    else:
-        try:
-            os.unlink(cache_file)
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            print_warning(f"Unable to remove buildreq_cache file: {e}")
 
-    content = read_conf_file(os.path.join(path, "pkgconfig_add"))
-    for extra in content:
-        extra = "pkgconfig(%s)" % extra
-        print("Adding additional build requirement: %s." % extra)
-        buildreq.add_buildreq(extra)
+        cache_file = os.path.join(path, "buildreq_cache")
+        content = self.read_conf_file(cache_file)
+        if content and content[0] == version:
+            for extra in content[1:]:
+                print("Adding additional build (cache) requirement: %s." % extra)
+                buildreq.add_buildreq(extra)
+        else:
+            try:
+                os.unlink(cache_file)
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                print_warning(f"Unable to remove buildreq_cache file: {e}")
 
-    content = read_conf_file(os.path.join(path, "requires_add"))
-    for extra in content:
-        print("Adding additional runtime requirement: %s." % extra)
-        buildreq.add_requires(extra, override=True)
+        content = self.read_conf_file(os.path.join(path, "pkgconfig_add"))
+        for extra in content:
+            extra = "pkgconfig(%s)" % extra
+            print("Adding additional build requirement: %s." % extra)
+            buildreq.add_buildreq(extra)
 
-    content = read_conf_file(os.path.join(path, "excludes"))
-    for exclude in content:
-        print("%%exclude for: %s." % exclude)
-    filemanager.excludes += content
+        content = self.read_conf_file(os.path.join(path, "requires_add"))
+        for extra in content:
+            print("Adding additional runtime requirement: %s." % extra)
+            buildreq.add_requires(extra, self.os_packages, override=True)
 
-    content = read_conf_file(os.path.join(path, "extras"))
-    for extra in content:
-        print("extras for  : %s." % extra)
-    filemanager.extras += content
+        content = self.read_conf_file(os.path.join(path, "excludes"))
+        for exclude in content:
+            print("%%exclude for: %s." % exclude)
+        filemanager.excludes += content
 
-    for fname in os.listdir(path):
-        if not re.search('.+_extras$', fname) or fname == "dev_extras":
-            continue
-        content = {}
-        content['files'] = read_conf_file(os.path.join(path, fname))
-        if not content:
-            print_warning(f"Error reading custom extras file: {fname}")
-            continue
-        req_file = os.path.join(path, f'{fname}_requires')
-        if os.path.isfile(req_file):
-            content['requires'] = read_conf_file(req_file)
-        name = fname[:-len("_extras")]
-        print(f"extras-{name} for {content['files']}")
-        filemanager.custom_extras["extras-" + f"{name}"] = content
+        content = self.read_conf_file(os.path.join(path, "extras"))
+        for extra in content:
+            print("extras for  : %s." % extra)
+        filemanager.extras += content
 
-    content = read_conf_file(os.path.join(path, "dev_extras"))
-    for extra in content:
-        print("dev for     : %s." % extra)
-    filemanager.dev_extras += content
+        for fname in os.listdir(path):
+            if not re.search('.+_extras$', fname) or fname == "dev_extras":
+                continue
+            content = {}
+            content['files'] = self.read_conf_file(os.path.join(path, fname))
+            if not content:
+                print_warning(f"Error reading custom extras file: {fname}")
+                continue
+            req_file = os.path.join(path, f'{fname}_requires')
+            if os.path.isfile(req_file):
+                content['requires'] = self.read_conf_file(req_file)
+            name = fname[:-len("_extras")]
+            print(f"extras-{name} for {content['files']}")
+            filemanager.custom_extras["extras-" + f"{name}"] = content
 
-    content = read_conf_file(os.path.join(path, "setuid"))
-    for suid in content:
-        print("setuid for  : %s." % suid)
-    filemanager.setuid += content
+        content = self.read_conf_file(os.path.join(path, "dev_extras"))
+        for extra in content:
+            print("dev for     : %s." % extra)
+        filemanager.dev_extras += content
 
-    content = read_conf_file(os.path.join(path, "attrs"))
-    for line in content:
-        attr = line.split()
-        filename = attr.pop()
-        print("%attr({0},{1},{2}) for: {3}".format(
-            attr[0], attr[1], attr[2], filename))
-        filemanager.attrs[filename] = attr
+        content = self.read_conf_file(os.path.join(path, "setuid"))
+        for suid in content:
+            print("setuid for  : %s." % suid)
+        filemanager.setuid += content
 
-    patches += read_conf_file(os.path.join(path, "series"))
-    pfiles = [("%s/%s" % (path, x.split(" ")[0])) for x in patches]
-    cmd = "egrep \"(\+\+\+|\-\-\-).*((Makefile.am)|(aclocal.m4)|(configure.ac|configure.in))\" %s" % " ".join(pfiles)  # noqa: W605
-    if patches and call(cmd,
-                        check=False,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL) == 0:
-        autoreconf = True
+        content = self.read_conf_file(os.path.join(path, "attrs"))
+        for line in content:
+            attr = line.split()
+            filename = attr.pop()
+            print("%attr({0},{1},{2}) for: {3}".format(
+                attr[0], attr[1], attr[2], filename))
+            filemanager.attrs[filename] = attr
 
-    # Parse the version-specific patch lists
-    update_security_sensitive = False
-    for version in versions:
-        verpatches[version] = read_conf_file(os.path.join(path, '.'.join(['series', version])))
-        if any(p.lower().startswith('cve-') for p in verpatches[version]):
+        self.patches += self.read_conf_file(os.path.join(path, "series"))
+        pfiles = [("%s/%s" % (path, x.split(" ")[0])) for x in self.patches]
+        cmd = "egrep \"(\+\+\+|\-\-\-).*((Makefile.am)|(aclocal.m4)|(configure.ac|configure.in))\" %s" % " ".join(pfiles)  # noqa: W605
+        if self.patches and call(cmd,
+                                 check=False,
+                                 stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL) == 0:
+            self.autoreconf = True
+
+        # Parse the version-specific patch lists
+        update_security_sensitive = False
+        for version in self.versions:
+            self.verpatches[version] = self.read_conf_file(os.path.join(path, '.'.join(['series', version])))
+            if any(p.lower().startswith('cve-') for p in self.verpatches[version]):
+                update_security_sensitive = True
+
+        if any(p.lower().startswith('cve-') for p in self.patches):
             update_security_sensitive = True
 
-    if any(p.lower().startswith('cve-') for p in patches):
-        update_security_sensitive = True
+        if update_security_sensitive:
+            self.config_opts['security_sensitive'] = True
+            self.rewrite_config_opts(path)
 
-    if update_security_sensitive:
-        config_opts['security_sensitive'] = True
-        rewrite_config_opts(path)
+        content = self.read_conf_file(os.path.join(path, "configure"))
+        self.extra_configure = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure"))
-    extra_configure = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "configure32"))
+        self.extra_configure32 = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure32"))
-    extra_configure32 = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "configure64"))
+        self.extra_configure64 = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure64"))
-    extra_configure64 = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "configure_avx2"))
+        self.extra_configure_avx2 = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure_avx2"))
-    extra_configure_avx2 = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "configure_avx512"))
+        self.extra_configure_avx512 = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure_avx512"))
-    extra_configure_avx512 = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "configure_openmpi"))
+        self.extra_configure_openmpi = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "configure_openmpi"))
-    extra_configure_openmpi = " \\\n".join(content)
+        if self.config_opts["keepstatic"]:
+            self.disable_static = ""
+        if self.config_opts['broken_parallel_build']:
+            self.parallel_build = ""
 
-    if config_opts["keepstatic"]:
-        disable_static = ""
-    if config_opts['broken_parallel_build']:
-        parallel_build = ""
+        content = self.read_conf_file(os.path.join(path, "make_args"))
+        if content:
+            self.extra_make = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "make_args"))
-    if content:
-        extra_make = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "make32_args"))
+        if content:
+            self.extra32_make = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "make32_args"))
-    if content:
-        extra32_make = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "make_install_args"))
+        if content:
+            self.extra_make_install = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "make_install_args"))
-    if content:
-        extra_make_install = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "make32_install_args"))
+        if content:
+            self.extra_make32_install = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "make32_install_args"))
-    if content:
-        extra_make32_install = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "install_macro"))
+        if content and content[0]:
+            self.install_macro = content[0]
 
-    content = read_conf_file(os.path.join(path, "install_macro"))
-    if content and content[0]:
-        install_macro = content[0]
+        content = self.read_conf_file(os.path.join(path, "cmake_args"))
+        if content:
+            self.extra_cmake = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "cmake_args"))
-    if content:
-        extra_cmake = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "cmake_args_openmpi"))
+        if content:
+            self.extra_cmake_openmpi = " \\\n".join(content)
 
-    content = read_conf_file(os.path.join(path, "cmake_args_openmpi"))
-    if content:
-        extra_cmake_openmpi = " \\\n".join(content)
+        content = self.read_conf_file(os.path.join(path, "cmake_srcdir"))
+        if content and content[0]:
+            self.cmake_srcdir = content[0]
 
-    content = read_conf_file(os.path.join(path, "cmake_srcdir"))
-    if content and content[0]:
-        cmake_srcdir = content[0]
+        content = self.read_conf_file(os.path.join(path, "subdir"))
+        if content and content[0]:
+            self.subdir = content[0]
 
-    content = read_conf_file(os.path.join(path, "subdir"))
-    if content and content[0]:
-        subdir = content[0]
+        content = self.read_conf_file(os.path.join(path, "build_pattern"))
+        if content and content[0]:
+            buildpattern.set_build_pattern(content[0], 20)
+            self.autoreconf = False
 
-    content = read_conf_file(os.path.join(path, "build_pattern"))
-    if content and content[0]:
-        buildpattern.set_build_pattern(content[0], 20)
-        autoreconf = False
+        content = self.read_script_file(os.path.join(path, "make_check_command"))
+        if content:
+            check.tests_config = '\n'.join(content)
 
-    content = read_script_file(os.path.join(path, "make_check_command"))
-    if content:
-        check.tests_config = '\n'.join(content)
+        content = self.read_conf_file(os.path.join(path, tarball.name + ".license"))
+        if content and content[0]:
+            words = content[0].split()
+            for word in words:
+                if word.find(":") < 0:
+                    if not license.add_license(word, self.license_translations, self.license_blacklist):
+                        print_warning("{}: blacklisted license {} ignored.".format(tarball.name + ".license", word))
 
-    content = read_conf_file(os.path.join(path, tarball.name + ".license"))
-    if content and content[0]:
-        words = content[0].split()
-        for word in words:
-            if word.find(":") < 0:
-                if not license.add_license(word):
-                    print_warning("{}: blacklisted license {} ignored.".format(tarball.name + ".license", word))
+        content = self.read_conf_file(os.path.join(path, "golang_libpath"))
+        if content and content[0]:
+            tarball.golibpath = content[0]
+            print("golibpath   : {}".format(tarball.golibpath))
 
-    content = read_conf_file(os.path.join(path, "golang_libpath"))
-    if content and content[0]:
-        tarball.golibpath = content[0]
-        print("golibpath   : {}".format(tarball.golibpath))
+        if self.config_opts['use_clang']:
+            self.config_opts['funroll-loops'] = False
+            buildreq.add_buildreq("llvm")
 
-    if config_opts['use_clang']:
-        config_opts['funroll-loops'] = False
-        buildreq.add_buildreq("llvm")
+        if self.config_opts['32bit']:
+            buildreq.add_buildreq("glibc-libc32")
+            buildreq.add_buildreq("glibc-dev32")
+            buildreq.add_buildreq("gcc-dev32")
+            buildreq.add_buildreq("gcc-libgcc32")
+            buildreq.add_buildreq("gcc-libstdc++32")
 
-    if config_opts['32bit']:
-        buildreq.add_buildreq("glibc-libc32")
-        buildreq.add_buildreq("glibc-dev32")
-        buildreq.add_buildreq("gcc-dev32")
-        buildreq.add_buildreq("gcc-libgcc32")
-        buildreq.add_buildreq("gcc-libstdc++32")
+        if self.config_opts['openmpi']:
+            buildreq.add_buildreq("openmpi-dev")
+            buildreq.add_buildreq("modules")
+            # MPI testsuites generally require "openssh"
+            buildreq.add_buildreq("openssh")
 
-    if config_opts['openmpi']:
-        buildreq.add_buildreq("openmpi-dev")
-        buildreq.add_buildreq("modules")
-        # MPI testsuites generally require "openssh"
-        buildreq.add_buildreq("openssh")
+        self.prep_prepend = self.read_script_file(os.path.join(path, "prep_prepend"))
+        if os.path.isfile(os.path.join(path, "prep_append")):
+            os.rename(os.path.join(path, "prep_append"), os.path.join(path, "build_prepend"))
+        self.make_prepend = self.read_script_file(os.path.join(path, "make_prepend"))
+        self.build_prepend = self.read_script_file(os.path.join(path, "build_prepend"))
+        self.build_append = self.read_script_file(os.path.join(path, "build_append"))
+        self.install_prepend = self.read_script_file(os.path.join(path, "install_prepend"))
+        if os.path.isfile(os.path.join(path, "make_install_append")):
+            os.rename(os.path.join(path, "make_install_append"), os.path.join(path, "install_append"))
+        self.install_append = self.read_script_file(os.path.join(path, "install_append"))
+        self.service_restart = self.read_conf_file(os.path.join(path, "service_restart"))
 
-    prep_prepend = read_script_file(os.path.join(path, "prep_prepend"))
-    if os.path.isfile(os.path.join(path, "prep_append")):
-        os.rename(os.path.join(path, "prep_append"), os.path.join(path, "build_prepend"))
-    make_prepend = read_script_file(os.path.join(path, "make_prepend"))
-    build_prepend = read_script_file(os.path.join(path, "build_prepend"))
-    build_append = read_script_file(os.path.join(path, "build_append"))
-    install_prepend = read_script_file(os.path.join(path, "install_prepend"))
-    if os.path.isfile(os.path.join(path, "make_install_append")):
-        os.rename(os.path.join(path, "make_install_append"), os.path.join(path, "install_append"))
-    install_append = read_script_file(os.path.join(path, "install_append"))
-    service_restart = read_conf_file(os.path.join(path, "service_restart"))
+        self.profile_payload = self.read_script_file(os.path.join(path, "profile_payload"))
 
-    profile_payload = read_script_file(os.path.join(path, "profile_payload"))
+        self.custom_desc = self.read_conf_file(os.path.join(path, "description"))
+        self.custom_summ = self.read_conf_file(os.path.join(path, "summary"))
 
-    custom_desc = read_conf_file(os.path.join(path, "description"))
-    custom_summ = read_conf_file(os.path.join(path, "summary"))
-
-
-def load_specfile(specfile):
-    """Load specfile object with configuration."""
-    specfile.urlban = urlban
-    specfile.keepstatic = config_opts['keepstatic']
-    specfile.no_autostart = config_opts['no_autostart']
-    specfile.extra_make = extra_make
-    specfile.extra32_make = extra32_make
-    specfile.extra_make_install = extra_make_install
-    specfile.extra_make32_install = extra_make32_install
-    specfile.extra_cmake = extra_cmake
-    specfile.extra_cmake_openmpi = extra_cmake_openmpi
-    specfile.cmake_srcdir = cmake_srcdir or specfile.cmake_srcdir
-    specfile.subdir = subdir
-    specfile.install_macro = install_macro
-    specfile.disable_static = disable_static
-    specfile.prep_prepend = prep_prepend
-    specfile.build_prepend = build_prepend
-    specfile.build_append = build_append
-    specfile.make_prepend = make_prepend
-    specfile.install_prepend = install_prepend
-    specfile.install_append = install_append
-    specfile.service_restart = service_restart
-    specfile.extra_sources = extra_sources
-    specfile.patches = patches
-    specfile.verpatches = verpatches
-    specfile.autoreconf = autoreconf
-    specfile.set_gopath = set_gopath
+    def load_specfile(self, specfile):
+        """Load specfile object with configuration."""
+        specfile.urlban = self.urlban
+        specfile.keepstatic = self.config_opts['keepstatic']
+        specfile.no_autostart = self.config_opts['no_autostart']
+        specfile.extra_make = self.extra_make
+        specfile.extra32_make = self.extra32_make
+        specfile.extra_make_install = self.extra_make_install
+        specfile.extra_make32_install = self.extra_make32_install
+        specfile.extra_cmake = self.extra_cmake
+        specfile.extra_cmake_openmpi = self.extra_cmake_openmpi
+        specfile.cmake_srcdir = self.cmake_srcdir or specfile.cmake_srcdir
+        specfile.subdir = self.subdir
+        specfile.install_macro = self.install_macro
+        specfile.disable_static = self.disable_static
+        specfile.prep_prepend = self.prep_prepend
+        specfile.build_prepend = self.build_prepend
+        specfile.build_append = self.build_append
+        specfile.make_prepend = self.make_prepend
+        specfile.install_prepend = self.install_prepend
+        specfile.install_append = self.install_append
+        specfile.service_restart = self.service_restart
+        specfile.extra_sources = self.extra_sources
+        specfile.patches = self.patches
+        specfile.verpatches = self.verpatches
+        specfile.autoreconf = self.autoreconf
+        specfile.set_gopath = self.set_gopath

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -24,7 +24,6 @@ import re
 from collections import OrderedDict
 
 import build
-import config
 import tarball
 import util
 
@@ -32,8 +31,9 @@ import util
 class FileManager(object):
     """Class to handle spec file %files section management."""
 
-    def __init__(self):
+    def __init__(self, config):
         """Set defaults for FileManager."""
+        self.config = config
         self.packages = OrderedDict()  # per sub-package file list for spec purposes
         self.files = set()  # global file set to weed out dupes
         self.files_blacklist = set()
@@ -89,7 +89,7 @@ class FileManager(object):
 
     def compat_exclude(self, filename):
         """Exclude non-library files if the package is for compatability."""
-        if not config.config_opts.get("compat"):
+        if not self.config.config_opts.get("compat"):
             return False
 
         patterns = [
@@ -228,8 +228,8 @@ class FileManager(object):
         # if configured to do so, add .so files to the lib package instead of
         # the dev package. THis is useful for packages with a plugin
         # architecture like elfutils and mesa.
-        so_dest = 'lib' if config.config_opts.get('so_to_lib') else 'dev'
-        so_dest_ompi = 'openmpi' if config.config_opts.get('so_to_lib') else 'dev'
+        so_dest = 'lib' if self.config.config_opts.get('so_to_lib') else 'dev'
+        so_dest_ompi = 'openmpi' if self.config.config_opts.get('so_to_lib') else 'dev'
 
         patterns = [
             # Patterns for matching files, format is a tuple as follows:

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -25,12 +25,11 @@ import subprocess
 
 import build
 import buildpattern
-import config
 import tarball
 from util import call, write_out
 
 
-def commit_to_git(path):
+def commit_to_git(path, config):
     """Update package's git tree for autospec managed changes."""
     call("git init", stdout=subprocess.DEVNULL, cwd=path)
 

--- a/autospec/pkg_scan.py
+++ b/autospec/pkg_scan.py
@@ -17,11 +17,10 @@
 #
 import subprocess
 
-import config
 import util
 
 
-def get_whatrequires(pkg):
+def get_whatrequires(pkg, yum_conf):
     """
     Write list of packages.
 
@@ -30,7 +29,7 @@ def get_whatrequires(pkg):
     """
     # clean up dnf cache to avoid 'no more mirrors repo' error
     try:
-        subprocess.check_output(['dnf', '--config', config.yum_conf,
+        subprocess.check_output(['dnf', '--config', yum_conf,
                                  '--releasever', 'clear', 'clean', 'all'])
     except subprocess.CalledProcessError as err:
         util.print_warning("Unable to clean dnf repo: {}, {}".format(pkg, err))
@@ -38,7 +37,7 @@ def get_whatrequires(pkg):
 
     try:
         out = subprocess.check_output(['dnf', 'repoquery',
-                                       '--config', config.yum_conf,
+                                       '--config', yum_conf,
                                        '--releasever', 'clear',
                                        '--archlist=src', '--recursive', '--queryformat=%{NAME}',
                                        '--whatrequires', pkg]).decode('utf-8')

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -20,7 +20,8 @@ def mock_return(retval):
 class TestFiles(unittest.TestCase):
 
     def setUp(self):
-        self.fm = FileManager()
+        conf = config.Config()
+        self.fm = FileManager(conf)
 
     def test_banned_path(self):
         """
@@ -66,14 +67,14 @@ class TestFiles(unittest.TestCase):
         """
         Test compat_exclude with a file that shouldn't be excluded.
         """
-        config.config_opts['compat'] = True
+        self.fm.config.config_opts['compat'] = True
         self.assertFalse(self.fm.compat_exclude('/usr/lib64/libfoo.so.1'))
 
     def test_compat_exclude_exclude_file(self):
         """
         Test compat_exclude with a file that should be excluded.
         """
-        config.config_opts['compat'] = True
+        self.fm.config.config_opts['compat'] = True
         self.assertTrue(self.fm.compat_exclude('/usr/lib64/libfoo.so'))
 
     def test_compat_exclude_not_compat_mode(self):
@@ -81,7 +82,7 @@ class TestFiles(unittest.TestCase):
         Test compat_exclude with a file that should be excluded but isn't
         because the package isn't being run in compat mode.
         """
-        config.config_opts['compat'] = False
+        self.fm.config.config_opts['compat'] = False
         self.assertFalse(self.fm.compat_exclude('/usr/lib64/libfoo.so'))
 
     def test_file_pat_match(self):

--- a/tests/test_infile_update_spec.py
+++ b/tests/test_infile_update_spec.py
@@ -1,5 +1,6 @@
 import unittest
 
+import config
 import infile_update_spec
 import specfiles
 
@@ -8,7 +9,7 @@ class TestUpdateSpecfile(unittest.TestCase):
     def setUp(self):
         # url, version, name, release
         url = "http://www.testpkg.com/testpkg/pkg-1.0.tar.gz"
-        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1')
+        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1', config.Config())
 
         self.bb_dict = {
             "DEPENDS": "ncurses gettext-native",

--- a/tests/test_specdescription.py
+++ b/tests/test_specdescription.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import mock_open, patch
+import config
 import specdescription
 
 
@@ -15,7 +16,6 @@ class TestSpecdescription(unittest.TestCase):
         specdescription.default_summary = "No detailed summary available"
         specdescription.default_summary_score = 0
         specdescription.license.licenses = []
-        specdescription.config.license_translations = {}
 
     def test_clean_license_string(self):
         """
@@ -48,7 +48,7 @@ class TestSpecdescription(unittest.TestCase):
                 "%donewithdesc\n"
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
-            specdescription.description_from_spec("filename")
+            specdescription.description_from_spec("filename", {}, [])
 
         self.assertEqual(specdescription.default_description,
                          "Here is the description section\n"
@@ -68,7 +68,7 @@ class TestSpecdescription(unittest.TestCase):
         content = "# this is a specfile without much in it\n"
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
-            specdescription.description_from_spec("filename")
+            specdescription.description_from_spec("filename", {}, [])
 
         self.assertEqual(specdescription.default_description,
                          "No detailed description available")
@@ -94,7 +94,7 @@ class TestSpecdescription(unittest.TestCase):
                 "donewithdesc:\n"
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
-            specdescription.description_from_pkginfo("filename")
+            specdescription.description_from_pkginfo("filename", {}, [])
 
         self.assertEqual(specdescription.default_description,
                          "Here is the description section\n"
@@ -113,7 +113,7 @@ class TestSpecdescription(unittest.TestCase):
         content = "# this is a pkginfo file without much in it\n"
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
-            specdescription.description_from_pkginfo("filename")
+            specdescription.description_from_pkginfo("filename", {}, [])
 
         self.assertEqual(specdescription.default_description,
                          "No detailed description available")

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import Mock, patch
+import config
 import tarball
 
 
@@ -123,11 +124,12 @@ def detect_build_test_generator(url, build_pattern):
 
 def name_and_version_test_generator(url, name, version):
     """Create test for tarball.name_and_version method."""
-    @patch('tarball.config.parse_config_versions', Mock(return_value={}))
     def generator(self):
         """Test template."""
+        conf = config.Config()
+        conf.parse_config_versions = Mock(return_value={})
         tarball.url = url
-        n, _, v = tarball.name_and_version('', '', Mock())
+        n, _, v = tarball.name_and_version('', '', Mock(), conf)
         self.assertEqual(name, n)
         self.assertEqual(version, v)
         if "github.com" in url:
@@ -217,7 +219,6 @@ class TestTarball(unittest.TestCase):
         tarball.process_go_archives(go_archives)
         self.assertEqual(go_archives, go_archives_expected)
 
-    @patch('tarball.config', Mock())
     def test_process_multiver_archives(self):
         """Test for tarball.process_multiver_archives method."""
         # Set up input values
@@ -236,8 +237,9 @@ class TestTarball(unittest.TestCase):
         ]
         # Set up a return value for parse_config_versions method
         attrs = {'parse_config_versions.return_value': config_versions}
-        tarball.config.configure_mock(**attrs)
-        tarball.process_multiver_archives(main_src, multiver_archives)
+        conf = Mock()
+        conf.configure_mock(**attrs)
+        tarball.process_multiver_archives(main_src, multiver_archives, conf)
         self.assertEqual(multiver_archives, expected_multiver_archives)
 
     @patch('tarball.Source.set_prefix', Mock())


### PR DESCRIPTION
The config module had a large amount of globals that were being
touched across many modules that would import. This made changes to
config very fragile as figuring out what would be modified in any
given call chain was difficult to diagnose.

It also made testing fragile as one would need to reset a given
module's config import to the best of their knowledge before rerunning
another test.

To get away from that (and to try and reduce the number of globally
modified variablies in autospec as a whole), refactor the config
module to provide its state as part config class. The long running
goal of changes like this is to better track what content can be
updated by a particular function (if a function would have access
to the config instance is now the hint rather than the config module
getting imported).