### PR TITLE
Ban the 'typing' package

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -275,7 +275,8 @@ class Requirements(object):
     def __init__(self, url):
         """Initialize Default requirements settings."""
         self.banned_requires = {None: set(["futures",
-                                           "configparser"])}
+                                           "configparser",
+                                           "typing"])}
         self.buildreqs = set()
         self.buildreqs_cache = set()
         self.requires = {None: set(), "pypi": set()}
@@ -294,7 +295,8 @@ class Requirements(object):
                                      "oslo-python",
                                      "libxml2No-python",
                                      "futures",
-                                     "configparser"])
+                                     "configparser",
+                                     "typing"])
         self.autoreconf_reqs = ["gettext-bin",
                                 "automake-dev",
                                 "automake",


### PR DESCRIPTION
This package was present for compatibility, but it's been superseded by the stdlib module with the same name.