### PR TITLE
actions: set job timeouts to 30 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ jobs:
   test_style:
     runs-on: ubuntu-latest
     name: Flake8
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2.1.0
@@ -16,6 +17,7 @@ jobs:
   test_unit:
     runs-on: ubuntu-latest
     name: Unit
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2.1.0


### PR DESCRIPTION
The default timeout is 6 hours, which is too long for autospec's needs.

We could probably lessen the timeout even more, but I want to account
for the possibility of variable network speeds and future bundle size
increases, which may increase runtime of the `docker build` phase of the
testing steps. Long term, it would be nice to ship a prebuilt container
in Dockerhub for autospec CI testing like mixer-tools does.