### PR TITLE
Ignore "unknown xref" warnings for R packages

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -293,7 +293,6 @@ class Config(object):
             (r"Target '[a-zA-Z0-9\-]' can't be generated as '(.*)' could not be found", 0, None),
             (r"Unable to `import (.*)`", 0, None),
             (r"Unable to find '(.*)'", 0, None),
-            (r"Unknown packages? ['‘]([a-zA-Z0-9\-]*)['’].* in Rd xrefs", 0, 'R'),
             (r"WARNING:  [a-zA-Z\-\_]+ dependency on ([a-zA-Z0-9\-\_:]*) \([<>=~]+ ([0-9.]+).*\) .*", 0, 'ruby'),
             (r"Warning: prerequisite ([a-zA-Z:]+) [0-9\.]+ not found.", 0, 'perl'),
             (r"Warning\: no usable ([a-zA-Z0-9]+) found", 0, None),

--- a/tests/builderrors
+++ b/tests/builderrors
@@ -70,10 +70,6 @@ Program swig found: NO|swig
 Target 't' can't be generated as 'swig' could not be found|swig
 Unable to `import swig`|swig
 Unable to find 'swig'|swig
-Unknown package 'swig' in Rd xrefs|R-swig
-Unknown package ‘swig’ in Rd xrefs|R-swig
-Unknown packages 'swig', 'swig2' in Rd xrefs|R-swig
-Unknown packages ‘swig’, ‘swig2’ in Rd xrefs|R-swig
 WARNING:  package dependency on swig (= 5.4) ardilla|rubygem-swig
 Warning: no usable swig found|swig
 Warning: prerequisite swig 8 not found.|perl(swig)


### PR DESCRIPTION
These warning messages appear whenever an R package's tests cannot
resolve documentation cross-references to other packages.

Although the warnings may create usability problems with a package's
documentation, any unresolvable cross-references are for *optional*
or *undeclared* dependencies, and thus do not impact the overall
functionality of that package.

I consider these unresolvable cross-references to be a minor drawback,
and there is greater benefit to ignoring them than acting on them: (a)
build rounds for R packages will be reduced in general, especially
improving build times for packages with multiple warnings raised, and
(b) the dependency tree becomes smaller, simplifying and improving the
time to rebuild all R packages in dependency order.