### PR TITLE
Refactor buildreq into a class

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -87,7 +87,6 @@ def check_requirements(use_git):
 
 def load_specfile(conf, specfile):
     """Gather all information from static analysis into Specfile instance."""
-    conf.load_specfile(specfile)
     tarball.load_specfile(specfile)
     specdescription.load_specfile(specfile, conf.custom_desc, conf.custom_summ)
     license.load_specfile(specfile)

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -30,147 +30,61 @@ import specdescription
 import toml
 import util
 
-banned_requires = set(["futures",
-                       "configparser"])
-buildreqs = set()
-buildreqs_cache = set()
-requires = set()
-extra_cmake = set()
-extra_cmake_openmpi = set()
-verbose = False
-cargo_bin = False
-pypi_provides = None
-pypi_requires = set()
-banned_buildreqs = set(["llvm-devel",
-                        "gcj",
-                        "pkgconfig(dnl)",
-                        "pkgconfig(hal)",
-                        "tslib-0.0",
-                        "pkgconfig(parallels-sdk)",
-                        "oslo-python",
-                        "libxml2No-python",
-                        "futures",
-                        "configparser"])
-autoreconf_reqs = ["gettext-bin",
-                   "automake-dev",
-                   "automake",
-                   "m4",
-                   "libtool",
-                   "libtool-dev",
-                   "pkg-config-dev"]
+
+def is_qmake_pro(f):
+    """Test if file extension is pro and not hidden."""
+    return f.endswith(".pro") and not f.startswith(".")
 
 
-def add_buildreq(req, cache=False):
-    """Add req to the global buildreqs set if req is not banned."""
-    global buildreqs
-    global buildreqs_cache
-    new = True
+def get_python_build_version_from_classifier(filename):
+    """Detect if setup should use distutils3 only.
 
-    req.strip()
+    Uses "Programming Language :: Python :: [2,3] :: Only" classifiers in the
+    setup.py file.  Defaults to distutils3 if no such classifiers are found.
+    """
+    with util.open_auto(filename) as setup_file:
+        data = setup_file.read()
 
-    if req in banned_buildreqs:
-        return False
-    if req in buildreqs:
-        new = False
-    if verbose and new:
-        print("  Adding buildreq:", req)
+    if "Programming Language :: Python :: 3 :: Only" in data:
+        return "distutils3"
 
-    buildreqs.add(req)
-    if cache and new:
-        buildreqs_cache.add(req)
-    return new
+    return "distutils3"
 
 
-def add_requires(req, packages, override=False):
-    """Add req to the global requires set if it is present in buildreqs and packages and is not banned."""
-    global buildreqs
-    global requires
-    new = True
-    req = req.strip()
-    if req in requires:
-        new = False
-    if req in banned_requires:
-        return False
+def clean_python_req(req, add_python=True):
+    """Strip version information from req."""
+    if req.find("#") == 0:
+        return ""
+    ret = req.rstrip("\n\r").strip()
+    i = ret.find(";")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find("<")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find("\n")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find(">")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find("=")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find("#")
+    if i > 0:
+        ret = ret[:i]
+    i = ret.find("!")
+    if i > 0:
+        ret = ret[:i]
 
-    # Try dashes instead of underscores as some ecosystems are inconsistent in their naming
-    req2 = req.replace("_", "-")
-    if req not in buildreqs and req2 in packages and req2 not in requires and req2 not in banned_requires:
-        # Since this is done for python add a buildreq just in case (might not be correct though)
-        buildreqs.add(req2)
-        requires.add(req2)
-        return True
-
-    # Try reversing the case of the first letter as some ecosystems are inconsistent in their naming
-    if len(req) > 1:
-        if req[0].isupper():
-            req2 = req[0].lower() + req[1:]
-        else:
-            req2 = req[0].upper() + req[1:]
-    if req not in buildreqs and req2 in packages and req2 not in requires and req2 not in banned_requires:
-        # Since this is done for python add a buildreq just in case (might not be correct though)
-        buildreqs.add(req2)
-        requires.add(req2)
-        return True
-
-    if req not in buildreqs and req not in packages and not override:
-        if req:
-            print("requirement '{}' not found in buildreqs or os_packages, skipping".format(req))
-        return False
-    if new:
-        # print("Adding requirement:", req)
-        requires.add(req)
-    return new
-
-
-def add_pkgconfig_buildreq(preq, conf32, cache=False):
-    """Format preq as pkgconfig req and add to buildreqs."""
-    if conf32:
-        req = "pkgconfig(32" + preq + ")"
-        add_buildreq(req, cache)
-    req = "pkgconfig(" + preq + ")"
-    return add_buildreq(req, cache)
-
-
-def configure_ac_line(line, conf32):
-    """Parse configure_ac line and add appropriate buildreqs."""
-    # print("----\n", line, "\n----")
-    # ignore comments
-    if line.startswith('#'):
-        return
-
-    pat_reqs = [(r"AC_CHECK_FUNC\([tgetent]", ["ncurses-devel"]),
-                ("PROG_INTLTOOL", ["intltool"]),
-                ("GETTEXT_PACKAGE", ["gettext", "perl(XML::Parser)"]),
-                ("AM_GLIB_GNU_GETTEXT", ["gettext", "perl(XML::Parser)"]),
-                ("GTK_DOC_CHECK", ["gtk-doc", "gtk-doc-dev", "libxslt-bin", "docbook-xml"]),
-                ("AC_PROG_SED", ["sed"]),
-                ("AC_PROG_GREP", ["grep"])]
-
-    for pat, reqs in pat_reqs:
-        if pat in line:
-            for req in reqs:
-                add_buildreq(req)
-
-    line = line.strip()
-
-    # XFCE uses an equivalent to PKG_CHECK_MODULES, handle them both the same
-    for style in [r"PKG_CHECK_MODULES\((.*?)\)", r"XDT_CHECK_PACKAGE\((.*?)\)"]:
-        match = re.search(style, line)
-        L = []
-        if match:
-            L = match.group(1).split(",")
-        if len(L) > 1:
-            rqlist = L[1].strip()
-            for req in parse_modules_list(rqlist):
-                add_pkgconfig_buildreq(req, conf32)
-
-    # PKG_CHECK_EXISTS(MODULES, action-if-found, action-if-not-found)
-    match = re.search(r"PKG_CHECK_EXISTS\((.*?)\)", line)
-    if match:
-        L = match.group(1).split(",")
-        rqlist = L[0].strip()
-        for req in parse_modules_list(rqlist):
-            add_pkgconfig_buildreq(req, conf32)
+    ret = ret.strip()
+    # is ret actually a valid (non-empty) string?
+    if ret and add_python:
+        ret = ret.strip()
+    # use the dictionary to translate funky names to our current pgk names
+    ret = util.translate(ret)
+    return ret
 
 
 def is_number(num_str):
@@ -188,6 +102,39 @@ def is_version(num_str):
         return True
 
     return False
+
+
+def parse_modules_list(modules_string, is_cmake=False):
+    """Parse the modules_string for the list of modules, stripping out the version requirements."""
+    if is_cmake:
+        modules = [m for m in re.split(r'\s*([><]?=|\${?[^}]*}?)\s*', modules_string)]
+        modules = filter(None, modules)
+    else:
+        modules = [m.strip('[]') for m in modules_string.split()]
+    res = []
+    next_is_ver = False
+    for mod in modules:
+        if next_is_ver:
+            next_is_ver = False
+            continue
+
+        if any(s in mod for s in ['<', '>', '=']):
+            next_is_ver = True
+            continue
+
+        if is_number(mod):
+            continue
+
+        if is_version(mod):
+            continue
+
+        if mod.startswith('$'):
+            continue
+
+        if len(mod) >= 2:
+            res.append(mod)
+
+    return res
 
 
 def parse_go_mod(path):
@@ -232,83 +179,6 @@ def parse_go_mod(path):
             if line.startswith("require ("):
                 dep_start = True
     return reqs
-
-
-def parse_modules_list(modules_string, is_cmake=False):
-    """Parse the modules_string for the list of modules, stripping out the version requirements."""
-    if is_cmake:
-        modules = [m for m in re.split(r'\s*([><]?=|\${?[^}]*}?)\s*', modules_string)]
-        modules = filter(None, modules)
-    else:
-        modules = [m.strip('[]') for m in modules_string.split()]
-    res = []
-    next_is_ver = False
-    for mod in modules:
-        if next_is_ver:
-            next_is_ver = False
-            continue
-
-        if any(s in mod for s in ['<', '>', '=']):
-            next_is_ver = True
-            continue
-
-        if is_number(mod):
-            continue
-
-        if is_version(mod):
-            continue
-
-        if mod.startswith('$'):
-            continue
-
-        if len(mod) >= 2:
-            res.append(mod)
-
-    return res
-
-
-def parse_configure_ac(filename, conf32):
-    """Parse the configure.ac file for build requirements."""
-    buf = ""
-    depth = 0
-    # print("Configure parse: ", filename)
-    buildpattern.set_build_pattern("configure_ac", 1)
-    f = util.open_auto(filename, "r")
-    while 1:
-        c = f.read(1)
-        if not c:
-            break
-        if c == "(":
-            depth += 1
-        if c == ")" and depth > 0:
-            depth -= 1
-        if c != "\n":
-            buf += c
-        if c == "\n" and depth == 0:
-            configure_ac_line(buf, conf32)
-            buf = ""
-
-    configure_ac_line(buf, conf32)
-    f.close()
-
-
-def parse_cargo_toml(filename, packages):
-    """Update build requirements using Cargo.toml.
-
-    Set the build requirements for building rust programs using cargo.
-    """
-    global cargo_bin
-    buildpattern.set_build_pattern("cargo", 1)
-    add_buildreq("rustc")
-    with util.open_auto(filename, "r") as ctoml:
-        cargo = toml.loads(ctoml.read())
-    if cargo.get("bin") or os.path.exists(os.path.join(os.path.dirname(filename), "src/main.rs")):
-        cargo_bin = True
-    if not cargo.get("dependencies"):
-        return
-    for cdep in cargo["dependencies"]:
-        if add_buildreq(cdep):
-            add_requires(cdep, packages)
 
 
 def _get_desc_field(field, desc):
@@ -400,541 +270,642 @@ def _get_r_provides():
     return set(provides)
 
 
-def parse_r_description(filename, packages):
-    """Update build/runtime requirements according to the R package description."""
-    deps = []
-    with util.open_auto(filename, "r") as desc:
-        content = desc.read()
-        deps = _get_desc_field("Depends", content)
-        deps.extend(_get_desc_field("Imports", content))
-        deps.extend(_get_desc_field("LinkingTo", content))
-    r_provides = _get_r_provides()
-    for dep in deps:
-        if dep == 'R':
-            continue
-        if dep in r_provides:
-            continue
-        pkg = 'R-' + dep
-        if pkg in packages:
-            add_buildreq(pkg)
-            add_requires(pkg, packages)
-        else:
-            print("CRAN package '{}' not found in os_packages, skipping".format(pkg))
+class Requirements(object):
+    """Handle package build and runtime requiremnts."""
 
+    def __init__(self, url):
+        """Initialize Default requirements settings."""
+        self.banned_requires = set(["futures",
+                                    "configparser"])
+        self.buildreqs = set()
+        self.buildreqs_cache = set()
+        self.requires = set()
+        self.extra_cmake = set()
+        self.extra_cmake_openmpi = set()
+        self.verbose = False
+        self.cargo_bin = False
+        self.pypi_provides = None
+        self.pypi_requires = set()
+        self.banned_buildreqs = set(["llvm-devel",
+                                     "gcj",
+                                     "pkgconfig(dnl)",
+                                     "pkgconfig(hal)",
+                                     "tslib-0.0",
+                                     "pkgconfig(parallels-sdk)",
+                                     "oslo-python",
+                                     "libxml2No-python",
+                                     "futures",
+                                     "configparser"])
+        self.autoreconf_reqs = ["gettext-bin",
+                                "automake-dev",
+                                "automake",
+                                "m4",
+                                "libtool",
+                                "libtool-dev",
+                                "pkg-config-dev"]
+        if "gnome.org" in url:
+            self.add_buildreq("buildreq-gnome")
+        if "kde.org" in url or "https://github.com/KDE" in url:
+            self.add_buildreq("buildreq-kde")
 
-def set_build_req():
-    """Add build requirements based on the buildpattern pattern."""
-    if buildpattern.default_pattern == "maven":
-        maven_reqs = ["apache-maven",
-                      "openjdk-dev",
-                      "mvn-aether-core",
-                      "mvn-aopalliance",
-                      "mvn-cdi-api",
-                      "mvn-commons-cli",
-                      "mvn-commons-codec",
-                      "mvn-commons-io",
-                      "mvn-commons-lang",
-                      "mvn-commons-lang3",
-                      "mvn-commons-logging",
-                      "mvn-guice",
-                      "mvn-guava",
-                      "mvn-httpcomponents-client",
-                      "mvn-httpcomponents-core",
-                      "mvn-jsoup",
-                      "mvn-jsr305",
-                      "mvn-wagon",
-                      "mvn-sisu",
-                      "mvn-plexus-cipher",
-                      "mvn-plexus-classworlds",
-                      "mvn-plexus-containers",
-                      "mvn-plexus-interpolation",
-                      "mvn-sonatype-plexus-sec-dispatcher",
-                      "mvn-plexus-utils",
-                      "mvn-slf4j"]
-        for req in maven_reqs:
-            add_buildreq(req)
+    def add_buildreq(self, req, cache=False):
+        """Add req to the global buildreqs set if req is not banned."""
+        new = True
+        req.strip()
+        if req in self.banned_buildreqs:
+            return False
+        if req in self.buildreqs:
+            new = False
+        if self.verbose and new:
+            print("  Adding buildreq:", req)
 
-    if buildpattern.default_pattern == "ruby":
-        add_buildreq("ruby")
-        add_buildreq("rubygem-rdoc")
-    if buildpattern.default_pattern == "cargo":
-        add_buildreq("rustc")
+        self.buildreqs.add(req)
+        if cache and new:
+            self.buildreqs_cache.add(req)
+        return new
 
+    def add_requires(self, req, packages, override=False):
+        """Add req to the global requires set if it is present in buildreqs and packages and is not banned."""
+        new = True
+        req = req.strip()
+        if req in self.requires:
+            new = False
+        if req in self.banned_requires:
+            return False
 
-def rakefile(filename, gems):
-    """Scan Rakefile for build requirements."""
-    with util.open_auto(filename, "r") as f:
-        lines = f.readlines()
+        # Try dashes instead of underscores as some ecosystems are inconsistent in their naming
+        req2 = req.replace("_", "-")
+        if req not in self.buildreqs and req2 in packages and req2 not in self.requires and req2 not in self.banned_requires:
+            # Since this is done for python add a buildreq just in case (might not be correct though)
+            self.buildreqs.add(req2)
+            self.requires.add(req2)
+            return True
 
-    pat = re.compile(r"^require '(.*)'$")
-    for line in lines:
-        match = pat.search(line)
-        if match:
-            s = match.group(1)
-            if s != "rubygems" and s in gems:
-                print("Rakefile-dep: " + gems[s])
-                add_buildreq(gems[s])
+        # Try reversing the case of the first letter as some ecosystems are inconsistent in their naming
+        if len(req) > 1:
+            if req[0].isupper():
+                req2 = req[0].lower() + req[1:]
             else:
-                print("Rakefile-new: rubygem-" + s)
+                req2 = req[0].upper() + req[1:]
+        if req not in self.buildreqs and req2 in packages and req2 not in self.requires and req2 not in self.banned_requires:
+            # Since this is done for python add a buildreq just in case (might not be correct though)
+            self.buildreqs.add(req2)
+            self.requires.add(req2)
+            return True
 
+        if req not in self.buildreqs and req not in packages and not override:
+            if req:
+                print("requirement '{}' not found in buildreqs or os_packages, skipping".format(req))
+            return False
+        if new:
+            # print("Adding requirement:", req)
+            self.requires.add(req)
+        return new
 
-def parse_cmake(filename, cmake_modules, conf32):
-    """Scan a .cmake or CMakeLists.txt file for what's it's actually looking for."""
-    findpackage = re.compile(r"^[^#]*find_package\((\w+)\b.*\)", re.I)
-    pkgconfig = re.compile(r"^[^#]*pkg_check_modules\s*\(\w+ (.*)\)", re.I)
-    pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
-                            'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
-    extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')
+    def add_pkgconfig_buildreq(self, preq, conf32, cache=False):
+        """Format preq as pkgconfig req and add to buildreqs."""
+        if conf32:
+            req = "pkgconfig(32" + preq + ")"
+            self.add_buildreq(req, cache)
+        req = "pkgconfig(" + preq + ")"
+        return self.add_buildreq(req, cache)
 
-    with util.open_auto(filename, "r") as f:
-        lines = f.readlines()
-    for line in lines:
-        match = findpackage.search(line)
+    def configure_ac_line(self, line, conf32):
+        """Parse configure_ac line and add appropriate buildreqs."""
+        # print("----\n", line, "\n----")
+        # ignore comments
+        if line.startswith('#'):
+            return
+
+        pat_reqs = [(r"AC_CHECK_FUNC\([tgetent]", ["ncurses-devel"]),
+                    ("PROG_INTLTOOL", ["intltool"]),
+                    ("GETTEXT_PACKAGE", ["gettext", "perl(XML::Parser)"]),
+                    ("AM_GLIB_GNU_GETTEXT", ["gettext", "perl(XML::Parser)"]),
+                    ("GTK_DOC_CHECK", ["gtk-doc", "gtk-doc-dev", "libxslt-bin", "docbook-xml"]),
+                    ("AC_PROG_SED", ["sed"]),
+                    ("AC_PROG_GREP", ["grep"])]
+
+        for pat, reqs in pat_reqs:
+            if pat in line:
+                for req in reqs:
+                    self.add_buildreq(req)
+
+        line = line.strip()
+
+        # XFCE uses an equivalent to PKG_CHECK_MODULES, handle them both the same
+        for style in [r"PKG_CHECK_MODULES\((.*?)\)", r"XDT_CHECK_PACKAGE\((.*?)\)"]:
+            match = re.search(style, line)
+            L = []
+            if match:
+                L = match.group(1).split(",")
+            if len(L) > 1:
+                rqlist = L[1].strip()
+                for req in parse_modules_list(rqlist):
+                    self.add_pkgconfig_buildreq(req, conf32)
+
+        # PKG_CHECK_EXISTS(MODULES, action-if-found, action-if-not-found)
+        match = re.search(r"PKG_CHECK_EXISTS\((.*?)\)", line)
         if match:
-            module = match.group(1)
-            try:
-                pkg = cmake_modules[module]
-                add_buildreq(pkg)
-            except Exception:
-                pass
+            L = match.group(1).split(",")
+            rqlist = L[0].strip()
+            for req in parse_modules_list(rqlist):
+                self.add_pkgconfig_buildreq(req, conf32)
 
-        match = pkgconfig.search(line)
-        if match:
-            rest = match.group(1)
-            while rest:
-                wordmatch = extractword.search(rest)
-                if not wordmatch:
-                    break
-                rest = wordmatch.group(3)
-                if wordmatch.group(2) in pkg_search_modifiers:
-                    continue
-                # Only one of the two groups can match at a time
-                module = wordmatch.group(1)
-                if not module:
-                    module = wordmatch.group(2)
-                # We have a match, so strip out any version info
-                for m in parse_modules_list(module, is_cmake=True):
-                    add_pkgconfig_buildreq(m, conf32)
+    def parse_configure_ac(self, filename, conf32):
+        """Parse the configure.ac file for build requirements."""
+        buf = ""
+        depth = 0
+        # print("Configure parse: ", filename)
+        buildpattern.set_build_pattern("configure_ac", 1)
+        f = util.open_auto(filename, "r")
+        while 1:
+            c = f.read(1)
+            if not c:
+                break
+            if c == "(":
+                depth += 1
+            if c == ")" and depth > 0:
+                depth -= 1
+            if c != "\n":
+                buf += c
+            if c == "\n" and depth == 0:
+                self.configure_ac_line(buf, conf32)
+                buf = ""
+        self.configure_ac_line(buf, conf32)
+        f.close()
 
+    def parse_cargo_toml(self, filename, packages):
+        """Update build requirements using Cargo.toml.
 
-def qmake_profile(filename, qt_modules):
-    """Scan .pro file for build requirements."""
-    with util.open_auto(filename, "r") as f:
-        lines = f.readlines()
+        Set the build requirements for building rust programs using cargo.
+        """
+        buildpattern.set_build_pattern("cargo", 1)
+        self.add_buildreq("rustc")
+        with util.open_auto(filename, "r") as ctoml:
+            cargo = toml.loads(ctoml.read())
+        if cargo.get("bin") or os.path.exists(os.path.join(os.path.dirname(filename), "src/main.rs")):
+            self.cargo_bin = True
+        if not cargo.get("dependencies"):
+            return
+        for cdep in cargo["dependencies"]:
+            if self.add_buildreq(cdep):
+                self.add_requires(cdep, packages)
 
-    pat = re.compile(r"(QT|QT_PRIVATE|QT_FOR_CONFIG).*=\s*(.*)\s*")
-    for line in lines:
-        match = pat.search(line)
-        if not match:
-            continue
-        s = match.group(2)
-        for module in s.split():
-            module = re.sub('-private$', '', module)
-            try:
-                pc = qt_modules[module]
-                add_buildreq('pkgconfig({})'.format(pc))
-            except Exception:
-                pass
-
-
-def clean_python_req(req, add_python=True):
-    """Strip version information from req."""
-    if req.find("#") == 0:
-        return ""
-    ret = req.rstrip("\n\r").strip()
-    i = ret.find(";")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find("<")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find("\n")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find(">")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find("=")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find("#")
-    if i > 0:
-        ret = ret[:i]
-    i = ret.find("!")
-    if i > 0:
-        ret = ret[:i]
-
-    ret = ret.strip()
-    # is ret actually a valid (non-empty) string?
-    if ret and add_python:
-        ret = ret.strip()
-    # use the dictionary to translate funky names to our current pgk names
-    ret = util.translate(ret)
-    return ret
-
-
-def grab_python_requirements(descfile, packages):
-    """Add python requirements from requirements.txt file."""
-    if "/demo/" in descfile:
-        return
-    if "/doc/" in descfile:
-        return
-    if "/docs/" in descfile:
-        return
-    if "/example/" in descfile:
-        return
-    if "/test/" in descfile:
-        return
-    if "/tests/" in descfile:
-        return
-
-    with util.open_auto(descfile, "r") as f:
-        lines = f.readlines()
-
-    for line in lines:
-        # don't add the test section
-        if clean_python_req(line) == '[test]':
-            break
-        if clean_python_req(line) == '[testing]':
-            break
-        if clean_python_req(line) == '[dev]':
-            break
-        if clean_python_req(line) == '[doc]':
-            break
-        if clean_python_req(line) == '[docs]':
-            break
-        if 'pytest' in line:
-            continue
-        if clean_python_req(line) == 'mock':
-            continue
-        add_requires(clean_python_req(line), packages)
-
-
-def get_python_build_version_from_classifier(filename):
-    """Detect if setup should use distutils3 only.
-
-    Uses "Programming Language :: Python :: [2,3] :: Only" classifiers in the
-    setup.py file.  Defaults to distutils3 if no such classifiers are found.
-    """
-    with util.open_auto(filename) as setup_file:
-        data = setup_file.read()
-
-    if "Programming Language :: Python :: 3 :: Only" in data:
-        return "distutils3"
-
-    return "distutils3"
-
-
-def add_setup_py_requires(filename, packages):
-    """Detect build requirements listed in setup.py in the install_requires and setup_requires lists.
-
-    Handles the following patterns:
-    install_requires='one'
-    install_requires=['one', 'two', 'three']
-    install_requires=['one',
-                      'two',
-                      'three']
-    setup_requires=[
-        'one>=2.1',   # >=2.1 is removed
-        'two',
-        'three'
-    ]
-    setuptools.setup(
-        setup_requires=['one', 'two'],
-        ...)
-    setuptools.setup(setup_requires=['one', 'two'], ...)
-
-    Does not evaluate variables for security purposes
-    """
-    multiline = False
-    with util.open_auto(filename) as f:
-        lines = f.readlines()
-
-    for line in lines:
-        if "install_requires" in line or "setup_requires" in line:
-            req = "install_requires" in line
-            # find the value for *_requires
-            line = line.split("=", 1)
-            if len(line) == 2:
-                line = line[1].strip()
-            else:
-                # skip because this could be a conditionally extended list
-                # we only want to automatically detect the core packages
+    def parse_r_description(self, filename, packages):
+        """Update build/runtime requirements according to the R package description."""
+        deps = []
+        with util.open_auto(filename, "r") as desc:
+            content = desc.read()
+            deps = _get_desc_field("Depends", content)
+            deps.extend(_get_desc_field("Imports", content))
+            deps.extend(_get_desc_field("LinkingTo", content))
+        r_provides = _get_r_provides()
+        for dep in deps:
+            if dep == 'R':
                 continue
-
-            # easy, one-line case
-            if line.startswith("[") and "]" in line:
-                # remove the leading [ and split off everthing after the ]
-                line = line[1:].split("]")[0]
-                for item in line.split(','):
-                    item = item.strip()
-                    try:
-                        # eval the string and add requirements
-                        dep = clean_python_req(ast.literal_eval(item), False)
-                        add_buildreq(dep)
-                        if req:
-                            add_requires(dep, packages)
-
-                    except Exception:
-                        # do not fail, the line contained a variable and
-                        # had to be skipped
-                        pass
-
+            if dep in r_provides:
                 continue
-
-            # more complicated, multi-line list.
-            # this sets the py_dep_string with the current line, which
-            # is the beginning of a multi-line list.
-            elif line.startswith("["):
-                multiline = True
-                line = line.lstrip("[")
-
-            # if the line doesn't start with '[' it is the case where
-            # there is (should be) a single dependency as a string
+            pkg = 'R-' + dep
+            if pkg in packages:
+                self.add_buildreq(pkg)
+                self.add_requires(pkg, packages)
             else:
-                line = line.strip()
+                print("CRAN package '{}' not found in os_packages, skipping".format(pkg))
+
+    def set_build_req(self):
+        """Add build requirements based on the buildpattern pattern."""
+        if buildpattern.default_pattern == "maven":
+            maven_reqs = ["apache-maven",
+                          "openjdk-dev",
+                          "mvn-aether-core",
+                          "mvn-aopalliance",
+                          "mvn-cdi-api",
+                          "mvn-commons-cli",
+                          "mvn-commons-codec",
+                          "mvn-commons-io",
+                          "mvn-commons-lang",
+                          "mvn-commons-lang3",
+                          "mvn-commons-logging",
+                          "mvn-guice",
+                          "mvn-guava",
+                          "mvn-httpcomponents-client",
+                          "mvn-httpcomponents-core",
+                          "mvn-jsoup",
+                          "mvn-jsr305",
+                          "mvn-wagon",
+                          "mvn-sisu",
+                          "mvn-plexus-cipher",
+                          "mvn-plexus-classworlds",
+                          "mvn-plexus-containers",
+                          "mvn-plexus-interpolation",
+                          "mvn-sonatype-plexus-sec-dispatcher",
+                          "mvn-plexus-utils",
+                          "mvn-slf4j"]
+            for req in maven_reqs:
+                self.add_buildreq(req)
+
+        if buildpattern.default_pattern == "ruby":
+            self.add_buildreq("ruby")
+            self.add_buildreq("rubygem-rdoc")
+        if buildpattern.default_pattern == "cargo":
+            self.add_buildreq("rustc")
+
+    def rakefile(self, filename, gems):
+        """Scan Rakefile for build requirements."""
+        with util.open_auto(filename, "r") as f:
+            lines = f.readlines()
+
+        pat = re.compile(r"^require '(.*)'$")
+        for line in lines:
+            match = pat.search(line)
+            if match:
+                s = match.group(1)
+                if s != "rubygems" and s in gems:
+                    print("Rakefile-dep: " + gems[s])
+                    self.add_buildreq(gems[s])
+                else:
+                    print("Rakefile-new: rubygem-" + s)
+
+    def parse_cmake(self, filename, cmake_modules, conf32):
+        """Scan a .cmake or CMakeLists.txt file for what's it's actually looking for."""
+        findpackage = re.compile(r"^[^#]*find_package\((\w+)\b.*\)", re.I)
+        pkgconfig = re.compile(r"^[^#]*pkg_check_modules\s*\(\w+ (.*)\)", re.I)
+        pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
+                                'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
+        extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')
+
+        with util.open_auto(filename, "r") as f:
+            lines = f.readlines()
+        for line in lines:
+            match = findpackage.search(line)
+            if match:
+                module = match.group(1)
                 try:
-                    dep = clean_python_req(ast.literal_eval(line), False)
-                    add_buildreq(dep)
-                    if req:
-                        add_requires(dep, packages)
-
+                    pkg = cmake_modules[module]
+                    self.add_buildreq(pkg)
                 except Exception:
-                    # Do not fail, just keep looking
                     pass
 
+            match = pkgconfig.search(line)
+            if match:
+                rest = match.group(1)
+                while rest:
+                    wordmatch = extractword.search(rest)
+                    if not wordmatch:
+                        break
+                    rest = wordmatch.group(3)
+                    if wordmatch.group(2) in pkg_search_modifiers:
+                        continue
+                    # Only one of the two groups can match at a time
+                    module = wordmatch.group(1)
+                    if not module:
+                        module = wordmatch.group(2)
+                    # We have a match, so strip out any version info
+                    for m in parse_modules_list(module, is_cmake=True):
+                        self.add_pkgconfig_buildreq(m, conf32)
+
+    def qmake_profile(self, filename, qt_modules):
+        """Scan .pro file for build requirements."""
+        with util.open_auto(filename, "r") as f:
+            lines = f.readlines()
+
+        pat = re.compile(r"(QT|QT_PRIVATE|QT_FOR_CONFIG).*=\s*(.*)\s*")
+        for line in lines:
+            match = pat.search(line)
+            if not match:
+                continue
+            s = match.group(2)
+            for module in s.split():
+                module = re.sub('-private$', '', module)
+                try:
+                    pc = qt_modules[module]
+                    self.add_buildreq('pkgconfig({})'.format(pc))
+                except Exception:
+                    pass
+
+    def grab_python_requirements(self, descfile, packages):
+        """Add python requirements from requirements.txt file."""
+        if "/demo/" in descfile:
+            return
+        if "/doc/" in descfile:
+            return
+        if "/docs/" in descfile:
+            return
+        if "/example/" in descfile:
+            return
+        if "/test/" in descfile:
+            return
+        if "/tests/" in descfile:
+            return
+
+        with util.open_auto(descfile, "r") as f:
+            lines = f.readlines()
+
+        for line in lines:
+            # don't add the test section
+            if clean_python_req(line) == '[test]':
+                break
+            if clean_python_req(line) == '[testing]':
+                break
+            if clean_python_req(line) == '[dev]':
+                break
+            if clean_python_req(line) == '[doc]':
+                break
+            if clean_python_req(line) == '[docs]':
+                break
+            if 'pytest' in line:
+                continue
+            if clean_python_req(line) == 'mock':
+                continue
+            self.add_requires(clean_python_req(line), packages)
+
+    def add_setup_py_requires(self, filename, packages):
+        """Detect build requirements listed in setup.py in the install_requires and setup_requires lists.
+
+        Handles the following patterns:
+        install_requires='one'
+        install_requires=['one', 'two', 'three']
+        install_requires=['one',
+                          'two',
+                          'three']
+        setup_requires=[
+            'one>=2.1',   # >=2.1 is removed
+            'two',
+            'three'
+        ]
+        setuptools.setup(
+            setup_requires=['one', 'two'],
+        ...)
+        setuptools.setup(setup_requires=['one', 'two'], ...)
+
+        Does not evaluate variables for security purposes
+        """
+        multiline = False
+        with util.open_auto(filename) as f:
+            lines = f.readlines()
+
+        for line in lines:
+            if "install_requires" in line or "setup_requires" in line:
+                req = "install_requires" in line
+                # find the value for *_requires
+                line = line.split("=", 1)
+                if len(line) == 2:
+                    line = line[1].strip()
+                else:
+                    # skip because this could be a conditionally extended list
+                    # we only want to automatically detect the core packages
+                    continue
+
+                # easy, one-line case
+                if line.startswith("[") and "]" in line:
+                    # remove the leading [ and split off everthing after the ]
+                    line = line[1:].split("]")[0]
+                    for item in line.split(','):
+                        item = item.strip()
+                        try:
+                            # eval the string and add requirements
+                            dep = clean_python_req(ast.literal_eval(item), False)
+                            self.add_buildreq(dep)
+                            if req:
+                                self.add_requires(dep, packages)
+
+                        except Exception:
+                            # do not fail, the line contained a variable and
+                            # had to be skipped
+                            pass
+
+                    continue
+
+                # more complicated, multi-line list.
+                # this sets the py_dep_string with the current line, which
+                # is the beginning of a multi-line list.
+                elif line.startswith("["):
+                    multiline = True
+                    line = line.lstrip("[")
+
+                # if the line doesn't start with '[' it is the case where
+                # there is (should be) a single dependency as a string
+                else:
+                    line = line.strip()
+                    try:
+                        dep = clean_python_req(ast.literal_eval(line), False)
+                        self.add_buildreq(dep)
+                        if req:
+                            self.add_requires(dep, packages)
+
+                    except Exception:
+                        # Do not fail, just keep looking
+                        pass
+
+                    continue
+
+            # if multiline was set above when a multi-line list was
+            # detected, for each line until the end bracket is found attempt to
+            # add the line as a buildreq
+            if multiline:
+                # if end bracket found, reset the flag
+                if "]" in line:
+                    multiline = False
+                    line = line.split("]")[0]
+
+                try:
+                    dep = ast.literal_eval(line.split('#')[0].strip(' ,\n'))
+                    dep = clean_python_req(dep)
+                    self.add_buildreq(dep)
+                    if req:
+                        self.add_requires(dep, packages)
+
+                except Exception:
+                    # do not fail, the line contained a variable and had to
+                    # be skipped
+                    pass
+
+    def parse_catkin_deps(self, cmakelists_file, conf32):
+        """Determine requirements for catkin packages."""
+        f = util.open_auto(cmakelists_file, "r")
+        lines = f.readlines()
+        pat = re.compile(r"^find_package.*\(.*(catkin)(?: REQUIRED *)?(?:COMPONENTS (?P<comp>.*))?\)$")
+        catkin = False
+        for line in lines:
+            match = pat.search(line)
+            if not match:
                 continue
 
-        # if multiline was set above when a multi-line list was
-        # detected, for each line until the end bracket is found attempt to
-        # add the line as a buildreq
-        if multiline:
-            # if end bracket found, reset the flag
-            if "]" in line:
-                multiline = False
-                line = line.split("]")[0]
+            # include catkin's required components
+            comp = match.group("comp")
+            if comp:
+                for curr in comp.split(" "):
+                    self.add_pkgconfig_buildreq(curr, conf32)
 
-            try:
-                dep = ast.literal_eval(line.split('#')[0].strip(' ,\n'))
-                dep = clean_python_req(dep)
-                add_buildreq(dep)
-                if req:
-                    add_requires(dep, packages)
+            catkin = True
 
-            except Exception:
-                # do not fail, the line contained a variable and had to
-                # be skipped
-                pass
+        # catkin find_package() function will always rely on CMAKE_PREFIX_PATH
+        # make sure we keep it consistent with CMAKE_INSTALL_PREFIX otherwise
+        # it'll never be able to find its modules
+        if catkin:
+            for curr in ["catkin", "catkin_pkg", "empy", "googletest"]:
+                self.add_buildreq(curr)
 
+            self.extra_cmake.add("-DCMAKE_PREFIX_PATH=/usr")
+            self.extra_cmake.add("-DCATKIN_BUILD_BINARY_PACKAGE=ON")
+            self.extra_cmake.add("-DSETUPTOOLS_DEB_LAYOUT=OFF")
 
-def parse_catkin_deps(cmakelists_file, conf32):
-    """Determine requirements for catkin packages."""
-    f = util.open_auto(cmakelists_file, "r")
-    lines = f.readlines()
-    pat = re.compile(r"^find_package.*\(.*(catkin)(?: REQUIRED *)?(?:COMPONENTS (?P<comp>.*))?\)$")
-    catkin = False
+    def scan_for_configure(self, dirn, tname, dlpath, config):
+        """Scan the package directory for build files to determine build pattern."""
+        if buildpattern.default_pattern == "distutils36":
+            self.add_buildreq("buildreq-distutils36")
+        elif buildpattern.default_pattern == "distutils3":
+            self.add_buildreq("buildreq-distutils3")
+        elif buildpattern.default_pattern == "golang":
+            self.add_buildreq("buildreq-golang")
+        elif buildpattern.default_pattern == "cmake":
+            self.add_buildreq("buildreq-cmake")
+        elif buildpattern.default_pattern == "configure":
+            self.add_buildreq("buildreq-configure")
+        elif buildpattern.default_pattern == "qmake":
+            self.add_buildreq("buildreq-qmake")
+        elif buildpattern.default_pattern == "cpan":
+            self.add_buildreq("buildreq-cpan")
+        elif buildpattern.default_pattern == "scons":
+            self.add_buildreq("buildreq-scons")
+        elif buildpattern.default_pattern == "R":
+            self.add_buildreq("buildreq-R")
+            self.parse_r_description(os.path.join(dirn, "DESCRIPTION"), config.os_packages)
+        elif buildpattern.default_pattern == "phpize":
+            self.add_buildreq("buildreq-php")
+        elif buildpattern.default_pattern == "nginx":
+            self.add_buildreq("buildreq-nginx")
 
-    for line in lines:
-        match = pat.search(line)
+        count = 0
+        for dirpath, _, files in os.walk(dirn):
+            default_score = 2 if dirpath == dirn else 1
 
-        if not match:
-            continue
-
-        # include catkin's required components
-        comp = match.group("comp")
-        if comp:
-            for curr in comp.split(" "):
-                add_pkgconfig_buildreq(curr, conf32)
-
-        catkin = True
-
-    # catkin find_package() function will always rely on CMAKE_PREFIX_PATH
-    # make sure we keep it consistent with CMAKE_INSTALL_PREFIX otherwise
-    # it'll never be able to find its modules
-    if catkin:
-        for curr in ["catkin", "catkin_pkg", "empy", "googletest"]:
-            add_buildreq(curr)
-
-        extra_cmake.add("-DCMAKE_PREFIX_PATH=/usr")
-        extra_cmake.add("-DCATKIN_BUILD_BINARY_PACKAGE=ON")
-        extra_cmake.add("-DSETUPTOOLS_DEB_LAYOUT=OFF")
-
-
-def is_qmake_pro(f):
-    """Test if file extension is pro and not hidden."""
-    return f.endswith(".pro") and not f.startswith(".")
-
-
-def scan_for_configure(dirn, tname, dlpath, config):
-    """Scan the package directory for build files to determine build pattern."""
-    global pypi_provides
-    global pypi_requires
-    if buildpattern.default_pattern == "distutils36":
-        add_buildreq("buildreq-distutils36")
-    elif buildpattern.default_pattern == "distutils3":
-        add_buildreq("buildreq-distutils3")
-    elif buildpattern.default_pattern == "golang":
-        add_buildreq("buildreq-golang")
-    elif buildpattern.default_pattern == "cmake":
-        add_buildreq("buildreq-cmake")
-    elif buildpattern.default_pattern == "configure":
-        add_buildreq("buildreq-configure")
-    elif buildpattern.default_pattern == "qmake":
-        add_buildreq("buildreq-qmake")
-    elif buildpattern.default_pattern == "cpan":
-        add_buildreq("buildreq-cpan")
-    elif buildpattern.default_pattern == "scons":
-        add_buildreq("buildreq-scons")
-    elif buildpattern.default_pattern == "R":
-        add_buildreq("buildreq-R")
-        parse_r_description(os.path.join(dirn, "DESCRIPTION"), config.os_packages)
-    elif buildpattern.default_pattern == "phpize":
-        add_buildreq("buildreq-php")
-    elif buildpattern.default_pattern == "nginx":
-        add_buildreq("buildreq-nginx")
-
-    count = 0
-    for dirpath, _, files in os.walk(dirn):
-        default_score = 2 if dirpath == dirn else 1
-
-        if any(f.endswith(".go") for f in files):
-            add_buildreq("buildreq-golang")
-            buildpattern.set_build_pattern("golang", default_score)
-
-        if "go.mod" in files:
-            if "Makefile" not in files:
-                # Go packages usually have make build systems so far
-                # so only use go directly if we can't find a Makefile
+            if any(f.endswith(".go") for f in files):
+                self.add_buildreq("buildreq-golang")
                 buildpattern.set_build_pattern("golang", default_score)
-            add_buildreq("buildreq-golang")
-            if buildpattern.default_pattern == "golang-mod" or buildpattern.default_pattern == "godep":
-                config.set_gopath = False
-                mod_path = os.path.join(dirpath, "go.mod")
-                reqs = parse_go_mod(mod_path)
-                for req in reqs:
-                    # req[0] is a SCM url segment in the form, repo/XXX/dependency-name
-                    # req[1] is the version of the dependency
-                    pkg = "go-" + req[0].replace("/", "-")
-                    add_buildreq(pkg)
-                    if buildpattern.default_pattern == "godep":
-                        add_requires(pkg, config.os_packages)
 
-        if "CMakeLists.txt" in files and "configure.ac" not in files:
-            add_buildreq("buildreq-cmake")
-            buildpattern.set_build_pattern("cmake", default_score)
+            if "go.mod" in files:
+                if "Makefile" not in files:
+                    # Go packages usually have make build systems so far
+                    # so only use go directly if we can't find a Makefile
+                    buildpattern.set_build_pattern("golang", default_score)
+                self.add_buildreq("buildreq-golang")
+                if buildpattern.default_pattern == "golang-mod" or buildpattern.default_pattern == "godep":
+                    config.set_gopath = False
+                    mod_path = os.path.join(dirpath, "go.mod")
+                    reqs = parse_go_mod(mod_path)
+                    for req in reqs:
+                        # req[0] is a SCM url segment in the form, repo/XXX/dependency-name
+                        # req[1] is the version of the dependency
+                        pkg = "go-" + req[0].replace("/", "-")
+                        self.add_buildreq(pkg)
+                        if buildpattern.default_pattern == "godep":
+                            self.add_requires(pkg, config.os_packages)
 
-            srcdir = os.path.abspath(os.path.join(dirn, "clr-build", config.cmake_srcdir or ".."))
-            if os.path.samefile(dirpath, srcdir):
-                parse_catkin_deps(os.path.join(srcdir, "CMakeLists.txt"), config.config_opts.get('32bit'))
-
-        if "configure" in files and os.access(dirpath + '/configure', os.X_OK):
-            buildpattern.set_build_pattern("configure", default_score)
-        elif any(is_qmake_pro(f) for f in files):
-            add_buildreq("buildreq-qmake")
-            buildpattern.set_build_pattern("qmake", default_score)
-
-        if "requires.txt" in files:
-            grab_python_requirements(dirpath + '/requires.txt', config.os_packages)
-
-        if "setup.py" in files:
-            add_buildreq("buildreq-distutils3")
-            add_setup_py_requires(dirpath + '/setup.py', config.os_packages)
-            python_pattern = get_python_build_version_from_classifier(dirpath + '/setup.py')
-            buildpattern.set_build_pattern(python_pattern, default_score)
-
-        if "Makefile.PL" in files or "Build.PL" in files:
-            buildpattern.set_build_pattern("cpan", default_score)
-            add_buildreq("buildreq-cpan")
-
-        if "SConstruct" in files:
-            add_buildreq("buildreq-scons")
-            buildpattern.set_build_pattern("scons", default_score)
-
-        if "requirements.txt" in files:
-            grab_python_requirements(dirpath + '/requirements.txt', config.os_packages)
-
-        if "meson.build" in files:
-            add_buildreq("buildreq-meson")
-            buildpattern.set_build_pattern("meson", default_score)
-
-        if "build.xml" in files:
-            add_buildreq("apache-ant")
-            buildpattern.set_build_pattern("ant", default_score)
-
-        for name in files:
-            if name.lower() == "cargo.toml" and dirpath == dirn:
-                parse_cargo_toml(os.path.join(dirpath, name), config.os_packages)
-            if name.lower().startswith("configure."):
-                parse_configure_ac(os.path.join(dirpath, name), config.config_opts.get('32bit'))
-            if name.lower().startswith("rakefile") and buildpattern.default_pattern == "ruby":
-                rakefile(os.path.join(dirpath, name), config.gems)
-            if name.endswith(".pro") and buildpattern.default_pattern == "qmake":
-                qmake_profile(os.path.join(dirpath, name), config.qt_modules)
-            if name.lower() == "makefile":
-                buildpattern.set_build_pattern("make", default_score)
-            if name.lower() == "autogen.sh":
-                buildpattern.set_build_pattern("autogen", default_score)
-            if name.lower() == "cmakelists.txt":
+            if "CMakeLists.txt" in files and "configure.ac" not in files:
+                self.add_buildreq("buildreq-cmake")
                 buildpattern.set_build_pattern("cmake", default_score)
-            if (name.lower() == "cmakelists.txt" or name.endswith(".cmake")) \
-               and buildpattern.default_pattern == "cmake":
-                parse_cmake(os.path.join(dirpath, name), config.cmake_modules, config.config_opts.get('32bit'))
 
-    can_reconf = os.path.exists(os.path.join(dirn, "configure.ac"))
-    if not can_reconf:
-        can_reconf = os.path.exists(os.path.join(dirn, "configure.in"))
+                srcdir = os.path.abspath(os.path.join(dirn, "clr-build", config.cmake_srcdir or ".."))
+                if os.path.samefile(dirpath, srcdir):
+                    self.parse_catkin_deps(os.path.join(srcdir, "CMakeLists.txt"), config.config_opts.get('32bit'))
 
-    if can_reconf and config.autoreconf:
-        print("Patches touch configure.*, adding autoreconf stage")
-        for breq in autoreconf_reqs:
-            add_buildreq(breq)
-    else:
-        config.autoreconf = False
+            if "configure" in files and os.access(dirpath + '/configure', os.X_OK):
+                buildpattern.set_build_pattern("configure", default_score)
+            elif any(is_qmake_pro(f) for f in files):
+                self.add_buildreq("buildreq-qmake")
+                buildpattern.set_build_pattern("qmake", default_score)
 
-    if buildpattern.default_pattern == "distutils3":
-        # First look for a local override
-        pypi_json = ""
-        pypi_file = os.path.join(dlpath, "pypi.json")
-        if os.path.isfile(pypi_file):
-            with open(pypi_file, "r") as pfile:
-                pypi_json = pfile.read()
+            if "requires.txt" in files:
+                self.grab_python_requirements(dirpath + '/requires.txt', config.os_packages)
+
+            if "setup.py" in files:
+                self.add_buildreq("buildreq-distutils3")
+                self.add_setup_py_requires(dirpath + '/setup.py', config.os_packages)
+                python_pattern = get_python_build_version_from_classifier(dirpath + '/setup.py')
+                buildpattern.set_build_pattern(python_pattern, default_score)
+
+            if "Makefile.PL" in files or "Build.PL" in files:
+                buildpattern.set_build_pattern("cpan", default_score)
+                self.add_buildreq("buildreq-cpan")
+
+            if "SConstruct" in files:
+                self.add_buildreq("buildreq-scons")
+                buildpattern.set_build_pattern("scons", default_score)
+
+            if "requirements.txt" in files:
+                self.grab_python_requirements(dirpath + '/requirements.txt', config.os_packages)
+
+            if "meson.build" in files:
+                self.add_buildreq("buildreq-meson")
+                buildpattern.set_build_pattern("meson", default_score)
+
+            if "build.xml" in files:
+                self.add_buildreq("apache-ant")
+                buildpattern.set_build_pattern("ant", default_score)
+
+            for name in files:
+                if name.lower() == "cargo.toml" and dirpath == dirn:
+                    self.parse_cargo_toml(os.path.join(dirpath, name), config.os_packages)
+                if name.lower().startswith("configure."):
+                    self.parse_configure_ac(os.path.join(dirpath, name), config.config_opts.get('32bit'))
+                if name.lower().startswith("rakefile") and buildpattern.default_pattern == "ruby":
+                    self.rakefile(os.path.join(dirpath, name), config.gems)
+                if name.endswith(".pro") and buildpattern.default_pattern == "qmake":
+                    self.qmake_profile(os.path.join(dirpath, name), config.qt_modules)
+                if name.lower() == "makefile":
+                    buildpattern.set_build_pattern("make", default_score)
+                if name.lower() == "autogen.sh":
+                    buildpattern.set_build_pattern("autogen", default_score)
+                if name.lower() == "cmakelists.txt":
+                    buildpattern.set_build_pattern("cmake", default_score)
+                if (name.lower() == "cmakelists.txt" or name.endswith(".cmake")) \
+                   and buildpattern.default_pattern == "cmake":
+                    self.parse_cmake(os.path.join(dirpath, name), config.cmake_modules, config.config_opts.get('32bit'))
+
+        can_reconf = os.path.exists(os.path.join(dirn, "configure.ac"))
+        if not can_reconf:
+            can_reconf = os.path.exists(os.path.join(dirn, "configure.in"))
+        if can_reconf and config.autoreconf:
+            print("Patches touch configure.*, adding autoreconf stage")
+            for breq in self.autoreconf_reqs:
+                self.add_buildreq(breq)
         else:
-            # Try and grab the pypi details for the package
-            if config.alias:
-                tname = config.alias
-            pypi_name = pypidata.get_pypi_name(tname)
-            pypi_json = pypidata.get_pypi_metadata(pypi_name)
-        if pypi_json:
-            try:
-                package_pypi = json.loads(pypi_json)
-            except json.JSONDecodeError:
-                package_pypi = {}
-            if package_pypi.get("name"):
-                pypi_provides = package_pypi["name"]
-            if package_pypi.get("requires"):
-                pypi_requires = set(package_pypi["requires"])
-            if package_pypi.get("license"):
-                # The license field is freeform, might be worth looking at though
-                print(f"Pypi says the license is: {package_pypi['license']}")
-            if package_pypi.get("summary"):
-                specdescription.assign_summary(package_pypi["summary"], 4)
+            config.autoreconf = False
 
-    print("Buildreqs   : ", end="")
-    for lic in sorted(buildreqs):
-        if count > 4:
-            count = 0
-            print("\nBuildreqs   : ", end="")
-        count = count + 1
-        print(lic + " ", end="")
-    print("")
+        if buildpattern.default_pattern == "distutils3":
+            # First look for a local override
+            pypi_json = ""
+            pypi_file = os.path.join(dlpath, "pypi.json")
+            if os.path.isfile(pypi_file):
+                with open(pypi_file, "r") as pfile:
+                    pypi_json = pfile.read()
+            else:
+                # Try and grab the pypi details for the package
+                if config.alias:
+                    tname = config.alias
+                pypi_name = pypidata.get_pypi_name(tname)
+                pypi_json = pypidata.get_pypi_metadata(pypi_name)
+            if pypi_json:
+                try:
+                    package_pypi = json.loads(pypi_json)
+                except json.JSONDecodeError:
+                    package_pypi = {}
+                if package_pypi.get("name"):
+                    self.pypi_provides = package_pypi["name"]
+                if package_pypi.get("requires"):
+                    self.pypi_requires = set(package_pypi["requires"])
+                if package_pypi.get("license"):
+                    # The license field is freeform, might be worth looking at though
+                    print(f"Pypi says the license is: {package_pypi['license']}")
+                if package_pypi.get("summary"):
+                    specdescription.assign_summary(package_pypi["summary"], 4)
 
-
-def load_specfile(specfile):
-    """Load specfile object with necessary buildreq data."""
-    specfile.buildreqs = buildreqs
-    specfile.requires = requires
-    specfile.cargo_bin = cargo_bin
-    specfile.extra_cmake += " " + " ".join(extra_cmake)
-    specfile.pypi_provides = pypi_provides
-    specfile.pypi_requires = sorted(pypi_requires)
-    specfile.extra_cmake_openmpi += " " + " ".join(extra_cmake_openmpi)
+        print("Buildreqs   : ", end="")
+        for lic in sorted(self.buildreqs):
+            if count > 4:
+                count = 0
+                print("\nBuildreqs   : ", end="")
+            count = count + 1
+            print(lic + " ", end="")
+        print("")

--- a/autospec/check.py
+++ b/autospec/check.py
@@ -23,7 +23,6 @@ import os
 import re
 
 import buildpattern
-import buildreq
 import count
 import tarball
 import util
@@ -55,7 +54,7 @@ def check_regression(pkg_dir, skip_tests):
     util.write_out(os.path.join(pkg_dir, "testresults"), res_str)
 
 
-def scan_for_tests(src_dir, config):
+def scan_for_tests(src_dir, config, requirements):
     """Scan source directory for test files and set tests_config accordingly."""
     global tests_config
 
@@ -166,11 +165,11 @@ def scan_for_tests(src_dir, config):
                 break
 
     if "tox.ini" in files:
-        buildreq.add_buildreq("tox")
-        buildreq.add_buildreq("pytest")
-        buildreq.add_buildreq("virtualenv")
-        buildreq.add_buildreq("pluggy")
-        buildreq.add_buildreq("py-python")
+        requirements.add_buildreq("tox")
+        requirements.add_buildreq("pytest")
+        requirements.add_buildreq("virtualenv")
+        requirements.add_buildreq("pluggy")
+        requirements.add_buildreq("py-python")
 
 
 def load_specfile(specfile):

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -91,7 +91,7 @@ class Config(object):
         self.extra_make32_install = ""
         self.extra_cmake = ""
         self.extra_cmake_openmpi = ""
-        self.cmake_srcdir = ""
+        self.cmake_srcdir = ".."
         self.subdir = ""
         self.install_macro = "%make_install"
         self.disable_static = "--disable-static"
@@ -929,31 +929,3 @@ class Config(object):
 
         self.custom_desc = self.read_conf_file(os.path.join(path, "description"))
         self.custom_summ = self.read_conf_file(os.path.join(path, "summary"))
-
-    def load_specfile(self, specfile):
-        """Load specfile object with configuration."""
-        specfile.urlban = self.urlban
-        specfile.keepstatic = self.config_opts['keepstatic']
-        specfile.no_autostart = self.config_opts['no_autostart']
-        specfile.extra_make = self.extra_make
-        specfile.extra32_make = self.extra32_make
-        specfile.extra_make_install = self.extra_make_install
-        specfile.extra_make32_install = self.extra_make32_install
-        specfile.extra_cmake = self.extra_cmake
-        specfile.extra_cmake_openmpi = self.extra_cmake_openmpi
-        specfile.cmake_srcdir = self.cmake_srcdir or specfile.cmake_srcdir
-        specfile.subdir = self.subdir
-        specfile.install_macro = self.install_macro
-        specfile.disable_static = self.disable_static
-        specfile.prep_prepend = self.prep_prepend
-        specfile.build_prepend = self.build_prepend
-        specfile.build_append = self.build_append
-        specfile.make_prepend = self.make_prepend
-        specfile.install_prepend = self.install_prepend
-        specfile.install_append = self.install_append
-        specfile.service_restart = self.service_restart
-        specfile.extra_sources = self.extra_sources
-        specfile.patches = self.patches
-        specfile.verpatches = self.verpatches
-        specfile.autoreconf = self.autoreconf
-        specfile.set_gopath = self.set_gopath

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -26,7 +26,6 @@ from collections import OrderedDict
 
 import build
 import buildpattern
-import buildreq
 import download
 from util import call, do_regex, get_sha1sum, print_fatal, write_out
 
@@ -358,12 +357,6 @@ def name_and_version(name_arg, version_arg, filemanager, config):
             version = convert_version(version, name)
             if not giturl:
                 giturl = "https://github.com/" + match.group(1).strip() + "/" + repo + ".git"
-
-    if "gnome.org" in url:
-        buildreq.add_buildreq("buildreq-gnome")
-
-    if "kde.org" in url or "https://github.com/KDE" in url:
-        buildreq.add_buildreq("buildreq-kde")
 
     # SQLite tarballs use 7 digit versions, e.g 3290000 = 3.29.0, 3081002 = 3.8.10.2
     if "sqlite.org" in url:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from unittest.mock import mock_open, patch
 
+import buildreq
 import check
 import config
 
@@ -28,7 +29,6 @@ class TestTest(unittest.TestCase):
     def setUp(self):
         check.tests_config = ''
         check.tarball.name = ''
-        check.buildreq.buildreqs = set()
         check.buildpattern.default_pattern = "make"
 
     def test_check_regression(self):
@@ -88,6 +88,7 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with makecheck suite
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.in'])
@@ -95,7 +96,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "configure"
-            check.scan_for_tests('pkgdir', conf)
+            check.scan_for_tests('pkgdir', conf, reqs)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -106,13 +107,14 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with makecheck suite via Makefile.am
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.am'])
         m_open = mock_open()
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "configure_ac"
-            check.scan_for_tests('pkgdir', conf)
+            check.scan_for_tests('pkgdir', conf, reqs)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -123,11 +125,12 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with perlcheck suite
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.PL'])
         check.buildpattern.default_pattern = "cpan"
-        check.scan_for_tests('pkgdir', conf)
+        check.scan_for_tests('pkgdir', conf, reqs)
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
         self.assertEqual(check.tests_config, 'make TEST_VERBOSE=1 test')
@@ -136,6 +139,7 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with perlcheck suite via Makefile.in
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.in'])
@@ -143,7 +147,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "cpan"
-            check.scan_for_tests('pkgdir', conf)
+            check.scan_for_tests('pkgdir', conf, reqs)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -153,6 +157,7 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with setup.py suite
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['setup.py'])
@@ -160,7 +165,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "distutils3"
-            check.scan_for_tests('pkgdir', conf)
+            check.scan_for_tests('pkgdir', conf, reqs)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -172,6 +177,7 @@ class TestTest(unittest.TestCase):
         """
         Test scan_for_tests with cmake suite
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['CMakeLists.txt'])
@@ -179,7 +185,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "cmake"
-            check.scan_for_tests('pkgdir', conf)
+            check.scan_for_tests('pkgdir', conf, reqs)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -191,12 +197,13 @@ class TestTest(unittest.TestCase):
         Test scan_for_tests with tox.ini in the files list, should add several
         build requirements
         """
+        reqs = buildreq.Requirements("")
         conf = config.Config()
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['tox.ini'])
-        check.scan_for_tests('pkgdir', conf)
+        check.scan_for_tests('pkgdir', conf, reqs)
         check.os.listdir = listdir_backup
-        self.assertEqual(check.buildreq.buildreqs,
+        self.assertEqual(reqs.buildreqs,
                          set(['tox',
                               'pytest',
                               'virtualenv',

--- a/tests/test_infile_update_spec.py
+++ b/tests/test_infile_update_spec.py
@@ -1,5 +1,6 @@
 import unittest
 
+import buildreq
 import config
 import infile_update_spec
 import specfiles
@@ -9,7 +10,7 @@ class TestUpdateSpecfile(unittest.TestCase):
     def setUp(self):
         # url, version, name, release
         url = "http://www.testpkg.com/testpkg/pkg-1.0.tar.gz"
-        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1', config.Config())
+        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1', config.Config(), buildreq.Requirements(url))
 
         self.bb_dict = {
             "DEPENDS": "ncurses gettext-native",

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -1,5 +1,6 @@
 import unittest
 import unittest.mock
+import buildreq
 import config
 import specfiles
 
@@ -15,7 +16,8 @@ class TestSpecfileWrite(unittest.TestCase):
         conf = config.Config()
         conf.config_opts['dev_requires_extras'] = False
         url = "http://www.testpkg.com/testpkg/pkg-1.0.tar.gz"
-        self.specfile = specfiles.Specfile(url, '1.0', 'pkg', '2', conf)
+        reqs = buildreq.Requirements(url)
+        self.specfile = specfiles.Specfile(url, '1.0', 'pkg', '2', conf, reqs)
 
         def mock_write(string):
             self.WRITES.append(string)
@@ -100,8 +102,8 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["autostart"] = ["autostart"]
         self.specfile.packages["bin"] = []
         self.specfile.packages["lib"] = ["package.so"]
-        self.specfile.requires.add("pkg1")
-        self.specfile.requires.add("pkg2")
+        self.specfile.requirements.requires.add("pkg1")
+        self.specfile.requirements.requires.add("pkg2")
         self.specfile.config.config_opts['no_autostart'] = True
         self.specfile.write_main_subpackage_requires()
         expect = ["Requires: pkg-bin = %{version}-%{release}\n",
@@ -122,8 +124,8 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["ignore"] = []
         self.specfile.packages["dev"] = []
         self.specfile.packages["active-units"] = []
-        self.specfile.requires.add("pkg1")
-        self.specfile.requires.add("pkg2")
+        self.specfile.requirements.requires.add("pkg1")
+        self.specfile.requirements.requires.add("pkg2")
         self.specfile.write_main_subpackage_requires()
         expect = ["Requires: pkg-autostart = %{version}-%{release}\n",
                   "Requires: pkg-bin = %{version}-%{release}\n",
@@ -143,7 +145,7 @@ class TestSpecfileWrite(unittest.TestCase):
         """
         test write_buildreq with unsorted list of build requirements.
         """
-        self.specfile.buildreqs = ["python", "ruby", "go"]
+        self.specfile.requirements.buildreqs = ["python", "ruby", "go"]
         self.specfile.write_buildreq()
         expect = ["BuildRequires : go\n",
                   "BuildRequires : python\n",
@@ -195,8 +197,8 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["python"] = ["pyfile1", "pyfile2"]
         self.specfile.packages["dev"] = ["dev1", "dev2"]
         self.specfile.packages["pack"] = ["packf1"]
-        self.specfile.requires = ["pep8", "pylint", "pycurl"]
-        self.specfile.buildreqs = ["pep8", "pycurl"]
+        self.specfile.requirements.requires = ["pep8", "pylint", "pycurl"]
+        self.specfile.requirements.buildreqs = ["pep8", "pycurl"]
         self.specfile.write_files_header()
         expect = ["\n%package data\n",
                   "Summary: data components for the pkg package.\n",

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -40,7 +40,7 @@ class TestSpecfileWrite(unittest.TestCase):
         """
         test Specfile.write_nvr with urlban set
         """
-        self.specfile.urlban = "www.testpkg.com"
+        self.specfile.config.urlban = "www.testpkg.com"
         self.specfile.write_nvr()
         expect = ["Name     : pkg\n",
                   "Version  : 1.0\n",
@@ -102,7 +102,7 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["lib"] = ["package.so"]
         self.specfile.requires.add("pkg1")
         self.specfile.requires.add("pkg2")
-        self.specfile.no_autostart = True
+        self.specfile.config.config_opts['no_autostart'] = True
         self.specfile.write_main_subpackage_requires()
         expect = ["Requires: pkg-bin = %{version}-%{release}\n",
                   "Requires: pkg-lib = %{version}-%{release}\n",
@@ -161,9 +161,9 @@ class TestSpecfileWrite(unittest.TestCase):
         """
         test write_patch_header with list of patches.
         """
-        self.specfile.patches = ["speedup.patch",
-                                 "slowdown.patch",
-                                 "revert.patch reverts slowdown.patch"]
+        self.specfile.config.patches = ["speedup.patch",
+                                        "slowdown.patch",
+                                        "revert.patch reverts slowdown.patch"]
         self.specfile.write_patch_header()
         expect = ["Patch1: speedup.patch\n",
                   "Patch2: slowdown.patch\n",
@@ -421,7 +421,7 @@ class TestSpecfileWrite(unittest.TestCase):
         Validate that service_restart configuration is written to the spec file
         correctly.
         """
-        self.specfile.service_restart = [
+        self.specfile.config.service_restart = [
                 "/usr/lib/systemd/system/foo.service",
                 "/usr/lib/systemd/system/bar.service",
         ]


### PR DESCRIPTION
The first change adds a little more cleanup from the config
refactor. I incorporated that type of change into the buildreq
refactor commit directly.

This one is a little lighter than the config refactor thankfully since
buildreq wasn't used in quite as many places.