### PR TITLE
Refactor tarball to remove remaining globals

### DIFF
--- a/autospec/abireport.py
+++ b/autospec/abireport.py
@@ -27,7 +27,6 @@ import shutil
 import subprocess
 import sys
 
-import tarball
 import util
 
 valid_dirs = ["/usr/lib", "/usr/lib64"]
@@ -202,7 +201,7 @@ def truncate_file(path):
         trunc.truncate()
 
 
-def examine_abi(download_path):
+def examine_abi(download_path, name):
     """Proxy the ABI reporting to the right function."""
     download_path = os.path.abspath(download_path)
     results_dir = os.path.abspath(os.path.join(download_path, "results"))
@@ -212,17 +211,17 @@ def examine_abi(download_path):
         sys.exit(1)
 
     if util.binary_in_path("abireport"):
-        examine_abi_host(download_path, results_dir)
+        examine_abi_host(download_path, results_dir, name)
     else:
         util.print_warning("abireport is not installed. Using slow scanning")
-        examine_abi_fallback(download_path, results_dir)
+        examine_abi_fallback(download_path, results_dir, name)
 
 
-def examine_abi_host(download_path, results_dir):
+def examine_abi_host(download_path, results_dir, name):
     """Make use of the hostside abireport tool."""
     rpms = set()
     for item in os.listdir(results_dir):
-        namelen = len(tarball.name)
+        namelen = len(name)
         if item.find("-extras-", namelen) >= namelen:
             continue
         if item.endswith(".rpm") and not item.endswith(".src.rpm"):
@@ -239,13 +238,13 @@ def examine_abi_host(download_path, results_dir):
         util.print_fatal("Error invoking abireport: {}".format(e))
 
 
-def examine_abi_fallback(download_path, results_dir):
+def examine_abi_fallback(download_path, results_dir, name):
     """Missing abireport so fallback to internal scanning."""
     old_dir = os.getcwd()
 
     rpms = set()
     for item in os.listdir(results_dir):
-        namelen = len(tarball.name)
+        namelen = len(name)
         if item.find("-extras-", namelen) >= namelen:
             continue
         if item.endswith(".rpm") and not item.endswith(".src.rpm"):

--- a/autospec/check.py
+++ b/autospec/check.py
@@ -24,7 +24,6 @@ import re
 
 import buildpattern
 import count
-import tarball
 import util
 
 tests_config = ""
@@ -54,7 +53,7 @@ def check_regression(pkg_dir, skip_tests):
     util.write_out(os.path.join(pkg_dir, "testresults"), res_str)
 
 
-def scan_for_tests(src_dir, config, requirements):
+def scan_for_tests(src_dir, config, requirements, content):
     """Scan source directory for test files and set tests_config accordingly."""
     global tests_config
 
@@ -90,8 +89,8 @@ def scan_for_tests(src_dir, config, requirements):
         "perlcheck": perl_check,
         "setup.py": setup_check,
         "cmake": "cd clr-build; " + cmake_check,
-        "rakefile": "pushd %{buildroot}%{gem_dir}/gems/" + tarball.tarball_prefix + "\nrake --trace test TESTOPTS=\"-v\"\npopd",
-        "rspec": "pushd %{buildroot}%{gem_dir}/gems/" + tarball.tarball_prefix + "\nrspec -I.:lib spec/\npopd",
+        "rakefile": "pushd %{buildroot}%{gem_dir}/gems/" + content.tarball_prefix + "\nrake --trace test TESTOPTS=\"-v\"\npopd",
+        "rspec": "pushd %{buildroot}%{gem_dir}/gems/" + content.tarball_prefix + "\nrspec -I.:lib spec/\npopd",
         "meson": meson_check,
     }
     if config.config_opts.get('32bit'):
@@ -147,7 +146,7 @@ def scan_for_tests(src_dir, config, requirements):
     elif buildpattern.default_pattern == "R":
         tests_config = "export _R_CHECK_FORCE_SUGGESTS_=false\n"              \
                        "R CMD check --no-manual --no-examples --no-codoc "    \
-                       + tarball.rawname + " || :"
+                       + content.rawname + " || :"
     elif buildpattern.default_pattern == "meson":
         found_tests = False
         makefile_path = os.path.join(src_dir, "meson.build")

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -24,7 +24,6 @@ import re
 from collections import OrderedDict
 
 import build
-import tarball
 import util
 
 
@@ -188,7 +187,7 @@ class FileManager(object):
 
         return removed
 
-    def push_file(self, filename):
+    def push_file(self, filename, pkg_name):
         """Perform a number of checks against the filename and push the filename if appropriate."""
         if filename in self.files or filename in self.files_blacklist:
             return
@@ -309,7 +308,7 @@ class FileManager(object):
             (r"^/usr/share/aclocal/[a-zA-Z0-9._+-]*\.m4$", "dev", "/usr/share/aclocal/*.m4"),
             (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9._+-]*\.ac$", "dev", "/usr/share/aclocal-1.*/*.ac"),
             (r"^/usr/share/aclocal-1.[0-9]+/[a-zA-Z0-9._+-]*\.m4$", "dev", "/usr/share/aclocal-1.*/*.m4"),
-            (r"^/usr/share/doc/" + re.escape(tarball.name) + "/", "doc", "%doc /usr/share/doc/" + re.escape(tarball.name) + "/*"),
+            (r"^/usr/share/doc/" + re.escape(pkg_name) + "/", "doc", "%doc /usr/share/doc/" + re.escape(pkg_name) + "/*"),
             (r"^/usr/share/doc/", "doc"),
             (r"^/usr/share/gtk-doc/html", "doc"),
             (r"^/usr/share/help", "doc"),

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -25,11 +25,10 @@ import subprocess
 
 import build
 import buildpattern
-import tarball
 from util import call, write_out
 
 
-def commit_to_git(path, config):
+def commit_to_git(path, config, name):
     """Update package's git tree for autospec managed changes."""
     call("git init", stdout=subprocess.DEVNULL, cwd=path)
 
@@ -38,7 +37,7 @@ def commit_to_git(path, config):
         try:
             call("git config --get remote.origin.url", cwd=path)
         except subprocess.CalledProcessError:
-            upstream_uri = config.git_uri % {'NAME': tarball.name}
+            upstream_uri = config.git_uri % {'NAME': name}
             call("git remote add origin %s" % upstream_uri, cwd=path)
 
     for config_file in config.config_files:
@@ -48,7 +47,7 @@ def commit_to_git(path, config):
     call("git add Makefile", cwd=path)
     call("git add upstream", cwd=path)
     call("bash -c 'shopt -s failglob; git add *.spec'", cwd=path)
-    call("git add %s.tmpfiles" % tarball.name, check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add %s.tmpfiles" % name, check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add prep_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add pypi.json", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add build_prepend", check=False, stderr=subprocess.DEVNULL, cwd=path)

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -30,7 +30,6 @@ import urllib.parse
 import chardet
 import download
 
-import tarball
 from util import get_contents, get_sha1sum, print_fatal, print_warning
 
 default_license = "TO BE DETERMINED"
@@ -95,7 +94,7 @@ def decode_license(license):
     return try_with_charset(license, chardet.detect(license)['encoding'])
 
 
-def license_from_copying_hash(copying, srcdir, config):
+def license_from_copying_hash(copying, srcdir, config, name):
     """Add licenses based on the hash of the copying file."""
     try:
         data = get_contents(copying)
@@ -114,7 +113,7 @@ def license_from_copying_hash(copying, srcdir, config):
     hash_sum = get_sha1sum(copying)
 
     if config.license_fetch:
-        values = {'hash': hash_sum, 'text': data, 'package': tarball.name}
+        values = {'hash': hash_sum, 'text': data, 'package': name}
         data = urllib.parse.urlencode(values)
         data = data.encode('utf-8')
 
@@ -149,7 +148,7 @@ def license_from_copying_hash(copying, srcdir, config):
         print_warning("Visit {0} to enter".format(hash_url))
 
 
-def scan_for_licenses(srcdir, config):
+def scan_for_licenses(srcdir, config, pkg_name):
     """Scan the project directory for things we can use to guess a description and summary."""
     targets = ["copyright",
                "copyright.txt",
@@ -169,10 +168,10 @@ def scan_for_licenses(srcdir, config):
         for name in files:
             if name.lower() in targets or target_pat.search(name.lower()):
                 license_from_copying_hash(os.path.join(dirpath, name),
-                                          srcdir, config)
+                                          srcdir, config, pkg_name)
 
     if not licenses:
-        print_fatal(" Cannot find any license or a valid {}.license file!\n".format(tarball.name))
+        print_fatal(" Cannot find any license or a valid {}.license file!\n".format(pkg_name))
         sys.exit(1)
 
     print("Licenses    : ", " ".join(sorted(licenses)))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,7 +6,7 @@ import build
 import buildreq
 import config
 import files
-
+import tarball
 
 class TestBuildpattern(unittest.TestCase):
 
@@ -24,10 +24,8 @@ class TestBuildpattern(unittest.TestCase):
         """
         Test that setup_workingdir sets the correct directory patterns
         """
-        build.tarball.name = "testtarball"
         build.setup_workingdir("test_directory")
         self.assertEqual(build.base_path, "test_directory")
-        self.assertEqual(build.download_path, "test_directory/testtarball")
 
     def test_simple_pattern_pkgconfig(self):
         """
@@ -371,6 +369,7 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
+        tcontent = tarball.Content("", "", "", [], conf)
         conf.config_opts['32bit'] = True
         call_backup = build.util.call
         build.util.call = mock_util_call
@@ -381,7 +380,7 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs)
+            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
@@ -400,6 +399,7 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
+        tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
         fm = files.FileManager(conf)
@@ -409,7 +409,7 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs)
+            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
@@ -424,6 +424,7 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
+        tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         open_auto_backup = build.util.open_auto
         build.util.call = MagicMock(return_value=None)
@@ -436,7 +437,7 @@ class TestBuildpattern(unittest.TestCase):
                     input, output = error.strip('\n').split('|')
                     reqs.buildreqs = set()
                     build.util.open_auto = mock_open(read_data=input)
-                    build.parse_build_results('testname', 0, fm, conf, reqs)
+                    build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
                     self.assertIn(output, reqs.buildreqs)
                     self.assertGreater(build.must_restart, 0)
@@ -455,6 +456,7 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
+        tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
         fm = files.FileManager(conf)
@@ -470,7 +472,7 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs)
+            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
@@ -491,6 +493,7 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
+        tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
         fm = files.FileManager(conf)
@@ -508,7 +511,7 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs)
+            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,6 +6,7 @@ from unittest.mock import mock_open, patch
 import buildreq
 import check
 import config
+import tarball
 
 def mock_generator(rv=None):
     def mock_f(*args, **kwargs):
@@ -28,7 +29,6 @@ class TestTest(unittest.TestCase):
 
     def setUp(self):
         check.tests_config = ''
-        check.tarball.name = ''
         check.buildpattern.default_pattern = "make"
 
     def test_check_regression(self):
@@ -90,13 +90,14 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.in'])
         content = 'check:'
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "configure"
-            check.scan_for_tests('pkgdir', conf, reqs)
+            check.scan_for_tests('pkgdir', conf, reqs, tcontent)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -109,12 +110,13 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.am'])
         m_open = mock_open()
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "configure_ac"
-            check.scan_for_tests('pkgdir', conf, reqs)
+            check.scan_for_tests('pkgdir', conf, reqs, tcontent)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -127,10 +129,11 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.PL'])
         check.buildpattern.default_pattern = "cpan"
-        check.scan_for_tests('pkgdir', conf, reqs)
+        check.scan_for_tests('pkgdir', conf, reqs, tcontent)
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
         self.assertEqual(check.tests_config, 'make TEST_VERBOSE=1 test')
@@ -141,13 +144,14 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['Makefile.in'])
         content = 'test:'
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "cpan"
-            check.scan_for_tests('pkgdir', conf, reqs)
+            check.scan_for_tests('pkgdir', conf, reqs, tcontent)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -159,13 +163,14 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['setup.py'])
         content = 'test_suite'
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "distutils3"
-            check.scan_for_tests('pkgdir', conf, reqs)
+            check.scan_for_tests('pkgdir', conf, reqs, tcontent)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -179,13 +184,14 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['CMakeLists.txt'])
         content = 'enable_testing'
         m_open = mock_open(read_data=content)
         with patch(self.open_name, m_open, create=True):
             check.buildpattern.default_pattern = "cmake"
-            check.scan_for_tests('pkgdir', conf, reqs)
+            check.scan_for_tests('pkgdir', conf, reqs, tcontent)
 
         check.os.listdir = listdir_backup
         check.buildpattern.default_pattern = "make"
@@ -199,9 +205,10 @@ class TestTest(unittest.TestCase):
         """
         reqs = buildreq.Requirements("")
         conf = config.Config()
+        tcontent = tarball.Content("", "", "", [], conf)
         listdir_backup = os.listdir
         check.os.listdir = mock_generator(['tox.ini'])
-        check.scan_for_tests('pkgdir', conf, reqs)
+        check.scan_for_tests('pkgdir', conf, reqs, tcontent)
         check.os.listdir = listdir_backup
         self.assertEqual(reqs.buildreqs,
                          set(['tox',

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -150,7 +150,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         autostart = '/usr/lib/systemd/system/some.target.wants/some'
-        self.fm.push_file(autostart)
+        self.fm.push_file(autostart, '')
         calls = [call(autostart, 'autostart'), call('%exclude ' + autostart, 'services')]
         self.fm.push_package_file.assert_has_calls(calls)
 
@@ -161,7 +161,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.extras.append('test')
-        self.fm.push_file('test')
+        self.fm.push_file('test', '')
         calls = [call('test', 'extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
@@ -173,7 +173,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.custom_extras = {'test-extras': {'files': ["test"]}}
-        self.fm.push_file('test')
+        self.fm.push_file('test', '')
         calls = [call('test', 'test-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
@@ -185,7 +185,7 @@ class TestFiles(unittest.TestCase):
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
         self.fm.setuid.append('test')
-        self.fm.push_file('test')
+        self.fm.push_file('test', '')
         calls = [call('%attr(4755, root, root) test', 'setuid')]
         self.fm.push_package_file.assert_has_calls(calls)
 
@@ -196,18 +196,17 @@ class TestFiles(unittest.TestCase):
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
-        self.fm.push_file('/usr/bin/test')
+        self.fm.push_file('/usr/bin/test', '')
         self.fm.push_package_file.assert_called_once_with('/usr/bin/test', 'bin')
 
-    def test_push_file_match_tarball_name_dependency(self):
+    def test_push_file_match_pkg_name_dependency(self):
         """
         Test push_file with match in the list on the single item that is
-        dependent on the tarball name.
+        dependent on the pkg_name.
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
-        files.tarball.name = 'testball'
-        self.fm.push_file('/usr/share/doc/testball/')
+        self.fm.push_file('/usr/share/doc/testball/', 'testball')
         self.fm.push_package_file.assert_called_once_with('%doc /usr/share/doc/testball/*', 'doc')
 
     def test_push_file_no_match(self):
@@ -217,7 +216,7 @@ class TestFiles(unittest.TestCase):
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
-        self.fm.push_file('doesntmatcha thing')
+        self.fm.push_file('doesntmatcha thing', '')
         self.fm.push_package_file.assert_called_once_with('doesntmatcha thing')
 
     def test_remove_file(self):

--- a/tests/test_infile_update_spec.py
+++ b/tests/test_infile_update_spec.py
@@ -4,13 +4,17 @@ import buildreq
 import config
 import infile_update_spec
 import specfiles
+import tarball
 
 
 class TestUpdateSpecfile(unittest.TestCase):
     def setUp(self):
         # url, version, name, release
         url = "http://www.testpkg.com/testpkg/pkg-1.0.tar.gz"
-        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1', config.Config(), buildreq.Requirements(url))
+        conf = config.Config()
+        content = tarball.Content('', '', '', [], conf)
+        conf.content = content
+        self.specfile = specfiles.Specfile(url, '1.1.1', 'test_pkg', '1', conf, buildreq.Requirements(url), content)
 
         self.bb_dict = {
             "DEPENDS": "ncurses gettext-native",

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -60,7 +60,7 @@ class TestLicense(unittest.TestCase):
         """
         conf = config.Config()
         conf.setup_patterns()
-        license.license_from_copying_hash('tests/COPYING_TEST', '', conf)
+        license.license_from_copying_hash('tests/COPYING_TEST', '', conf, '')
         self.assertIn('GPL-3.0', license.licenses)
 
     def test_license_from_copying_hash_no_license_show(self):
@@ -73,7 +73,7 @@ class TestLicense(unittest.TestCase):
         # remove the hash from license_hashes
         del(conf.license_hashes[license.get_sha1sum('tests/COPYING_TEST')])
         conf.license_show = "license.show.url"
-        license.license_from_copying_hash('tests/COPYING_TEST', '', conf)
+        license.license_from_copying_hash('tests/COPYING_TEST', '', conf, '')
 
         self.assertEquals(license.licenses, [])
 
@@ -87,7 +87,7 @@ class TestLicense(unittest.TestCase):
         m_open.__str__.return_value = content
 
         with patch('license.get_contents', m_open, create=True):
-            license.license_from_copying_hash('copying.txt', '', conf)
+            license.license_from_copying_hash('copying.txt', '', conf, '')
 
         self.assertEquals(license.licenses, [])
 
@@ -125,7 +125,7 @@ class TestLicense(unittest.TestCase):
         out = StringIO()
         with redirect_stdout(out):
             with self.assertRaises(SystemExit):
-                license.license_from_copying_hash('tests/COPYING_TEST', '', conf)
+                license.license_from_copying_hash('tests/COPYING_TEST', '', conf, '')
 
         self.assertIn('Unable to fetch license.server.url: Test Exception', out.getvalue())
 
@@ -178,7 +178,7 @@ class TestLicense(unittest.TestCase):
         # let's check that the proper thing is being printed as well
         out = StringIO()
         with redirect_stdout(out):
-            license.license_from_copying_hash('tests/COPYING_TEST', '', conf)
+            license.license_from_copying_hash('tests/COPYING_TEST', '', conf, '')
 
         self.assertIn('GPL-3.0', license.licenses)
         self.assertIn('License     :  GPL-3.0  (server)', out.getvalue())
@@ -206,7 +206,7 @@ class TestLicense(unittest.TestCase):
             for testf in ['testlib.c', 'testmain.c', 'testheader.h']:
                 with open(os.path.join(tmpd, testf), 'w') as newtestf:
                     newtestf.write('test content')
-            license.scan_for_licenses(tmpd, conf)
+            license.scan_for_licenses(tmpd, conf, '')
 
         self.assertIn('GPL-3.0', license.licenses)
 
@@ -227,7 +227,7 @@ class TestLicense(unittest.TestCase):
             out = StringIO()
             with redirect_stdout(out):
                 with self.assertRaises(SystemExit) as thread:
-                    license.scan_for_licenses(tmpd, conf)
+                    license.scan_for_licenses(tmpd, conf, '')
 
         self.assertEqual(thread.exception.code, 1)
         self.assertIn("Cannot find any license", out.getvalue())

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -3,6 +3,7 @@ import unittest.mock
 import buildreq
 import config
 import specfiles
+import tarball
 
 
 class TestSpecfileWrite(unittest.TestCase):
@@ -16,8 +17,10 @@ class TestSpecfileWrite(unittest.TestCase):
         conf = config.Config()
         conf.config_opts['dev_requires_extras'] = False
         url = "http://www.testpkg.com/testpkg/pkg-1.0.tar.gz"
+        content = tarball.Content(url, 'pkg', '1.0', [], conf)
+        conf.content = content
         reqs = buildreq.Requirements(url)
-        self.specfile = specfiles.Specfile(url, '1.0', 'pkg', '2', conf, reqs)
+        self.specfile = specfiles.Specfile(url, '1.0', 'pkg', '2', conf, reqs, content)
 
         def mock_write(string):
             self.WRITES.append(string)


### PR DESCRIPTION
The tarball module had a number of globals that were referenced by
many other modules and has ordering dependencies with the config
module for some values. This made deciding on where certain values get
initialized difficult but before the initialization can be addressed a
refactor is helpful.

This change moves the global state (and functions that needed to
act on that global state) into a Content class. The goal of this work
is to better track what can be updated by a particular function, load
data in a sensible order and have it owned by a sensible component.

I expect that future work will see the tarball, buildpattern and some
portions of the config moved around to better match what component
should own what data (and to better deliniate between the data that
has a similar use but comes from different sources).