### PR TITLE
Remove VERBOSE=1 for cmake pattern

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1504,8 +1504,6 @@ class Specfile(object):
 
     def write_cmake_pattern(self):
         """Write cmake pattern to spec file."""
-        if self.config.extra_make == "" or self.extra_cmake == " ":
-            self.config.extra_make = "VERBOSE=1"
         self.write_prep()
         self.write_lang_c(export_epoch=True)
 


### PR DESCRIPTION
In January 2018, we had intentionally removed all of the `V=1` and `VERBOSE=1` options from `%build` sections to make build logs less verbose by default, because it created a considerable build log parsing performance penalty for some packages, and autospec does not require any verbose logs for its operation (fail patterns, etc).

A `VERBOSE=1` option was re-introduced in February 2018, most likely on accident, when we added avx512 build support, but only for the cmake pattern. This commit removes that logic, which over time was made generic for all cmake builds (not just for the avx512 cmake build).