### PR TITLE
Quieten test compilation for make-based patterns

### DIFF
--- a/autospec/check.py
+++ b/autospec/check.py
@@ -60,16 +60,16 @@ def scan_for_tests(src_dir, config, requirements, content):
         return
 
     makeflags = "%{?_smp_mflags} " if config.parallel_build else ""
-    make_check = "make VERBOSE=1 V=1 {}check".format(makeflags)
+    make_check = "make {}check".format(makeflags)
     cmake_check = "make test"
     make_check_openmpi = "module load openmpi\nexport OMPI_MCA_rmaps_base_oversubscribe=1\n" \
-                         "make VERBOSE=1 V=1 {}check\nmodule unload openmpi".format(makeflags)
+                         "make {}check\nmodule unload openmpi".format(makeflags)
     cmake_check_openmpi = "module load openmpi\nexport OMPI_MCA_rmaps_base_oversubscribe=1\n" \
                           "make test\nmodule unload openmpi"
 
     if config.config_opts.get('allow_test_failures'):
         make_check_openmpi = "module load openmpi\nexport OMPI_MCA_rmaps_base_oversubscribe=1\n" \
-                             "make VERBOSE=1 V=1 {}check || :\nmodule unload openmpi".format(makeflags)
+                             "make {}check || :\nmodule unload openmpi".format(makeflags)
         cmake_check_openmpi = "module load openmpi\nexport OMPI_MCA_rmaps_base_oversubscribe=1\n" \
                               "make test || :\nmodule unload openmpi"
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -100,7 +100,7 @@ class TestTest(unittest.TestCase):
 
         check.os.listdir = listdir_backup
         self.assertEqual(check.tests_config,
-                         'make VERBOSE=1 V=1 %{?_smp_mflags} check')
+                         'make %{?_smp_mflags} check')
 
     def test_scan_for_tests_makecheck_am(self):
         """
@@ -118,7 +118,7 @@ class TestTest(unittest.TestCase):
 
         check.os.listdir = listdir_backup
         self.assertEqual(check.tests_config,
-                         'make VERBOSE=1 V=1 %{?_smp_mflags} check')
+                         'make %{?_smp_mflags} check')
 
     def test_scan_for_tests_perlcheck_PL(self):
         """


### PR DESCRIPTION
For make-based patterns, the make command from %build is not verbose by default, so remove the verbosity flags for the test compilation command as well.