### PR TITLE
Clean up stray tempdirs and processes

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -186,6 +186,8 @@ def cli_gpg_ctx(pubkey=None):
         yield GPGCli(pubkey, _gpghome)
     finally:
         if _gpghome is not None:
+            _ = subprocess.run(["gpgconf", "--homedir", _gpghome, "--kill", "all"],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             del os.environ['GNUPGHOME']
             shutil.rmtree(_gpghome, ignore_errors=True)
 

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -7,10 +7,10 @@ import os
 import re
 import shutil
 import signal
+import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
-from subprocess import PIPE, Popen, TimeoutExpired
 from urllib.parse import urlparse
 
 import download
@@ -86,10 +86,10 @@ class GPGCli(object):
     @staticmethod
     def exec_cmd(args):
         """Popen wrapper."""
-        proc = Popen(args, stdout=PIPE, stderr=PIPE)
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             out, err = proc.communicate(timeout=CMD_TIMEOUT)
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             proc.kill()
             out, err = proc.communicate()
         return out, err, proc.returncode
@@ -731,7 +731,7 @@ def parse_gpg_packets(filename, verbose=True):
     """Return a list with metadata about each packet from a GPG key or signature."""
     args = ["gpg", "--list-packets", filename]
     try:
-        out, err = Popen(args, stdout=PIPE, stderr=PIPE).communicate()
+        out, err = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         if err.decode('utf-8') != '' and verbose is True:
             print(err.decode('utf-8'))
             return None

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -178,26 +178,22 @@ class GPGCli(object):
 
 
 @contextmanager
-def cli_gpg_ctx(pubkey=None, gpghome=None):
+def cli_gpg_ctx(pubkey=None):
     """Return correctly initialized GPGCli."""
-    if pubkey is None:
-        yield GPGCli()
-    else:
-        try:
-            _gpghome = gpghome
-            if _gpghome is None:
-                _gpghome = tempfile.mkdtemp(prefix='tmp.gpghome')
-            yield GPGCli(pubkey, _gpghome)
-        finally:
-            if gpghome is None:
-                del os.environ['GNUPGHOME']
-                shutil.rmtree(_gpghome, ignore_errors=True)
+    _gpghome = None
+    try:
+        _gpghome = tempfile.mkdtemp(prefix='tmp.gpghome')
+        yield GPGCli(pubkey, _gpghome)
+    finally:
+        if _gpghome is not None:
+            del os.environ['GNUPGHOME']
+            shutil.rmtree(_gpghome, ignore_errors=True)
 
 
 # Use gpg command line
-def verify_cli(pubkey, tarball, signature, gpghome=None):
+def verify_cli(pubkey, tarball, signature):
     """Validate tarfile with signature."""
-    with cli_gpg_ctx(pubkey, gpghome) as ctx:
+    with cli_gpg_ctx(pubkey) as ctx:
         return ctx.verify(pubkey, tarball, signature)
     raise Exception('Verification did not take place using cli')
 

--- a/autospec/pypidata.py
+++ b/autospec/pypidata.py
@@ -52,7 +52,7 @@ def get_pypi_metadata(name):
     show = []
     # Create virtenv to do the pip install (needed for pip show)
     with tempfile.TemporaryDirectory() as tdir:
-        proc = subprocess.run(["virtualenv", tdir], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        proc = subprocess.run(["virtualenv", "--no-periodic-update", tdir], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if proc.returncode != 0:
             return ""
         proc = subprocess.run(f"source bin/activate && pip install {name}", cwd=tdir, shell=True,


### PR DESCRIPTION
Resolves a few issues:

- Remove temporary directories created for public key imports
- Avoid `virtualenv`'s default behavior of spawning processes to periodically update them
- Terminate daemonized processes spawned by `gpg` upon cleanup