### PR TITLE
Address some issues with license handling

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -234,6 +234,18 @@ def package(args, url, name, archives, workingdir, infile_dict):
     # Search up one level from here to capture multiple versions
     _dir = content.path
 
+    conf.setup_patterns()
+    conf.config_file = args.config
+    requirements = buildreq.Requirements(content.url)
+    requirements.set_build_req(conf)
+    conf.parse_config_files(args.bump, filemanager, content.version, requirements)
+    conf.setup_patterns(conf.failed_pattern_dir)
+    conf.parse_existing_spec(content.name)
+
+    if args.prep_only:
+        write_prep(conf, workingdir, content)
+        exit(0)
+
     if args.license_only:
         try:
             with open(os.path.join(conf.download_path,
@@ -245,18 +257,6 @@ def package(args, url, name, archives, workingdir, infile_dict):
             pass
         # Start one directory higher so we scan *all* versions for licenses
         license.scan_for_licenses(os.path.dirname(_dir), conf)
-        exit(0)
-
-    conf.setup_patterns()
-    conf.config_file = args.config
-    requirements = buildreq.Requirements(content.url)
-    requirements.set_build_req(conf)
-    conf.parse_config_files(args.bump, filemanager, content.version, requirements)
-    conf.setup_patterns(conf.failed_pattern_dir)
-    conf.parse_existing_spec(content.name)
-
-    if args.prep_only:
-        write_prep(conf, workingdir, content)
         exit(0)
 
     requirements.scan_for_configure(_dir, content.name, conf)

--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -256,7 +256,7 @@ def package(args, url, name, archives, workingdir, infile_dict):
         except Exception:
             pass
         # Start one directory higher so we scan *all* versions for licenses
-        license.scan_for_licenses(os.path.dirname(_dir), conf)
+        license.scan_for_licenses(os.path.dirname(_dir), conf, name)
         exit(0)
 
     requirements.scan_for_configure(_dir, content.name, conf)

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -169,6 +169,11 @@ def scan_for_licenses(srcdir, config, pkg_name):
             if name.lower() in targets or target_pat.search(name.lower()):
                 license_from_copying_hash(os.path.join(dirpath, name),
                                           srcdir, config, pkg_name)
+            # Also look for files that end with .txt and reside in a LICENSES
+            # directory. This is a convention that KDE is adopting.
+            if os.path.basename(dirpath) == "LICENSES" and re.search(r'\.txt$', name):
+                license_from_copying_hash(os.path.join(dirpath, name),
+                                          srcdir, config, pkg_name)
 
     if not licenses:
         print_fatal(" Cannot find any license or a valid {}.license file!\n".format(pkg_name))


### PR DESCRIPTION
- Support a new pattern for in-tree license files: any `.txt` files that reside in a directory named `LICENSES`. This is a new convention being adopted by some upstream projects.
- Fix autospec's "license-only" mode; there was a code ordering issue and a broken call to `license.scan_for_licenses()` from that code block.