### PR TITLE
Restore sorted order for pypi Requires lines

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -292,7 +292,7 @@ class Specfile(object):
                 self._write("Requires: python3-core\n")
                 if self.requirements.pypi_provides:
                     self._write(f"Provides: pypi({self.requirements.pypi_provides})\n")
-                for req in self.requirements.pypi_requires:
+                for req in sorted(self.requirements.pypi_requires):
                     self._write(f"Requires: pypi({req})\n")
 
             if pkg == "perl":


### PR DESCRIPTION
In the recently removed `load_specfile()` function in buildreq.py (see
commit 2a181a2d), the pypi_requires set was sorted and converted to a
list via `sorted()`. Now, the set is no longer converted to a list, so
we can instead sort it immediately before writing out the contents in
`write_files_header()` in specfiles.py.