### PR TITLE
Add pypi overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,20 @@ series
   0001-my-awesome-patch.patch -d some/subdir -p1
   ```
 
+pypi_overrides
+  This file contains a list of modules to remove version tests on during the
+  build. It also modifies the requirement of the requires.txt egg if it
+  exists in the package. For example:
+
+  ```
+  colorama
+  ```
+  in the file will cause this modification:
+  ```
+  -    'colorama>=0.2.5,<0.4.4',
+  +    'colorama',
+  ```
+
 golang_libpath
   When building go packages, the go import path will be guessed automatically
   (e.g. building ``https://github.com/go-yaml/yaml/`` would get

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -96,6 +96,7 @@ class Config(object):
         self.install_append = []
         self.service_restart = []
         self.patches = []
+        self.pypi_overrides = []
         self.verpatches = OrderedDict()
         self.extra_sources = []
         self.autoreconf = False
@@ -890,6 +891,8 @@ class Config(object):
         if update_security_sensitive:
             self.config_opts['security_sensitive'] = True
             self.rewrite_config_opts()
+
+        self.pypi_overrides += self.read_conf_file(os.path.join(self.download_path, "pypi_overrides"))
 
         content = self.read_conf_file(os.path.join(self.download_path, "configure"))
         self.extra_configure = " \\\n".join(content)

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1363,6 +1363,8 @@ class Specfile(object):
         self._write_strip("export MAKEFLAGS=%{?_smp_mflags}")
         if self.config.subdir:
             self._write_strip("pushd " + self.config.subdir)
+        for module in self.config.pypi_overrides:
+            self._write_strip(f"pypi-dep-fix.py . {module}")
         self._write_strip("python3 setup.py build  " + self.config.extra_configure)
         self._write_strip("\n")
         if self.tests_config and not self.config.config_opts['skip_tests']:


### PR DESCRIPTION
See https://github.com/clearlinux/clr-avx-tools/commit/013a989f5ad273adbc00e34eb18b87984b04ba78 for details about the new script autospec started to use for doing the dependency modifications.

Also adds some minor autospec cleanups I found along the way.