### PR TITLE
Address warnings from latest flake8 pre-release

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -89,9 +89,9 @@ def save_mock_logs(path, iteration):
     """Save Mock build logs to <path>/results/round<iteration>-*.log."""
     basedir = os.path.join(path, "results")
     loglist = ["build", "root", "srpm-build", "srpm-root", "mock_srpm", "mock_build"]
-    for l in loglist:
-        src = "{}/{}.log".format(basedir, l)
-        dest = "{}/round{}-{}.log".format(basedir, iteration, l)
+    for log in loglist:
+        src = "{}/{}.log".format(basedir, log)
+        dest = "{}/round{}-{}.log".format(basedir, iteration, log)
         os.rename(src, dest)
 
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -549,7 +549,7 @@ class Config(object):
         in the package git repo, specify 'track=False'.
         """
         lines = self.read_file(path, track=track)
-        return [l.strip() for l in lines if not l.strip().startswith("#") and l.split()]
+        return [line.strip() for line in lines if not line.strip().startswith("#") and line.split()]
 
     def process_extras_file(self, fname, name, filemanager):
         """Process extras type subpackages configuration."""

--- a/autospec/infile_update_spec.py
+++ b/autospec/infile_update_spec.py
@@ -51,7 +51,7 @@ def update_summary(bb_dict, specfile):
 def update_licenses(bb_dict, specfile):
     """Add the bitbake license if it is not included in the specfile."""
     if "LICENSE" in bb_dict:
-        if bb_dict.get("LICENSE").lower() not in [l.lower() for l in specfile.licenses]:
+        if bb_dict.get("LICENSE").lower() not in [license.lower() for license in specfile.licenses]:
             specfile.licenses.append(bb_dict.get("LICENSE"))
             print_infile("License added: {}".format(bb_dict.get("LICENSE")))
 

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -319,7 +319,7 @@ class Specfile(object):
                 content = self.config.read_conf_file("{}.{}".format(script, pkg))
                 if content:
                     self._write("\n%{0} {1}\n".format(script, pkg))
-                    content = ['{}\n'.format(l) for l in content]
+                    content = ['{}\n'.format(line) for line in content]
                     self.specfile.writelines(content)
 
     def write_files(self):


### PR DESCRIPTION
The following warnings are raised:
```
autospec/autospec.py:92:9: E741 ambiguous variable name 'l'
autospec/config.py:552:31: E741 ambiguous variable name 'l'
autospec/infile_update_spec.py:54:65: E741 ambiguous variable name 'l'
autospec/specfiles.py:322:53: E741 ambiguous variable name 'l'
```