### PR TITLE
Ban the 'ipaddress' package

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -276,7 +276,8 @@ class Requirements(object):
         """Initialize Default requirements settings."""
         self.banned_requires = {None: set(["futures",
                                            "configparser",
-                                           "typing"])}
+                                           "typing",
+                                           "ipaddress"])}
         self.buildreqs = set()
         self.buildreqs_cache = set()
         self.requires = {None: set(), "pypi": set()}
@@ -296,7 +297,8 @@ class Requirements(object):
                                      "libxml2No-python",
                                      "futures",
                                      "configparser",
-                                     "typing"])
+                                     "typing",
+                                     "ipaddress"])
         self.autoreconf_reqs = ["gettext-bin",
                                 "automake-dev",
                                 "automake",


### PR DESCRIPTION
The standard library has shipped an `ipaddress` module since Python 3.3, so we don't need this package anymore.