### PR TITLE
RFC: package installed tests to foo-tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -391,6 +391,12 @@ dev_extras
   functionality to place files used only for development against this
   software that Autospec does not automatically detect.
 
+tests_extras
+  Same as "extras" above, but instead of the files being placed in an
+  ``-extras`` subpackage, they will be placed in the ``-tests`` one. Use this
+  functionality to place files used only for testing against this
+  software that Autospec does not automatically detect.
+
 ${custom}_extras
   Same as "extras" above, but instead of the files being placed in an
   ``-extras`` subpackage, they will be placed in the ``extras-${custom}``

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -753,30 +753,28 @@ class Config(object):
             print("%%exclude for: %s." % exclude)
         filemanager.excludes += content
 
-        content = self.read_conf_file(os.path.join(path, "extras"))
-        for extra in content:
-            print("extras for  : %s." % extra)
-        filemanager.extras += content
-
         for fname in os.listdir(path):
-            if not re.search('.+_extras$', fname) or fname == "dev_extras":
+            if re.search(r'.+_extras$', fname):
+                # Prefix all but blessed names with extras-
+                name = fname[:-len("_extras")]
+                if name not in ('dev'):
+                    name = f'extras-{name}'
+            elif fname == 'extras':
+                name = 'extras'
+            else:
                 continue
+
             content = {}
             content['files'] = self.read_conf_file(os.path.join(path, fname))
             if not content:
                 print_warning(f"Error reading custom extras file: {fname}")
                 continue
+
             req_file = os.path.join(path, f'{fname}_requires')
             if os.path.isfile(req_file):
                 content['requires'] = self.read_conf_file(req_file)
-            name = fname[:-len("_extras")]
-            print(f"extras-{name} for {content['files']}")
-            filemanager.custom_extras["extras-" + f"{name}"] = content
 
-        content = self.read_conf_file(os.path.join(path, "dev_extras"))
-        for extra in content:
-            print("dev for     : %s." % extra)
-        filemanager.dev_extras += content
+            filemanager.file_maps[name] = content
 
         content = self.read_conf_file(os.path.join(path, "setuid"))
         for suid in content:

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -757,7 +757,7 @@ class Config(object):
             if re.search(r'.+_extras$', fname):
                 # Prefix all but blessed names with extras-
                 name = fname[:-len("_extras")]
-                if name not in ('dev'):
+                if name not in ('dev', 'tests'):
                     name = f'extras-{name}'
             elif fname == 'extras':
                 name = 'extras'

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -37,9 +37,7 @@ class FileManager(object):
         self.files = set()  # global file set to weed out dupes
         self.files_blacklist = set()
         self.excludes = []
-        self.extras = []
-        self.custom_extras = {}
-        self.dev_extras = []
+        self.file_maps = {}  # Filename-to-package mapping
         self.setuid = []
         self.attrs = {}
         self.locales = []
@@ -196,14 +194,8 @@ class FileManager(object):
         if self.file_is_locale(filename):
             return
 
-        # extras
-        if filename in self.extras:
-            self.push_package_file(filename, "extras")
-            return
-        if filename in self.dev_extras:
-            self.push_package_file(filename, "dev")
-            return
-        for k, v in self.custom_extras.items():
+        # Explicit file packaging
+        for k, v in self.file_maps.items():
             if filename in v['files']:
                 self.push_package_file(filename, k)
                 return
@@ -368,4 +360,4 @@ class FileManager(object):
         specfile.packages = self.packages
         specfile.excludes = self.excludes
         specfile.locales = self.locales
-        specfile.custom_extras = self.custom_extras
+        specfile.file_maps = self.file_maps

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -242,6 +242,8 @@ class FileManager(object):
             (r"^/usr/share/abi/", "abi"),
             (r"^/usr/share/qt5/examples/", "examples"),
             (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
+            (r"^/usr/share/installed-tests/", "tests"),
+            (r"^/usr/libexec/installed-tests/", "tests"),
             (r"^/usr/lib64/openmpi/bin/", "openmpi"),
             (r"^/usr/lib64/openmpi/share", "openmpi"),
             (r"^/usr/lib64/openmpi/include/", "dev"),

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -59,7 +59,7 @@ class Specfile(object):
         self.need_avx512_flags = False
         self.tests_config = ""
         self.excludes = []
-        self.custom_extras = {}
+        self.file_maps = {}
         self.keyid = ""
         self.email = ""
         self.extra_cmake = config.extra_cmake + " " + " ".join(requirements.extra_cmake)
@@ -244,7 +244,7 @@ class Specfile(object):
             deps["dev"].append("extras")
         if self.config.config_opts.get('openmpi'):
             deps["dev"].append("openmpi")
-        for k, v in self.custom_extras.items():
+        for k, v in self.file_maps.items():
             if "requires" in v:
                 deps[k] = v['requires']
 

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -176,7 +176,7 @@ class Specfile(object):
                 continue
             if pkg in ["ignore", "main", "dev", "active-units", "extras",
                        "lib32", "dev32", "doc", "examples", "abi", "staticdev",
-                       "staticdev32"]:
+                       "staticdev32", "tests"]:
                 continue
             # honor requires_ban for manual overrides
             if "{}-{}".format(self.name, pkg) in self.requirements.banned_requires:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -276,18 +276,15 @@ class Specfile(object):
             for prov in provides.get(pkg, []):
                 self._write("Provides: {}-{} = %{{version}}-%{{release}}\n".format(self.name, prov))
 
+            if pkg in ("dev", "perl", "tests"):
+                self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))
+
+            if pkg in ("staticdev", "staticdev32"):
+                self._write("Requires: {}-dev = %{{version}}-%{{release}}\n".format(self.name))
+
             if pkg == "python":
                 if self.name != self.name.lower():
                     self._write("Provides: {}-python\n".format(self.name.lower()))
-
-            if pkg == "dev":
-                self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))
-
-            if pkg == "staticdev":
-                self._write("Requires: {}-dev = %{{version}}-%{{release}}\n".format(self.name))
-
-            if pkg == "staticdev32":
-                self._write("Requires: {}-dev = %{{version}}-%{{release}}\n".format(self.name))
 
             if pkg == "python3":
                 self._write("Requires: python3-core\n")
@@ -295,9 +292,6 @@ class Specfile(object):
                     self._write(f"Provides: pypi({self.requirements.pypi_provides})\n")
                 for req in sorted(self.requirements.pypi_requires):
                     self._write(f"Requires: pypi({req})\n")
-
-            if pkg == "perl":
-                self._write("Requires: {} = %{{version}}-%{{release}}\n".format(self.name))
 
             self._write("\n%description {}\n".format(pkg))
             self._write("{} components for the {} package.\n".format(pkg, self.name))

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -156,27 +156,15 @@ class TestFiles(unittest.TestCase):
         calls = [call(autostart, 'autostart'), call('%exclude ' + autostart, 'services')]
         self.fm.push_package_file.assert_has_calls(calls)
 
-    def test_push_file_extras(self):
-        """
-        Test push_file to extras package
-        """
-        self.fm.file_is_locale = MagicMock(return_value=False)
-        self.fm.push_package_file = MagicMock()
-        self.fm.extras.append('test')
-        self.fm.push_file('test', '')
-        calls = [call('test', 'extras')]
-        self.fm.push_package_file.assert_has_calls(calls)
-
-
     def test_push_file_custom_extras(self):
         """
         Test push_file to a custom extras package
         """
         self.fm.file_is_locale = MagicMock(return_value=False)
         self.fm.push_package_file = MagicMock()
-        self.fm.custom_extras = {'test-extras': {'files': ["test"]}}
-        self.fm.push_file('test', '')
-        calls = [call('test', 'test-extras')]
+        self.fm.file_maps = {'foobar-extras': {'files': ["foobar"]}}
+        self.fm.push_file('foobar', '')
+        calls = [call('foobar', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
 

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -237,8 +237,8 @@ class TestSpecfileWrite(unittest.TestCase):
         test write_files_header with custom extras requires.
         """
         self.specfile.packages["data"] = ["file1"]
-        self.specfile.packages["test-extras"] = ["file2"]
-        self.specfile.custom_extras = { 'test-extras': { 'requires': ["data"] }}
+        self.specfile.packages["foobar-extras"] = ["file2"]
+        self.specfile.file_maps = { 'foobar-extras': { 'requires': ["data"] }}
         self.specfile.write_files_header()
         expect = ["\n%package data\n",
                   "Summary: data components for the pkg package.\n",
@@ -246,12 +246,12 @@ class TestSpecfileWrite(unittest.TestCase):
                   "\n%description data\n",
                   "data components for the pkg package.\n",
                   "\n",
-                  "\n%package test-extras\n",
-                  "Summary: test-extras components for the pkg package.\n",
+                  "\n%package foobar-extras\n",
+                  "Summary: foobar-extras components for the pkg package.\n",
                   "Group: Default\n",
                   "Requires: pkg-data = %{version}-%{release}\n",
-                  "\n%description test-extras\n",
-                  "test-extras components for the pkg package.\n",
+                  "\n%description foobar-extras\n",
+                  "foobar-extras components for the pkg package.\n",
                   "\n"]
         self.assertEqual(expect, self.WRITES)
 


### PR DESCRIPTION
Many GNOME packages install their test suite for integration testing[1] but these test suites end up in foo and foo-libexec, thus part of every user's install wasting space.

We could just disable the installed test suite but the tests are actually useful: the builder is too limited an environment for many test suites to actually pass, so running them on a full image is preferable.

This branch does some cleanup to how extras files are parsed, and packages the test suite into foo-tests.  This new package isn't in any bundles, so the files will be removed from images.

[1] https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests