### PR TITLE
Revise CRAN package dep handling

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -128,7 +128,6 @@ class Build(object):
             elif buildtool == 'R':
                 if requirements.add_buildreq("R-" + s, cache=True) > 0:
                     self.must_restart += 1
-                    requirements.add_requires("R-" + s, config.os_packages)
             elif buildtool == 'perl':
                 s = s.replace('inc::', '')
                 self.must_restart += requirements.add_buildreq('perl(%s)' % s, cache=True)

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -485,11 +485,8 @@ class Requirements(object):
             if dep in r_provides:
                 continue
             pkg = 'R-' + dep
-            if pkg in packages:
-                self.add_buildreq(pkg)
-                self.add_requires(pkg, packages)
-            else:
-                print("CRAN package '{}' not found in os_packages, skipping".format(pkg))
+            self.add_buildreq(pkg)
+            self.add_requires(pkg, packages)
 
     def set_build_req(self, config):
         """Add build requirements based on the build pattern."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -147,7 +147,7 @@ class TestBuildpattern(unittest.TestCase):
                              0,  # verbose=0
                              buildtool='R')
         self.assertIn('R-testpkg', reqs.buildreqs)
-        self.assertIn('R-testpkg', reqs.requires[None])
+        self.assertNotIn('R-testpkg', reqs.requires[None])
         self.assertEqual(pkg.must_restart, 1)
 
     def test_failed_pattern_perl(self):

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -797,8 +797,12 @@ find_package(different_name)
         with patch(open_name, m_open):
             self.reqs.parse_r_description('filename', pkgs)
         self.assertTrue('R-pkg1' in self.reqs.buildreqs)
-        self.assertFalse('R-pkg2' in self.reqs.buildreqs)
-        self.assertFalse('R-pkg3' in self.reqs.buildreqs)
+        self.assertTrue('R-pkg1' in self.reqs.requires[None])
+        # Names absent from the os-packages list are also added, because the
+        # DESCRIPTION file is considered authoritative.
+        for pkg in ['R-pkg2', 'R-pkg3']:
+            self.assertTrue(pkg in self.reqs.buildreqs)
+            self.assertTrue(pkg in self.reqs.requires[None])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Autospec's DESCRIPTION file parsing for CRAN packages is working well
enough that I think we can unconditionally add the detected requirements
as both build and runtime dependencies.

Also remove the propagation of CRAN build->runtime deps via fail
pattern, since we no longer need it; the deps detected via fail pattern
are either Suggests (optional) or not listed in DESCRIPTION at all.
Either way, they are not required dependencies.