### PR TITLE
Don't handle install_requires parsing when already in multiline

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -662,7 +662,7 @@ class Requirements(object):
             lines = f.readlines()
 
         for line in lines:
-            if "install_requires" in line or "setup_requires" in line:
+            if not multiline and ("install_requires" in line or "setup_requires" in line):
                 req = "install_requires" in line
                 # find the value for *_requires
                 line = line.split("=", 1)

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -394,6 +394,24 @@ class TestBuildreq(unittest.TestCase):
         self.assertEqual(self.reqs.buildreqs, set(['req1', 'req2']))
         self.assertEqual(self.reqs.requires[None], set(['req1', 'req2']))
 
+    def test_add_setup_py_requires_multiline_install_requires_variable(self):
+        """
+        Test add_setup_py_requires with multiline item in install_requires that
+        contains a non-literal object.
+        """
+        open_name = 'buildreq.util.open_auto'
+        content = "install_requires=[\n"   \
+                  "'req1',\n"              \
+                  "'req2'"                 \
+                  "] + install_requires\n" \
+                  "'bad']\n"
+        m_open = mock_open(read_data=content)
+        with patch(open_name, m_open, create=True):
+            self.reqs.add_setup_py_requires('filename', ['req1', 'req2'])
+
+        self.assertEqual(self.reqs.buildreqs, set(['req1', 'req2']))
+        self.assertEqual(self.reqs.requires[None], set(['req1', 'req2']))
+
     def test_add_setup_py_requires_variable(self):
         """
         Test add_setup_py_requires that contains a non-literal object.


### PR DESCRIPTION
When parsing setup.py files, if already in multiline and install_requires
is used as a variable, don't try and treat the line as if it was an
install_requires assignment.

Signed-off-by: William Douglas <william.douglas@intel.com>