### PR TITLE
Specify -flto=auto instead of -flto=4

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -540,7 +540,7 @@ class Specfile(object):
             self._write_strip("CXXFLAGS=${CXXFLAGS/ -Wa,/ -fno-integrated-as -Wa,}")
             lto = "-flto"
         else:
-            lto = "-flto=4"
+            lto = "-flto=auto"
 
         if not self.config.set_gopath:
             self._write_strip("export GOPROXY=file:///usr/share/goproxy")


### PR DESCRIPTION
The special value of `auto` for `-flto` will scale better when building on a system with many CPUs.