### PR TITLE
Add nomissingbuildids, noautoreq, noautoprov flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -597,6 +597,17 @@ compat
 
 nodebug
   If this option is set, ``debuginfo`` is not created for this package.
+  
+nomissingbuildids
+  If this option is set, missing build ids will not terminate the build.
+  
+noautoreq
+  If this option is set, ``AutoReq: no`` will be set for this package and 
+  automatic requeriments processing will be disabled
+  
+noautoprov
+  If this option is set, ``AutoProv: no`` will be set for this package and
+  automatic provides processing will be disabled
 
 Name and version resolution
 ===========================

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -460,13 +460,13 @@ class Config(object):
 
         # default lto to true for new things
         config_f['autospec']['use_lto'] = 'true'
-        
+
         # default ignore missing build ids for new things
         config_f['autospec']['nomissingbuildids'] = 'false'
-        
+
         # default disable automatic requeriments processing for new things
         config_f['autospec']['noautoreq'] = 'false'
-        
+
         # default disable automatic provides processing for new things
         config_f['autospec']['noautoprov'] = 'false'
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -178,7 +178,10 @@ class Config(object):
             "autoupdate": "this package is trusted enough to automatically update (used by other tools)",
             "compat": "this package is a library compatibility package and only ships versioned library files",
             "nodebug": "do not generate debuginfo for this package",
-            "openmpi": "configure build also for openmpi"
+            "openmpi": "configure build also for openmpi",
+            "nomissingbuildids": "ignore missing build ids",
+            "noautoreq": "disable automatic requeriments processing",
+            "noautoprov": "disable automatic provides processing"
         }
         # simple_pattern_pkgconfig patterns
         # contains patterns for parsing build.log for missing dependencies
@@ -457,6 +460,15 @@ class Config(object):
 
         # default lto to true for new things
         config_f['autospec']['use_lto'] = 'true'
+        
+        # default ignore missing build ids for new things
+        config_f['autospec']['nomissingbuildids'] = 'false'
+        
+        # default disable automatic requeriments processing for new things
+        config_f['autospec']['noautoreq'] = 'false'
+        
+        # default disable automatic provides processing for new things
+        config_f['autospec']['noautoprov'] = 'false'
 
         # renamed options need special care
         if os.path.exists("skip_test_suite"):

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -83,6 +83,9 @@ class Specfile(object):
         self.write_buildreq()
         self.write_strip_command()
         self.write_debug_command()
+        self.write_missing_build_ids_command()
+        self.write_disable_autoreq()
+        self.write_disable_autoprov()
         self.write_patch_header()
 
         # main package extra content
@@ -201,6 +204,24 @@ class Specfile(object):
         if self.config.config_opts['nodebug']:
             self._write("# Suppress generation of debuginfo\n")
             self._write("%global debug_package %{nil}\n")
+
+    def write_missing_build_ids_command(self):
+        """Write commands to prevent failure if there are missing build ids."""
+        if self.config.config_opts['nomissingbuildids']:
+            self._write("# Ignore missing build ids\n")
+            self._write("%undefine _missing_build_ids_terminate_build\n")
+
+    def write_disable_autoreq(self):
+        """Write commands to disable automatic requeriments processing."""
+        if self.config.config_opts['noautoreq']:
+            self._write("# Disable automatic requeriments processing\n")
+            self._write("AutoReq: no\n")
+
+    def write_disable_autoprov(self):
+        """Write commands to disable automatic provides processing."""
+        if self.config.config_opts['noautoprov']:
+            self._write("# Disable automatic provides processing\n")
+            self._write("AutoProv: no\n")
 
     def write_patch_header(self):
         """Write patch list header."""


### PR DESCRIPTION
New useful controlling flags for options.conf that helps to build certain packages