### PR TITLE
Refactor build to remove remaining globals

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -60,7 +60,7 @@ def add_sources(download_path, archives, content):
     # /run or /tmp.
     #
     if os.path.exists(os.path.normpath(
-            build.download_path + "/{0}.tmpfiles".format(content.name))):
+            download_path + "/{0}.tmpfiles".format(content.name))):
         buildpattern.sources["tmpfile"].append(
             "{}.tmpfiles".format(content.name))
     if content.gcov_file:
@@ -238,23 +238,23 @@ def package(args, url, name, archives, workingdir, infile_dict):
     """Entry point for building a package with autospec."""
     conf = config.Config()
     check_requirements(args.git)
-    build.setup_workingdir(workingdir)
+    package = build.Build(workingdir)
 
     #
     # First, download the tarball, extract it and then do a set
     # of static analysis on the content of the tarball.
     #
-    filemanager = files.FileManager(conf)
+    filemanager = files.FileManager(conf, package)
     content = tarball.Content(url, name, args.version, archives, conf)
     content.process(args.target, filemanager)
-    conf.create_versions(build.download_path, content.multi_version)
+    conf.create_versions(package.download_path, content.multi_version)
     conf.content = content  # hack to avoid recursive dependency on init
     # Search up one level from here to capture multiple versions
     _dir = content.path
 
     if args.license_only:
         try:
-            with open(os.path.join(build.download_path,
+            with open(os.path.join(package.download_path,
                                    content.name + ".license"), "r") as dotlic:
                 for word in dotlic.read().split():
                     if ":" not in word:
@@ -269,20 +269,20 @@ def package(args, url, name, archives, workingdir, infile_dict):
     conf.config_file = args.config
     requirements = buildreq.Requirements(content.url)
     requirements.set_build_req()
-    conf.parse_config_files(build.download_path, args.bump, filemanager, content, requirements)
+    conf.parse_config_files(package.download_path, args.bump, filemanager, content, requirements)
     conf.setup_patterns(conf.failed_pattern_dir)
-    conf.parse_existing_spec(build.download_path, content.name)
+    conf.parse_existing_spec(package.download_path, content.name)
 
     if args.prep_only:
         write_prep(conf, workingdir, content)
         exit(0)
 
-    requirements.scan_for_configure(_dir, content.name, build.download_path, conf)
+    requirements.scan_for_configure(_dir, content.name, package.download_path, conf)
     specdescription.scan_for_description(content.name, _dir, conf.license_translations, conf.license_blacklist)
     # Start one directory higher so we scan *all* versions for licenses
     license.scan_for_licenses(os.path.dirname(_dir), conf, content.name)
-    commitmessage.scan_for_changes(build.download_path, _dir, conf.transforms)
-    add_sources(build.download_path, archives, content)
+    commitmessage.scan_for_changes(package.download_path, _dir, conf.transforms)
+    add_sources(package.download_path, archives, content)
     check.scan_for_tests(_dir, conf, requirements, content)
 
     #
@@ -310,33 +310,33 @@ def package(args, url, name, archives, workingdir, infile_dict):
 
     if args.integrity:
         interactive_mode = not args.non_interactive
-        pkg_integrity.check(url, build.download_path, conf, interactive=interactive_mode)
+        pkg_integrity.check(url, package.download_path, conf, interactive=interactive_mode)
         pkg_integrity.load_specfile(specfile)
 
-    specfile.write_spec(build.download_path)
+    specfile.write_spec(package.download_path)
     while 1:
-        build.package(filemanager, args.mock_config, args.mock_opts, conf, requirements, content, args.cleanup)
+        package.package(filemanager, args.mock_config, args.mock_opts, conf, requirements, content, args.cleanup)
         filemanager.load_specfile(specfile)
-        specfile.write_spec(build.download_path)
+        specfile.write_spec(package.download_path)
         filemanager.newfiles_printed = 0
         mock_chroot = "/var/lib/mock/clear-{}/root/builddir/build/BUILDROOT/" \
-                      "{}-{}-{}.x86_64".format(build.uniqueext,
+                      "{}-{}-{}.x86_64".format(package.uniqueext,
                                                content.name,
                                                content.version,
                                                content.release)
         if filemanager.clean_directories(mock_chroot):
             # directories added to the blacklist, need to re-run
-            build.must_restart += 1
+            package.must_restart += 1
 
-        if build.round > 20 or build.must_restart == 0:
+        if package.round > 20 or package.must_restart == 0:
             break
 
-        save_mock_logs(build.download_path, build.round)
+        save_mock_logs(package.download_path, package.round)
 
-    check.check_regression(build.download_path, conf.config_opts['skip_tests'])
+    check.check_regression(package.download_path, conf.config_opts['skip_tests'])
 
-    if build.success == 0:
-        conf.create_buildreq_cache(build.download_path, content.version, requirements.buildreqs_cache)
+    if package.success == 0:
+        conf.create_buildreq_cache(package.download_path, content.version, requirements.buildreqs_cache)
         print_fatal("Build failed, aborting")
         sys.exit(1)
     elif os.path.isfile("README.clear"):
@@ -350,20 +350,20 @@ def package(args, url, name, archives, workingdir, infile_dict):
         except Exception:
             pass
 
-    examine_abi(build.download_path, content.name)
+    examine_abi(package.download_path, content.name)
     if os.path.exists("/var/lib/rpm"):
         pkg_scan.get_whatrequires(content.name, conf.yum_conf)
 
-    write_out(build.download_path + "/release", content.release + "\n")
+    write_out(package.download_path + "/release", content.release + "\n")
 
     # record logcheck output
-    logcheck(build.download_path)
+    logcheck(package.download_path)
 
-    commitmessage.guess_commit_message(pkg_integrity.IMPORTED, conf, content)
-    conf.create_buildreq_cache(build.download_path, content.version, requirements.buildreqs_cache)
+    commitmessage.guess_commit_message(pkg_integrity.IMPORTED, conf, content, package)
+    conf.create_buildreq_cache(package.download_path, content.version, requirements.buildreqs_cache)
 
     if args.git:
-        git.commit_to_git(build.download_path, conf, content.name)
+        git.commit_to_git(package.download_path, conf, content.name, package.success)
     else:
         print("To commit your changes, git add the relevant files and "
               "run 'git commit -F commitmsg'")

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -25,38 +25,6 @@ import shutil
 
 import util
 
-success = 0
-round = 0
-must_restart = 0
-base_path = None
-download_path = None
-uniqueext = ''
-warned_about = set()
-
-
-def setup_workingdir(workingdir):
-    """Create directory for expanding tar file."""
-    global base_path
-    base_path = workingdir
-
-
-def simple_pattern_pkgconfig(line, pattern, pkgconfig, conf32, requirements):
-    """Check for pkgconfig patterns and restart build as needed."""
-    global must_restart
-    pat = re.compile(pattern)
-    match = pat.search(line)
-    if match:
-        must_restart += requirements.add_pkgconfig_buildreq(pkgconfig, conf32, cache=True)
-
-
-def simple_pattern(line, pattern, req, requirements):
-    """Check for simple patterns and restart the build as needed."""
-    global must_restart
-    pat = re.compile(pattern)
-    match = pat.search(line)
-    if match:
-        must_restart += requirements.add_buildreq(req, cache=True)
-
 
 def cleanup_req(s: str) -> str:
     """Strip unhelpful strings from requirements."""
@@ -92,106 +60,6 @@ def cleanup_req(s: str) -> str:
     return s
 
 
-def failed_pattern(line, config, requirements, pattern, verbose, buildtool=None):
-    """Check against failed patterns to restart build as needed."""
-    global must_restart
-    global warned_about
-
-    pat = re.compile(pattern)
-    match = pat.search(line)
-    if not match:
-        return
-    s = match.group(1)
-    # standard configure cleanups
-    s = cleanup_req(s)
-
-    if s in config.ignored_commands:
-        return
-
-    try:
-        if not buildtool:
-            req = config.failed_commands[s]
-            if req:
-                must_restart += requirements.add_buildreq(req, cache=True)
-        elif buildtool == 'pkgconfig':
-            must_restart += requirements.add_pkgconfig_buildreq(s, config.config_opts.get('32bit'), cache=True)
-        elif buildtool == 'R':
-            if requirements.add_buildreq("R-" + s, cache=True) > 0:
-                must_restart += 1
-                requirements.add_requires("R-" + s, config.os_packages)
-        elif buildtool == 'perl':
-            s = s.replace('inc::', '')
-            must_restart += requirements.add_buildreq('perl(%s)' % s, cache=True)
-        elif buildtool == 'pypi':
-            s = util.translate(s)
-            if not s:
-                return
-            must_restart += requirements.add_buildreq(util.translate('%s-python' % s), cache=True)
-        elif buildtool == 'ruby':
-            if s in config.gems:
-                must_restart += requirements.add_buildreq(config.gems[s], cache=True)
-            else:
-                must_restart += requirements.add_buildreq('rubygem-%s' % s, cache=True)
-        elif buildtool == 'ruby table':
-            if s in config.gems:
-                must_restart += requirements.add_buildreq(config.gems[s], cache=True)
-            else:
-                print("Unknown ruby gem match", s)
-        elif buildtool == 'maven' or buildtool == 'gradle':
-            group_count = len(match.groups())
-            if group_count == 2:
-                # Add fully qualified versioned mvn() dependency
-                name = match.group(1)
-                # Hyphens are disallowed for version strings, so use dots instead
-                ver = match.group(2).replace('-', '.')
-                mvn_provide = f'mvn({name}) = {ver}'
-                must_restart += requirements.add_buildreq(mvn_provide, cache=True)
-            elif s in config.maven_jars:
-                # Overrides for dependencies with custom grouping
-                must_restart += requirements.add_buildreq(config.maven_jars[s], cache=True)
-            elif group_count == 3:
-                org = match.group(1)
-                name = match.group(2)
-                ver = match.group(3).replace('-', '.')
-                if re.search("-(parent|pom|bom)$", name):
-                    mvn_provide = f'mvn({org}:{name}:pom) = {ver}'
-                else:
-                    mvn_provide = f'mvn({org}:{name}:jar) = {ver}'
-                must_restart += requirements.add_buildreq(mvn_provide, cache=True)
-            else:
-                # Fallback to mvn-ARTIFACTID package name
-                must_restart += requirements.add_buildreq('mvn-%s' % s, cache=True)
-        elif buildtool == 'catkin':
-            must_restart += requirements.add_pkgconfig_buildreq(s, config.config_opts.get('32bit'), cache=True)
-            must_restart += requirements.add_buildreq(s, cache=True)
-
-    except Exception:
-        if s not in warned_about and s[:2] != '--':
-            print("Unknown pattern match: ", s)
-            warned_about.add(s)
-
-
-def parse_buildroot_log(filename, returncode):
-    """Handle buildroot log contents."""
-    if returncode == 0:
-        return True
-    global must_restart
-    must_restart = 0
-    is_clean = True
-    util.call("sync")
-    with util.open_auto(filename, "r") as rootlog:
-        loglines = rootlog.readlines()
-
-    missing_pat = re.compile(r"^.*No matching package to install: '(.*)'$")
-    for line in loglines:
-        match = missing_pat.match(line)
-        if match is not None:
-            util.print_fatal("Cannot resolve dependency name: {}".format(match.group(1)))
-            is_clean = False
-
-    return is_clean
-
-
 def check_for_warning_pattern(line):
     """Print warning if a line matches against a warning list."""
     warning_patterns = [
@@ -200,68 +68,6 @@ def check_for_warning_pattern(line):
     for pat in warning_patterns:
         if pat in line:
             util.print_warning("Build log contains: {}".format(pat))
-
-
-def parse_build_results(filename, returncode, filemanager, config, requirements, content):
-    """Handle build log contents."""
-    global must_restart
-    global success
-    requirements.verbose = 1
-    must_restart = 0
-    infiles = 0
-
-    # Flush the build-log to disk, before reading it
-    util.call("sync")
-    with util.open_auto(filename, "r") as buildlog:
-        loglines = buildlog.readlines()
-
-    for line in loglines:
-        for pat in config.pkgconfig_pats:
-            simple_pattern_pkgconfig(line, *pat, config.config_opts.get('32bit'), requirements)
-
-        for pat in config.simple_pats:
-            simple_pattern(line, *pat, requirements)
-
-        for pat in config.failed_pats:
-            failed_pattern(line, config, requirements, *pat)
-
-        check_for_warning_pattern(line)
-
-        # Search for files to add to the %files section.
-        # * infiles == 0 before we reach the files listing
-        # * infiles == 1 for the "Installed (but unpackaged) file(s) found" header
-        #     and for the entirety of the files listing
-        # * infiles == 2 after the files listing has ended
-        if infiles == 1:
-            for search in ["RPM build errors", "Childreturncodewas",
-                           "Child returncode", "Empty %files file"]:
-                if search in line:
-                    infiles = 2
-            for start in ["Building", "Child return code was"]:
-                if line.startswith(start):
-                    infiles = 2
-
-        if infiles == 0 and "Installed (but unpackaged) file(s) found:" in line:
-            infiles = 1
-        elif infiles == 1 and "not matching the package arch" not in line:
-            # exclude blank lines from consideration...
-            file = line.strip()
-            if file and file[0] == "/":
-                filemanager.push_file(file, content.name)
-
-        if line.startswith("Sorry: TabError: inconsistent use of tabs and spaces in indentation"):
-            print(line)
-            returncode = 99
-
-        nvr = f"{content.name}-{content.version}-{content.release}"
-        match = f"File not found: /builddir/build/BUILDROOT/{nvr}.x86_64/"
-        if match in line:
-            missing_file = "/" + line.split(match)[1].strip()
-            filemanager.remove_file(missing_file)
-
-        if line.startswith("Executing(%clean") and returncode == 0:
-            print("RPM build successful")
-            success = 1
 
 
 def get_mock_cmd():
@@ -273,73 +79,246 @@ def get_mock_cmd():
     return 'sudo /usr/bin/mock'
 
 
-def package(filemanager, mockconfig, mockopts, config, requirements, content, cleanup=False):
-    """Run main package build routine."""
-    global round
-    global uniqueext
-    global success
-    round = round + 1
-    success = 0
-    mock_cmd = get_mock_cmd()
-    print("Building package " + content.name + " round", round)
+class Build(object):
+    """Manage package builds."""
 
-    uniqueext = content.name
+    def __init__(self, base_path):
+        """Initialize default build settings."""
+        self.success = 0
+        self.round = 0
+        self.must_restart = 0
+        self.base_path = base_path
+        self.download_path = None
+        self.uniqueext = ''
+        self.warned_about = set()
 
-    if cleanup:
-        cleanup_flag = "--cleanup-after"
-    else:
-        cleanup_flag = "--no-cleanup-after"
+    def simple_pattern_pkgconfig(self, line, pattern, pkgconfig, conf32, requirements):
+        """Check for pkgconfig patterns and restart build as needed."""
+        pat = re.compile(pattern)
+        match = pat.search(line)
+        if match:
+            self.must_restart += requirements.add_pkgconfig_buildreq(pkgconfig, conf32, cache=True)
 
-    print("{} mock chroot at /var/lib/mock/clear-{}".format(content.name, uniqueext))
+    def simple_pattern(self, line, pattern, req, requirements):
+        """Check for simple patterns and restart the build as needed."""
+        pat = re.compile(pattern)
+        match = pat.search(line)
+        if match:
+            self.must_restart += requirements.add_buildreq(req, cache=True)
 
-    if round == 1:
-        shutil.rmtree('{}/results'.format(download_path), ignore_errors=True)
-        os.makedirs('{}/results'.format(download_path))
+    def failed_pattern(self, line, config, requirements, pattern, verbose, buildtool=None):
+        """Check against failed patterns to restart build as needed."""
+        pat = re.compile(pattern)
+        match = pat.search(line)
+        if not match:
+            return
+        s = match.group(1)
+        # standard configure cleanups
+        s = cleanup_req(s)
 
-    cmd_args = [
-        mock_cmd,
-        f"--root={mockconfig}",
-        "--buildsrpm",
-        "--sources=./",
-        f"--spec={content.name}.spec",
-        f"--uniqueext={uniqueext}",
-        "--result=results/",
-        cleanup_flag,
-        mockopts,
-    ]
-    util.call(" ".join(cmd_args),
-              logfile=f"{download_path}/results/mock_srpm.log",
-              cwd=download_path)
+        if s in config.ignored_commands:
+            return
 
-    # back up srpm mock logs
-    util.call("mv results/root.log results/srpm-root.log", cwd=download_path)
-    util.call("mv results/build.log results/srpm-build.log", cwd=download_path)
+        try:
+            if not buildtool:
+                req = config.failed_commands[s]
+                if req:
+                    self.must_restart += requirements.add_buildreq(req, cache=True)
+            elif buildtool == 'pkgconfig':
+                self.must_restart += requirements.add_pkgconfig_buildreq(s, config.config_opts.get('32bit'), cache=True)
+            elif buildtool == 'R':
+                if requirements.add_buildreq("R-" + s, cache=True) > 0:
+                    self.must_restart += 1
+                    requirements.add_requires("R-" + s, config.os_packages)
+            elif buildtool == 'perl':
+                s = s.replace('inc::', '')
+                self.must_restart += requirements.add_buildreq('perl(%s)' % s, cache=True)
+            elif buildtool == 'pypi':
+                s = util.translate(s)
+                if not s:
+                    return
+                self.must_restart += requirements.add_buildreq(util.translate('%s-python' % s), cache=True)
+            elif buildtool == 'ruby':
+                if s in config.gems:
+                    self.must_restart += requirements.add_buildreq(config.gems[s], cache=True)
+                else:
+                    self.must_restart += requirements.add_buildreq('rubygem-%s' % s, cache=True)
+            elif buildtool == 'ruby table':
+                if s in config.gems:
+                    self.must_restart += requirements.add_buildreq(config.gems[s], cache=True)
+                else:
+                    print("Unknown ruby gem match", s)
+            elif buildtool == 'maven' or buildtool == 'gradle':
+                group_count = len(match.groups())
+                if group_count == 2:
+                    # Add fully qualified versioned mvn() dependency
+                    name = match.group(1)
+                    # Hyphens are disallowed for version strings, so use dots instead
+                    ver = match.group(2).replace('-', '.')
+                    mvn_provide = f'mvn({name}) = {ver}'
+                    self.must_restart += requirements.add_buildreq(mvn_provide, cache=True)
+                elif s in config.maven_jars:
+                    # Overrides for dependencies with custom grouping
+                    self.must_restart += requirements.add_buildreq(config.maven_jars[s], cache=True)
+                elif group_count == 3:
+                    org = match.group(1)
+                    name = match.group(2)
+                    ver = match.group(3).replace('-', '.')
+                    if re.search("-(parent|pom|bom)$", name):
+                        mvn_provide = f'mvn({org}:{name}:pom) = {ver}'
+                    else:
+                        mvn_provide = f'mvn({org}:{name}:jar) = {ver}'
+                    self.must_restart += requirements.add_buildreq(mvn_provide, cache=True)
+                else:
+                    # Fallback to mvn-ARTIFACTID package name
+                    self.must_restart += requirements.add_buildreq('mvn-%s' % s, cache=True)
+            elif buildtool == 'catkin':
+                self.must_restart += requirements.add_pkgconfig_buildreq(s, config.config_opts.get('32bit'), cache=True)
+                self.must_restart += requirements.add_buildreq(s, cache=True)
+        except Exception:
+            if s not in self.warned_about and s[:2] != '--':
+                print("Unknown pattern match: ", s)
+                self.warned_about.add(s)
 
-    srcrpm = f"results/{content.name}-{content.version}-{content.release}.src.rpm"
+    def parse_buildroot_log(self, filename, returncode):
+        """Handle buildroot log contents."""
+        if returncode == 0:
+            return True
+        self.must_restart = 0
+        is_clean = True
+        util.call("sync")
+        with util.open_auto(filename, "r") as rootlog:
+            loglines = rootlog.readlines()
+        missing_pat = re.compile(r"^.*No matching package to install: '(.*)'$")
+        for line in loglines:
+            match = missing_pat.match(line)
+            if match is not None:
+                util.print_fatal("Cannot resolve dependency name: {}".format(match.group(1)))
+                is_clean = False
+        return is_clean
 
-    cmd_args = [
-        mock_cmd,
-        f"--root={mockconfig}",
-        "--result=results/",
-        srcrpm,
-        "--enable-plugin=ccache",
-        f"--uniqueext={uniqueext}",
-        cleanup_flag,
-        mockopts,
-    ]
-    ret = util.call(" ".join(cmd_args),
-                    logfile=f"{download_path}/results/mock_build.log",
-                    check=False,
-                    cwd=download_path)
+    def parse_build_results(self, filename, returncode, filemanager, config, requirements, content):
+        """Handle build log contents."""
+        requirements.verbose = 1
+        self.must_restart = 0
+        infiles = 0
 
-    # sanity check the build log
-    if not os.path.exists(download_path + "/results/build.log"):
-        util.print_fatal("Mock command failed, results log does not exist. User may not have correct permissions.")
-        exit(1)
+        # Flush the build-log to disk, before reading it
+        util.call("sync")
+        with util.open_auto(filename, "r") as buildlog:
+            loglines = buildlog.readlines()
+        for line in loglines:
+            for pat in config.pkgconfig_pats:
+                self.simple_pattern_pkgconfig(line, *pat, config.config_opts.get('32bit'), requirements)
 
-    is_clean = parse_buildroot_log(download_path + "/results/root.log", ret)
-    if is_clean:
-        parse_build_results(download_path + "/results/build.log", ret, filemanager, config, requirements, content)
+            for pat in config.simple_pats:
+                self.simple_pattern(line, *pat, requirements)
+
+            for pat in config.failed_pats:
+                self.failed_pattern(line, config, requirements, *pat)
+
+            check_for_warning_pattern(line)
+
+            # Search for files to add to the %files section.
+            # * infiles == 0 before we reach the files listing
+            # * infiles == 1 for the "Installed (but unpackaged) file(s) found" header
+            #     and for the entirety of the files listing
+            # * infiles == 2 after the files listing has ended
+            if infiles == 1:
+                for search in ["RPM build errors", "Childreturncodewas",
+                               "Child returncode", "Empty %files file"]:
+                    if search in line:
+                        infiles = 2
+                for start in ["Building", "Child return code was"]:
+                    if line.startswith(start):
+                        infiles = 2
+
+            if infiles == 0 and "Installed (but unpackaged) file(s) found:" in line:
+                infiles = 1
+            elif infiles == 1 and "not matching the package arch" not in line:
+                # exclude blank lines from consideration...
+                file = line.strip()
+                if file and file[0] == "/":
+                    filemanager.push_file(file, content.name)
+
+            if line.startswith("Sorry: TabError: inconsistent use of tabs and spaces in indentation"):
+                print(line)
+                returncode = 99
+
+            nvr = f"{content.name}-{content.version}-{content.release}"
+            match = f"File not found: /builddir/build/BUILDROOT/{nvr}.x86_64/"
+            if match in line:
+                missing_file = "/" + line.split(match)[1].strip()
+                filemanager.remove_file(missing_file)
+
+            if line.startswith("Executing(%clean") and returncode == 0:
+                print("RPM build successful")
+                self.success = 1
+
+    def package(self, filemanager, mockconfig, mockopts, config, requirements, content, cleanup=False):
+        """Run main package build routine."""
+        self.round += 1
+        self.success = 0
+        mock_cmd = get_mock_cmd()
+        print("Building package " + content.name + " round", self.round)
+
+        self.uniqueext = content.name
+
+        if cleanup:
+            cleanup_flag = "--cleanup-after"
+        else:
+            cleanup_flag = "--no-cleanup-after"
+
+        print("{} mock chroot at /var/lib/mock/clear-{}".format(content.name, self.uniqueext))
+
+        if self.round == 1:
+            shutil.rmtree('{}/results'.format(self.download_path), ignore_errors=True)
+            os.makedirs('{}/results'.format(self.download_path))
+
+        cmd_args = [
+            mock_cmd,
+            f"--root={mockconfig}",
+            "--buildsrpm",
+            "--sources=./",
+            f"--spec={content.name}.spec",
+            f"--uniqueext={self.uniqueext}",
+            "--result=results/",
+            cleanup_flag,
+            mockopts,
+        ]
+        util.call(" ".join(cmd_args),
+                  logfile=f"{self.download_path}/results/mock_srpm.log",
+                  cwd=self.download_path)
+
+        # back up srpm mock logs
+        util.call("mv results/root.log results/srpm-root.log", cwd=self.download_path)
+        util.call("mv results/build.log results/srpm-build.log", cwd=self.download_path)
+
+        srcrpm = f"results/{content.name}-{content.version}-{content.release}.src.rpm"
+
+        cmd_args = [
+            mock_cmd,
+            f"--root={mockconfig}",
+            "--result=results/",
+            srcrpm,
+            "--enable-plugin=ccache",
+            f"--uniqueext={self.uniqueext}",
+            cleanup_flag,
+            mockopts,
+        ]
+        ret = util.call(" ".join(cmd_args),
+                        logfile=f"{self.download_path}/results/mock_build.log",
+                        check=False,
+                        cwd=self.download_path)
+
+        # sanity check the build log
+        if not os.path.exists(self.download_path + "/results/build.log"):
+            util.print_fatal("Mock command failed, results log does not exist. User may not have correct permissions.")
+            exit(1)
+
+        is_clean = self.parse_buildroot_log(self.download_path + "/results/root.log", ret)
+        if is_clean:
+            self.parse_build_results(self.download_path + "/results/build.log", ret, filemanager, config, requirements, content)
         if filemanager.has_banned:
             util.print_fatal("Content in banned paths found, aborting build")
             exit(1)

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -23,16 +23,16 @@ import os
 import re
 from collections import OrderedDict
 
-import build
 import util
 
 
 class FileManager(object):
     """Class to handle spec file %files section management."""
 
-    def __init__(self, config):
+    def __init__(self, config, package):
         """Set defaults for FileManager."""
         self.config = config
+        self.package = package
         self.packages = OrderedDict()  # per sub-package file list for spec purposes
         self.files = set()  # global file set to weed out dupes
         self.files_blacklist = set()
@@ -81,7 +81,7 @@ class FileManager(object):
             g = self.attrs[filename][2]
             filename = "%attr({0},{1},{2}) {3}".format(mod, u, g, filename)
         self.packages[package].add(filename)
-        build.must_restart += 1
+        self.package.must_restart += 1
         if not self.newfiles_printed:
             print("  New %files content found")
             self.newfiles_printed = True
@@ -358,7 +358,7 @@ class FileManager(object):
                 hit = True
         if hit:
             self.files_blacklist.add(filename)
-            build.must_restart += 1
+            self.package.must_restart += 1
 
     def load_specfile(self, specfile):
         """Load a specfile instance with relevant information to be written to the spec file."""

--- a/autospec/git.py
+++ b/autospec/git.py
@@ -23,12 +23,11 @@ import glob
 import os
 import subprocess
 
-import build
 import buildpattern
 from util import call, write_out
 
 
-def commit_to_git(path, config, name):
+def commit_to_git(path, config, name, success):
     """Update package's git tree for autospec managed changes."""
     call("git init", stdout=subprocess.DEVNULL, cwd=path)
 
@@ -137,7 +136,7 @@ def commit_to_git(path, config, name):
     write_out(os.path.join(path, '.gitignore'), '\n'.join(ignorelist))
     call("git add .gitignore", check=False, stderr=subprocess.DEVNULL, cwd=path)
 
-    if build.success == 0:
+    if success == 0:
         return
 
     call("git commit -a -F commitmsg ", cwd=path)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,62 +10,48 @@ import tarball
 
 class TestBuildpattern(unittest.TestCase):
 
-    def setUp(self):
-        """
-        Test setup method to reset the buildpattern module
-        """
-        build.success = 0
-        build.round = 0
-        build.must_restart = 0
-        build.base_path = None
-        build.download_path = None
-
-    def test_setup_workingdir(self):
-        """
-        Test that setup_workingdir sets the correct directory patterns
-        """
-        build.setup_workingdir("test_directory")
-        self.assertEqual(build.base_path, "test_directory")
-
     def test_simple_pattern_pkgconfig(self):
         """
         Test simple_pattern_pkgconfig with match
         """
         reqs = buildreq.Requirements("")
-        build.simple_pattern_pkgconfig('line to test for testpkg.xyz',
-                                       r'testpkg.xyz',
-                                       'testpkg',
-                                       False,
-                                       reqs)
+        pkg = build.Build("/")
+        pkg.simple_pattern_pkgconfig('line to test for testpkg.xyz',
+                                     r'testpkg.xyz',
+                                     'testpkg',
+                                     False,
+                                     reqs)
         self.assertIn('pkgconfig(testpkg)', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_simple_pattern_pkgconfig_32bit(self):
         """
         Test simple_pattern_pkgconfig with match and 32bit option set
         """
         reqs = buildreq.Requirements("")
-        build.simple_pattern_pkgconfig('line to test for testpkg.zyx',
-                                       r'testpkg.zyx',
-                                       'testpkgz',
-                                       True,
-                                       reqs)
+        pkg = build.Build("/")
+        pkg.simple_pattern_pkgconfig('line to test for testpkg.zyx',
+                                     r'testpkg.zyx',
+                                     'testpkgz',
+                                     True,
+                                     reqs)
         self.assertIn('pkgconfig(32testpkgz)', reqs.buildreqs)
         self.assertIn('pkgconfig(testpkgz)', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_simple_pattern_pkgconfig_no_match(self):
         """
         Test simple_pattern_pkgconfig with no match, nothing should be modified
         """
         reqs = buildreq.Requirements("")
-        build.simple_pattern_pkgconfig('line to test for somepkg.xyz',
-                                       r'testpkg.xyz',
-                                       'testpkg',
-                                       False,
-                                       reqs)
+        pkg = build.Build("/")
+        pkg.simple_pattern_pkgconfig('line to test for somepkg.xyz',
+                                     r'testpkg.xyz',
+                                     'testpkg',
+                                     False,
+                                     reqs)
         self.assertEqual(reqs.buildreqs, set())
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_simple_pattern(self):
         """
@@ -74,24 +60,26 @@ class TestBuildpattern(unittest.TestCase):
         to buildreq.buildreqs.
         """
         reqs = buildreq.Requirements("")
-        build.simple_pattern('line to test for testpkg.xyz',
-                             r'testpkg.xyz',
-                             'testpkg',
-                             reqs)
+        pkg = build.Build("/")
+        pkg.simple_pattern('line to test for testpkg.xyz',
+                           r'testpkg.xyz',
+                           'testpkg',
+                           reqs)
         self.assertIn('testpkg', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_simple_pattern_no_match(self):
         """
         Test simple_pattern with no match, nothing should be modified
         """
         reqs = buildreq.Requirements("")
-        build.simple_pattern('line to test for somepkg.xyz',
-                             r'testpkg.xyz',
-                             'testpkg',
-                             reqs)
+        pkg = build.Build("/")
+        pkg.simple_pattern('line to test for somepkg.xyz',
+                           r'testpkg.xyz',
+                           'testpkg',
+                           reqs)
         self.assertEqual(reqs.buildreqs, set())
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_failed_pattern_no_match(self):
         """
@@ -99,9 +87,10 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: somepkg', conf, reqs, r'(test)', 0)
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: somepkg', conf, reqs, r'(test)', 0)
         self.assertEqual(reqs.buildreqs, set())
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_failed_pattern_no_buildtool(self):
         """
@@ -110,9 +99,10 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg', conf, reqs, r'(test)', 0)
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg', conf, reqs, r'(test)', 0)
         self.assertEqual(reqs.buildreqs, set())
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_failed_pattern_no_buildtool_match(self):
         """
@@ -121,9 +111,10 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         reqs = buildreq.Requirements("")
         conf.setup_patterns()
-        build.failed_pattern('line to test for failure: lex', conf, reqs, r'(lex)', 0)
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: lex', conf, reqs, r'(lex)', 0)
         self.assertIn('flex', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_pkgconfig(self):
         """
@@ -131,14 +122,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg.xyz',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg.xyz',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='pkgconfig')
         self.assertIn('pkgconfig(testpkg)', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_R(self):
         """
@@ -147,7 +139,8 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg.r',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg.r',
                              conf,
                              reqs,
                              r'(testpkg)',
@@ -155,7 +148,7 @@ class TestBuildpattern(unittest.TestCase):
                              buildtool='R')
         self.assertIn('R-testpkg', reqs.buildreqs)
         self.assertIn('R-testpkg', reqs.requires)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_perl(self):
         """
@@ -163,14 +156,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg.pl',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg.pl',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='perl')
         self.assertIn('perl(testpkg)', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_pypi(self):
         """
@@ -178,14 +172,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg.py',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg.py',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='pypi')
         self.assertIn('testpkg-python', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_ruby(self):
         """
@@ -194,14 +189,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg.rb',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg.rb',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='ruby')
         self.assertIn('rubygem-testpkg', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_ruby_gem_match(self):
         """
@@ -212,14 +208,15 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: test/unit',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: test/unit',
                              conf,
                              reqs,
                              r'(test/unit)',
                              0,  # verbose=0
                              buildtool='ruby')
         self.assertIn('rubygem-test-unit', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_ruby_table(self):
         """
@@ -229,14 +226,15 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: test/unit',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: test/unit',
                              conf,
                              reqs,
                              r'(test/unit)',
                              0,  # verbose=0
                              buildtool='ruby table')
         self.assertIn('rubygem-test-unit', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_ruby_table_no_match(self):
         """
@@ -245,14 +243,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='ruby table')
         self.assertEqual(reqs.buildreqs, set())
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_failed_pattern_maven(self):
         """
@@ -261,14 +260,15 @@ class TestBuildpattern(unittest.TestCase):
         """
         conf = config.Config()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: testpkg',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: testpkg',
                              conf,
                              reqs,
                              r'(testpkg)',
                              0,  # verbose=0
                              buildtool='maven')
         self.assertIn('mvn-testpkg', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_maven_match(self):
         """
@@ -279,14 +279,15 @@ class TestBuildpattern(unittest.TestCase):
         conf = config.Config()
         conf.setup_patterns()
         reqs = buildreq.Requirements("")
-        build.failed_pattern('line to test for failure: aether',
+        pkg = build.Build("/")
+        pkg.failed_pattern('line to test for failure: aether',
                              conf,
                              reqs,
                              r'(aether)',
                              0,  # verbose=0
                              buildtool='maven')
         self.assertIn('mvn-aether-core', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_parse_buildroot_log_fail(self):
         """
@@ -302,15 +303,16 @@ class TestBuildpattern(unittest.TestCase):
         open_name = 'build.util.open_auto'
         content = "line1\nDEBUG util.py:399:  No matching package to install: 'foobar'\nDEBUG util.py:399:  No matching package to install: 'foobarbaz'\nline 4"
         m_open = mock_open(read_data=content)
+        pkg = build.Build("/")
 
         result = True
         with patch(open_name, m_open, create=True):
-            result = build.parse_buildroot_log('testname', 1)
+            result = pkg.parse_buildroot_log('testname', 1)
 
         build.util.call = call_backup
 
         self.assertFalse(result)
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_parse_buildroot_log_pass(self):
         """
@@ -325,15 +327,16 @@ class TestBuildpattern(unittest.TestCase):
         open_name = 'build.util.open_auto'
         content = "line 1\nline 2\nline 3\nline 4"
         m_open = mock_open(read_data=content)
+        pkg = build.Build("/")
 
         result = True
         with patch(open_name, m_open, create=True):
-            result = build.parse_buildroot_log('testname', 1)
+            result = pkg.parse_buildroot_log('testname', 1)
 
         build.util.call = call_backup
 
         self.assertTrue(result)
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_parse_buildroot_log_noop(self):
         """
@@ -349,10 +352,11 @@ class TestBuildpattern(unittest.TestCase):
         open_name = 'build.util.open_auto'
         content = "line 1\nline 2\nline 3\nline 4"
         m_open = mock_open(read_data=content)
+        pkg = build.Build("/")
 
         result = True
         with patch(open_name, m_open, create=True):
-            result = build.parse_buildroot_log('testname', 0)
+            result = pkg.parse_buildroot_log('testname', 0)
 
         build.util.call = call_backup
 
@@ -373,20 +377,21 @@ class TestBuildpattern(unittest.TestCase):
         conf.config_opts['32bit'] = True
         call_backup = build.util.call
         build.util.call = mock_util_call
-        fm = files.FileManager(conf)
+        pkg = build.Build("/")
+        fm = files.FileManager(conf, pkg)
 
         open_name = 'build.util.open_auto'
         content = 'line 1\nwhich: no qmake\nexiting'
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
+            pkg.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
         self.assertIn('pkgconfig(Qt)', reqs.buildreqs)
         self.assertIn('pkgconfig(32Qt)', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_parse_build_results_simple_pats(self):
         """
@@ -402,19 +407,20 @@ class TestBuildpattern(unittest.TestCase):
         tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
-        fm = files.FileManager(conf)
+        pkg = build.Build("/")
+        fm = files.FileManager(conf, pkg)
 
         open_name = 'build.util.open_auto'
         content = 'line 1\nchecking for Apache test module support\nexiting'
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
+            pkg.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
         self.assertIn('httpd-dev', reqs.buildreqs)
-        self.assertEqual(build.must_restart, 1)
+        self.assertEqual(pkg.must_restart, 1)
 
     def test_parse_build_results_failed_pats(self):
         """
@@ -428,7 +434,8 @@ class TestBuildpattern(unittest.TestCase):
         call_backup = build.util.call
         open_auto_backup = build.util.open_auto
         build.util.call = MagicMock(return_value=None)
-        fm = files.FileManager(conf)
+        pkg = build.Build("/")
+        fm = files.FileManager(conf, pkg)
 
         with open('tests/builderrors', 'r') as f:
             builderrors = f.readlines()
@@ -437,10 +444,10 @@ class TestBuildpattern(unittest.TestCase):
                     input, output = error.strip('\n').split('|')
                     reqs.buildreqs = set()
                     build.util.open_auto = mock_open(read_data=input)
-                    build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
+                    pkg.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
                     self.assertIn(output, reqs.buildreqs)
-                    self.assertGreater(build.must_restart, 0)
+                    self.assertGreater(pkg.must_restart, 0)
 
         # Restoring functions
         build.util.call = call_backup
@@ -459,7 +466,8 @@ class TestBuildpattern(unittest.TestCase):
         tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
-        fm = files.FileManager(conf)
+        pkg = build.Build("/")
+        fm = files.FileManager(conf, pkg)
 
         open_name = 'build.util.open_auto'
         content = 'line 1\n' \
@@ -472,7 +480,7 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
+            pkg.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
@@ -481,7 +489,7 @@ class TestBuildpattern(unittest.TestCase):
                               '/usr/testdir/file1',
                               '/usr/testdir/file2']))
         # one for each file added
-        self.assertEqual(build.must_restart, 3)
+        self.assertEqual(pkg.must_restart, 3)
 
     def test_parse_build_results_banned_files(self):
         """
@@ -496,7 +504,8 @@ class TestBuildpattern(unittest.TestCase):
         tcontent = tarball.Content("", "", "", [], conf)
         call_backup = build.util.call
         build.util.call = mock_util_call
-        fm = files.FileManager(conf)
+        pkg = build.Build("/")
+        fm = files.FileManager(conf, pkg)
 
         open_name = 'build.util.open_auto'
         content = 'line 1\n' \
@@ -511,13 +520,13 @@ class TestBuildpattern(unittest.TestCase):
         m_open = mock_open(read_data=content)
 
         with patch(open_name, m_open, create=True):
-            build.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
+            pkg.parse_build_results('testname', 0, fm, conf, reqs, tcontent)
 
         build.util.call = call_backup
 
         self.assertEqual(fm.has_banned, True)
         # check no files were added
-        self.assertEqual(build.must_restart, 0)
+        self.assertEqual(pkg.must_restart, 0)
 
     def test_get_mock_cmd_without_consolehelper(self):
         """

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -4,6 +4,7 @@ import files
 import tempfile
 import os
 from unittest.mock import call, MagicMock
+import build
 from files import FileManager
 
 
@@ -21,7 +22,8 @@ class TestFiles(unittest.TestCase):
 
     def setUp(self):
         conf = config.Config()
-        self.fm = FileManager(conf)
+        pkg = build.Build("/")
+        self.fm = FileManager(conf, pkg)
 
     def test_banned_path(self):
         """


### PR DESCRIPTION
The build module had a number of globals that were referenced by many
other modules and has ordering dependencies with the config and
tarball module for some values. This made deciding on where certain
values get initialized difficult but before the initialization can be
addressed a refactor is helpful.

This change moves the global state (and functions that needed to act
on that global state) into a Build class. The goal of this work is
to better track what can be updated by a particular function, load
data in a sensible order and have it owned by a sensible component.

Some of this data is likely to be removed from the build class in the
future as initialization of download and base paths should take place
in other modules most likely.