### PR TITLE
Port for GCC 11

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -553,7 +553,7 @@ class Specfile(object):
         if self.config.config_opts['security_sensitive']:
             flags.append("-fstack-protector-strong")
             if arch == 'x86_64':
-                flags.append("-mzero-caller-saved-regs=used")
+                flags.append("-fzero-call-used-regs=used")
         if self.need_avx2_flags:
             flags.extend(["-O3", "-march=haswell"])
         if self.need_avx512_flags:


### PR DESCRIPTION
The GCC 10 in Clear Linux OS carried a patch to support the `-mzero-caller-saved-regs` flag. This feature landed upstream in GCC 11, but with a new name: `-fzero-call-used-regs`. The new flag supports the value of `used`, so we will continue using that value.