### PR TITLE
Requirements: Properly initialize the class

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -284,6 +284,7 @@ class Requirements(object):
         self.extra_cmake_openmpi = set()
         self.verbose = False
         self.cargo_bin = False
+        self.pypi_provides = None
         self.banned_buildreqs = set(["llvm-devel",
                                      "gcj",
                                      "pkgconfig(dnl)",


### PR DESCRIPTION
The pypi_provides memeber wasn't being set on initialization causing
an error when processing the specfile in some cases.

Fixes #625.