### PR TITLE
Fix buildreq_cache handling

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -275,7 +275,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
     conf.config_file = args.config
     requirements = buildreq.Requirements(content.url)
     requirements.set_build_req()
-    conf.parse_config_files(package.download_path, args.bump, filemanager, content, requirements)
+    conf.parse_config_files(package.download_path, args.bump, filemanager, content.version, requirements)
     conf.setup_patterns(conf.failed_pattern_dir)
     conf.parse_existing_spec(package.download_path, content.name)
 


### PR DESCRIPTION
The fourth argument to `parse_config_files` is supposed to be the
content (tarball) version, not the Content instance itself. The
buildreq_cache file handling in `parse_config_files` is the only code
affected by the bug.

Fixes #599 