### PR TITLE
More content binning improvements for avx2/avx512

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -290,6 +290,7 @@ class FileManager(object):
             (r"^/usr/lib32/[a-zA-Z0-9._+-]*\.a$", "staticdev32"),
             (r"^/usr/lib/haswell/[a-zA-Z0-9._+-]*\.a$", "staticdev"),
             (r"^/usr/lib64/haswell/[a-zA-Z0-9._+-]*\.a$", "staticdev"),
+            (r"^/usr/lib64/haswell/avx512_1/[a-zA-Z0-9._+-]*\.a$", "staticdev"),
             (r"^/usr/lib32/haswell/[a-zA-Z0-9._+-]*\.a$", "staticdev32"),
             (r"^/usr/lib/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),
             (r"^/usr/lib64/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -295,6 +295,8 @@ class FileManager(object):
             (r"^/usr/lib/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),
             (r"^/usr/lib64/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),
             (r"^/usr/lib32/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev32"),
+            (r"^/usr/lib64/haswell/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),
+            (r"^/usr/lib64/haswell/avx512_1/pkgconfig/[a-zA-Z0-9._+-]*\.pc$", "dev"),
             (r"^/usr/lib/[a-zA-Z0-9._+-]*\.la$", "dev"),
             (r"^/usr/lib64/[a-zA-Z0-9._+-]*\.la$", "dev"),
             (r"^/usr/lib32/[a-zA-Z0-9._+-]*\.la$", "dev32"),


### PR DESCRIPTION
This PR adds subpackage binning for the following content:

- pkgconfig files that reside in either `/usr/lib64/haswell` or `/usr/lib64/haswell/avx512_1`
- static libraries that reside in `/usr/lib64/haswell/avx512_1`

The extra pkgconfig files could arguably be auto-excluded, but it's easier to just bin them in the most appropriate location for now.