### PR TITLE
Add support for an "-examples" sub-package, containing Qt 5 examples

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -240,6 +240,7 @@ class FileManager(object):
             (r"^/usr/share/man/", "man"),
             (r"^/usr/share/info/", "info"),
             (r"^/usr/share/abi/", "abi"),
+            (r"^/usr/share/qt5/examples/", "examples"),
             (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
             (r"^/usr/lib64/openmpi/bin/", "openmpi"),
             (r"^/usr/lib64/openmpi/share", "openmpi"),

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -175,7 +175,7 @@ class Specfile(object):
             if pkg.startswith("extras-"):
                 continue
             if pkg in ["ignore", "main", "dev", "active-units", "extras",
-                       "lib32", "dev32", "doc", "abi", "staticdev",
+                       "lib32", "dev32", "doc", "examples", "abi", "staticdev",
                        "staticdev32"]:
                 continue
             # honor requires_ban for manual overrides
@@ -233,6 +233,7 @@ class Specfile(object):
         deps = {}
         deps["dev"] = ["lib", "bin", "data"]
         deps["doc"] = ["man", "info"]
+        deps["examples"] = ["dev"]
         deps["dev32"] = ["lib32", "bin", "data", "dev"]
         deps["bin"] = ["data", "libexec", "config", "setuid", "attr", "license", "services"]
         deps["lib"] = ["data", "libexec", "license"]


### PR DESCRIPTION
Other installations welcome. I could have added them to the "-dev"
package but didn't think most people want the examples when
developing. This will be used in a new bundle in Clear Linux.

Needed to fix clearlinux/distribution#1781.