### PR TITLE
Minor improvements to tarball URL match patterns

### DIFF
--- a/.github/actions/clearlinux-latest-action/entrypoint.sh
+++ b/.github/actions/clearlinux-latest-action/entrypoint.sh
@@ -5,7 +5,7 @@ run_flake8() {
 }
 
 run_unittests() {
-	make unittests
+	make unittests-no-coverage
 }
 
 if t=$(type -t "$INPUT_TESTFUNC"); then

--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,8 @@ test_general:
 unittests:
 	PYTHONPATH=${CURDIR}/autospec coverage run -m unittest discover -b -s tests -p 'test_*.py' && coverage report
 
+unittests-no-coverage:
+	PYTHONPATH=${CURDIR}/autospec python3 -m unittest discover -b -s tests -p 'test_*.py'
+
 coverage:
 	coverage report -m

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -290,7 +290,8 @@ class Content(object):
         if "github.com" in self.url:
             # define regex accepted for valid packages, important for specific
             # patterns to come before general ones
-            github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/[v|r]?.*/(.*).tar",
+            github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/refs/tags/[vVrR]?(.*)\.tar",
+                               r"https?://github.com/(.*)/(.*?)/archive/[v|r]?.*/(.*).tar",
                                r"https?://github.com/(.*)/(.*?)/archive/[-a-zA-Z_]*-(.*).tar",
                                r"https?://github.com/(.*)/(.*?)/archive/[vVrR]?(.*).tar",
                                r"https?://github.com/(.*)/.*-downloads/releases/download/.*?/(.*)-(.*).tar",

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -375,7 +375,7 @@ class Content(object):
 
         if "gitlab.com" in self.url:
             # https://gitlab.com/leanlabsio/kanban/-/archive/1.7.1/kanban-1.7.1.tar.gz
-            m = re.search(r"gitlab\.com/.*/(.*)/-/archive/(.*)/", self.url)
+            m = re.search(r"gitlab\.com/.*/(.*)/-/archive/[vVrR]?(.*)/", self.url)
             if m:
                 name = m.group(1).strip()
                 version = convert_version(m.group(2), name)

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1122,6 +1122,7 @@ http://pypi.debian.net/PyWavelets/PyWavelets-0.5.2.tar.gz,PyWavelets,0.5.2
 http://pypi.debian.net/pyxdg/pyxdg-0.25.tar.gz,pyxdg,0.25
 http://pypi.debian.net/PyYAML/PyYAML-3.12.tar.gz,PyYAML,3.12
 http://pypi.debian.net/pyzmq/pyzmq-16.0.2.tar.gz,pyzmq,16.0.2
+https://github.com/intel/QAT_Engine/archive/refs/tags/v0.6.5.tar.gz,QAT_Engine,0.6.5
 http://wiki.qemu-project.org/download/qemu-2.10.1.tar.bz2,qemu,2.10.1
 https://github.com/qpdf/qpdf/archive/release-qpdf-7.0.0.tar.gz,qpdf,7.0.0
 http://apache.arvixe.com/qpid/0.32/qpid-python-0.32.tar.gz,qpid-python,0.32

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -622,7 +622,7 @@ https://www.libssh2.org/download/libssh2-1.8.0.tar.gz,libssh2,1.8.0
 https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.12.tar.gz,libtasn1,4.12
 ftp://linux.thai.net/pub/thailinux/software/libthai/libthai-0.1.26.tar.xz,libthai,0.1.26
 http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2,libtheora,1.1.1
-https://gitlab.com/libtiff/libtiff/-/archive/v4.0.10/libtiff-v4.0.10.tar.gz,libtiff,v4.0.10
+https://gitlab.com/libtiff/libtiff/-/archive/v4.0.10/libtiff-v4.0.10.tar.gz,libtiff,4.0.10
 https://sourceforge.net/projects/libtirpc/files/libtirpc/1.0.2/libtirpc-1.0.2.tar.bz2,libtirpc,1.0.2
 https://mirrors.kernel.org/gnu/libtool/libtool-2.4.6.tar.xz,libtool,2.4.6
 https://github.com/archlinux/libudev0-shim/archive/v1.tar.gz,libudev0-shim,1


### PR DESCRIPTION
- Support new Github endpoint for autogenerated tarballs (`/refs/tags/...`).
- Strip one-letter prefixes from versions in Gitlab URLs, if present.
- Update tests