### PR TITLE
Extend fail pattern for `make`

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -321,7 +321,7 @@ class Config(object):
             (r"configure: error: ([a-zA-Z0-9]+) (?:is required to build|not found)", 0, None),
             (r"configure: error: Cannot find (.*)\. Make sure", 0, None),
             (r"fatal error\: (.*)\: No such file or directory", 0, None),
-            (r"make: ([a-zA-Z0-9].+): Command not found", 0, None),
+            (r"make: ([a-zA-Z0-9].+): (?:Command not found|No such file or directory)", 0, None),
             (r"meson\.build\:[\d]+\:[\d]+\: ERROR: C library \'(.*)\' not found", 0, None),
             (r"there is no package called ['‘]([a-zA-Z0-9\-\.]*)['’]", 0, 'R'),
             (r"unable to execute '([a-zA-Z\-]*)': No such file or directory", 0, None),

--- a/tests/builderrors
+++ b/tests/builderrors
@@ -96,6 +96,7 @@ dependency testpkg found: NO (tried pkgconfig and cmake)|pkgconfig(testpkg)
 dependency testpkg found: NO (tried pkgconfig)|pkgconfig(testpkg)
 fatal error: swig: No such file or directory|swig
 make: swig: Command not found|swig
+make: help2man: No such file or directory|help2man
 swig 8 is required to configure this module; please install it or upgrade your CPAN/CPANPLUS shell.|swig
 swig is not installed: cannot load such file -- rdoc/swig|rubygem-swig
 swig tool not found or not executable|swig


### PR DESCRIPTION
This covers the "ENOENT" case. Also update the unittests to verify that
the updated pattern works.