### PR TITLE
Remove references to deprecated component (libXxf86misc)

### DIFF
--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -486,7 +486,7 @@ Wget, wget
 WinPR, FreeRDP-dev
 Wireshark, wireshark
 Wish, tk
-X11, libX11-dev libICE-dev libSM-dev libXau-dev libXcomposite-dev libXcursor-dev libXdamage-dev libXdmcp-dev libXext-dev libXfixes-dev libXft-dev libXi-dev libXinerama-dev libXi-dev libXmu-dev libXpm-dev libXrandr-dev libXrender-dev libXres-dev libXScrnSaver-dev libXt-dev libXtst-dev libXv-dev libXxf86misc-dev libXxf86vm-dev
+X11, libX11-dev libICE-dev libSM-dev libXau-dev libXcomposite-dev libXcursor-dev libXdamage-dev libXdmcp-dev libXext-dev libXfixes-dev libXft-dev libXi-dev libXinerama-dev libXi-dev libXmu-dev libXpm-dev libXrandr-dev libXrender-dev libXres-dev libXScrnSaver-dev libXt-dev libXtst-dev libXv-dev libXxf86vm-dev
 X11_XCB, extra-cmake-modules pkgconfig(x11-xcb)
 XCB, extra-cmake-modules pkgconfig(xcb) xcb-util-cursor-dev xcb-util-image-dev xcb-util-keysyms-dev xcb-util-renderutil-dev xcb-util-wm-dev xcb-util-dev
 Z3, Z3-dev

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -30,7 +30,6 @@
 -lXt, pkgconfig(xt)
 -lXtst, pkgconfig(xtst)
 -lXv, libXv-dev
--lXxf86misc, libXxf86misc-dev
 -lXxf86vm, libXxf86vm-dev
 -lacl, acl-dev
 -lasound, alsa-lib-dev
@@ -621,7 +620,6 @@ XCB, libxcb-dev
 XCB_IMAGE, xcb-util-image-dev
 XCB_RENDERUTIL, xcb-util-renderutil-dev
 XCOMPOSITE extension, libXcomposite-dev
-XF86MiscSetGrabKeysState in -lXxf86misc, libXxf86misc-dev
 XGetEventData, inputproto
 XML, libxml2-dev
 XML::Parser, perl(XML::Parser)


### PR DESCRIPTION
To avoid automatic additions of dependencies on libXxf86misc, remove
patterns and any references to it.