### PR TITLE
Rework for color-coded progress messages

### DIFF
--- a/autospec/util.py
+++ b/autospec/util.py
@@ -22,6 +22,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 
 dictionary_filename = os.path.dirname(__file__) + "/translate.dic"
 dictionary = [line.strip() for line in open(dictionary_filename, 'r')]
@@ -89,11 +90,14 @@ def get_sha1sum(filename):
     return sh.hexdigest()
 
 
+def _supports_color():
+    # FIXME: check terminfo instead
+    return sys.stdout.isatty()
 
 
 def _print_message(message, level, color=None):
     prefix = level
-    if color:
+    if color and _supports_color():
         # FIXME: use terminfo instead
         if color == 'red':
             params = '31;1'

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -123,7 +123,7 @@ def print_fatal(message):
 
 def print_warning(message):
     """Print warning, color coded for TTYs."""
-    _print_message(message, 'WARNING', 'yellow')
+    _print_message(message, 'WARNING', 'red')
 
 
 def print_info(message):

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -89,19 +89,52 @@ def get_sha1sum(filename):
     return sh.hexdigest()
 
 
+
+
+def _print_message(message, level, color=None):
+    prefix = level
+    if color:
+        # FIXME: use terminfo instead
+        if color == 'red':
+            params = '31;1'
+        elif color == 'green':
+            params = '32;1'
+        elif color == 'yellow':
+            params = '33;1'
+        elif color == 'blue':
+            params = '34;1'
+        prefix = f'\033[{params}m{level}\033[0m'
+    print(f'[{prefix}] {message}')
+
+
+def print_error(message):
+    """Print error, color coded for TTYs."""
+    _print_message(message, 'ERROR', 'red')
+
+
 def print_fatal(message):
-    """Print color coded fatal errors."""
-    print("[\033[1m\033[91mFATAL\033[0m] {}".format(message))
+    """Print fatal error, color coded for TTYs."""
+    _print_message(message, 'FATAL', 'red')
 
 
 def print_warning(message):
-    """Print color coded warnings."""
-    print("[\033[31;1mWARNING\033[0m] {}".format(message))
+    """Print warning, color coded for TTYs."""
+    _print_message(message, 'WARNING', 'yellow')
+
+
+def print_info(message):
+    """Print informational message, color coded for TTYs."""
+    _print_message(message, 'INFO', 'yellow')
+
+
+def print_success(message):
+    """Print success message, color coded for TTYs."""
+    _print_message(message, 'SUCCESS', 'green')
 
 
 def print_infile(message):
-    """Print colored INIFILE content."""
-    print("[\033[1;34mINFILE\033[0m] {}".format(message))
+    """Print INFILE content, color coded for TTYs."""
+    _print_message(message, 'INFILE', 'blue')
 
 
 def binary_in_path(binary):


### PR DESCRIPTION
- Remove the progress message functions from `pkg_integrity`, and extend/refactor the ones from `util` to support the needs of `pkg_integrity`.
- Avoid printing terminal escape sequences for color when stdout is not a tty.