### PR TITLE
commitmessage: skip invalid UTF-8 sequences

### DIFF
--- a/autospec/commitmessage.py
+++ b/autospec/commitmessage.py
@@ -204,11 +204,11 @@ def process_git(giturl, oldversion, newversion, name):
         newtag = guessed_newtag
 
     p = run(["git", "-C", "results/" + name, "log", "--no-merges", oldtag + ".." + newtag], stdout=PIPE)
-    fulllog = p.stdout.decode('utf-8').split('\n')
+    fulllog = p.stdout.decode('utf-8', errors='replace').split('\n')
     # 'git shortlog' can accept any 'git log' output over stdin, so make sure
     # it lacks merge commits, too.
     p = run(["git", "-C", "results/" + name, "shortlog"], input=p.stdout, stdout=PIPE)
-    shortlog = p.stdout.decode('utf-8').split('\n')
+    shortlog = p.stdout.decode('utf-8', errors='replace').split('\n')
 
     if len(fulllog) < 15:
         return fulllog


### PR DESCRIPTION
In case either `git log -p` or `git shortlog` output invalid UTF-8
sequences, make a best effort to convert to UTF-8, inserting the Unicode
replacement character in place of any invalid sequences.

An alternative could be to guess the character encoding (using
`charset-normalizer` for example), or establish another heuristic (like
in autospec/license.py), but I opted to take this simpler approach
because the shortlog we insert into the commit can be lossy... If any
replacement characters appear, rendering output difficult to understand,
developers can consult the upstream repo for details.