### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -175,7 +175,7 @@ class Build(object):
                 self.must_restart += requirements.add_pkgconfig_buildreq(s, config.config_opts.get('32bit'), cache=True)
                 self.must_restart += requirements.add_buildreq(s, cache=True)
         except Exception:
-            if s not in self.warned_about and s[:2] != '--':
+            if s.strip() and s not in self.warned_about and s[:2] != '--':
                 print("Unknown pattern match: ", s)
                 self.warned_about.add(s)
 

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -176,7 +176,7 @@ class Build(object):
                 self.must_restart += requirements.add_buildreq(s, cache=True)
         except Exception:
             if s.strip() and s not in self.warned_about and s[:2] != '--':
-                print("Unknown pattern match: ", s)
+                util.print_warning(f"Unknown pattern match: {s}")
                 self.warned_about.add(s)
 
     def parse_buildroot_log(self, filename, returncode):

--- a/autospec/logcheck.py
+++ b/autospec/logcheck.py
@@ -84,4 +84,4 @@ def logcheck(pkg_loc):
 
 def write_misses(pkg_loc, misses):
     """Create configure_misses file with automatically disabled configuration options."""
-    write_out(os.path.join(pkg_loc, 'configure_misses'), '\n'.join(misses))
+    write_out(os.path.join(pkg_loc, 'configure_misses'), '\n'.join(sorted(misses)))


### PR DESCRIPTION
* Sort the `configure_misses` file for better reproducibility.
* Avoid "unknown pattern match" for strings containing only whitespace.
* Make the "unknown pattern match" message a warning for better visibility.