### PR TITLE
Add support for custom subpackage requires

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,10 @@ requires_add
   Each line in the file provides the name of a package to add as a runtime
   dependency to the ``.spec``.
 
+${custom}_requires_add
+  Same as "requires_add" above, but instead of the Requires being placed on the
+  ``main`` subpackage, they will be placed on the ``-${custom}`` subpackage.
+
 buildreq_ban
   Each line in the file is a build dependency that under no circumstance should
   be automatically added to the build dependencies. This is useful to block
@@ -209,6 +213,11 @@ requires_ban
   should be automatically added to the runtime dependencies. This is useful to
   block automatic configuration routines adding undesired functionality, or to
   omit any automatically discovered dependencies during tarball scanning.
+
+${custom}_requires_ban
+  Same as "requires_ban" above, but instead of the Requires being removed from
+  the ``main`` subpackage, they will be removed from the ``-${custom}``
+  subpackage.
 
 .. note::
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -555,9 +555,6 @@ class Config(object):
         """Process extras type subpackages configuration."""
         content = {}
         content['files'] = self.read_conf_file(os.path.join(self.download_path, fname))
-        if not content:
-            print_warning(f"Error reading custom extras file: {fname}")
-            return
         req_file = os.path.join(self.download_path, f'{fname}_requires')
         if os.path.isfile(req_file):
             content['requires'] = self.read_conf_file(req_file)

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -178,11 +178,11 @@ class Specfile(object):
                        "staticdev32", "tests"]:
                 continue
             # honor requires_ban for manual overrides
-            if "{}-{}".format(self.name, pkg) in self.requirements.banned_requires:
+            if "{}-{}".format(self.name, pkg) in self.requirements.banned_requires.get(None, []):
                 continue
             self._write("Requires: {}-{} = %{{version}}-%{{release}}\n".format(self.name, pkg))
 
-        for pkg in sorted(self.requirements.requires):
+        for pkg in sorted(self.requirements.requires.get(None, [])):
             self._write("Requires: {}\n".format(pkg))
 
     def write_buildreq(self):
@@ -289,8 +289,9 @@ class Specfile(object):
                 self._write("Requires: python3-core\n")
                 if self.requirements.pypi_provides:
                     self._write(f"Provides: pypi({self.requirements.pypi_provides})\n")
-                for req in sorted(self.requirements.pypi_requires):
-                    self._write(f"Requires: pypi({req})\n")
+
+            for req in sorted(self.requirements.requires.get(pkg, [])):
+                self._write(f"Requires: {req}\n")
 
             self._write("\n%description {}\n".format(pkg))
             self._write("{} components for the {} package.\n".format(pkg, self.name))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -147,7 +147,7 @@ class TestBuildpattern(unittest.TestCase):
                              0,  # verbose=0
                              buildtool='R')
         self.assertIn('R-testpkg', reqs.buildreqs)
-        self.assertIn('R-testpkg', reqs.requires)
+        self.assertIn('R-testpkg', reqs.requires[None])
         self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_perl(self):

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -105,8 +105,7 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["autostart"] = ["autostart"]
         self.specfile.packages["bin"] = []
         self.specfile.packages["lib"] = ["package.so"]
-        self.specfile.requirements.requires.add("pkg1")
-        self.specfile.requirements.requires.add("pkg2")
+        self.specfile.requirements.requires[None] = set(["pkg1", "pkg2"])
         self.specfile.config.config_opts['no_autostart'] = True
         self.specfile.write_main_subpackage_requires()
         expect = ["Requires: pkg-bin = %{version}-%{release}\n",
@@ -127,8 +126,7 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["ignore"] = []
         self.specfile.packages["dev"] = []
         self.specfile.packages["active-units"] = []
-        self.specfile.requirements.requires.add("pkg1")
-        self.specfile.requirements.requires.add("pkg2")
+        self.specfile.requirements.requires[None] = set(["pkg1", "pkg2"])
         self.specfile.write_main_subpackage_requires()
         expect = ["Requires: pkg-autostart = %{version}-%{release}\n",
                   "Requires: pkg-bin = %{version}-%{release}\n",
@@ -200,7 +198,6 @@ class TestSpecfileWrite(unittest.TestCase):
         self.specfile.packages["python"] = ["pyfile1", "pyfile2"]
         self.specfile.packages["dev"] = ["dev1", "dev2"]
         self.specfile.packages["pack"] = ["packf1"]
-        self.specfile.requirements.requires = ["pep8", "pylint", "pycurl"]
         self.specfile.requirements.buildreqs = ["pep8", "pycurl"]
         self.specfile.write_files_header()
         expect = ["\n%package data\n",


### PR DESCRIPTION
Due to more systems being added for automated runtime dependency
injection for subpackages, we need a way for manual overrides of the
default detected dependencies.

This change provides support for specifying which subpackage runtime
dependencies should be added or removed and consolidates some of the
custom configuration file detection along with it.