### PR TITLE
Print unit test errors for meson pattern

### DIFF
--- a/autospec/check.py
+++ b/autospec/check.py
@@ -75,7 +75,7 @@ def scan_for_tests(src_dir, config, requirements, content):
 
     perl_check = "make TEST_VERBOSE=1 test"
     setup_check = """PYTHONPATH=%{buildroot}$(python -c "import sys; print(sys.path[-1])") python setup.py test"""
-    meson_check = "meson test -C builddir"
+    meson_check = "meson test -C builddir --print-errorlogs"
     if config.config_opts.get('allow_test_failures'):
         make_check += " || :"
         cmake_check += " || :"


### PR DESCRIPTION
The `meson test` subcommand has a `--print-errorlogs` flag that we can
use to print details about any failed unit tests. Thus any errors will
be more easily discoverable by inspection of the mock build.log.