### PR TITLE
Add build_append_once configuration support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,12 +246,19 @@ prep_prepend
   control is required.
 
 build_prepend
+  Additional actions that should take place after ``%build`` and before
+  the ``%configure`` macro or equivalent (``%cmake``, etc.). If autospec
+  is creating AVX2, AVX-512 or 32-bit, these actions will be repeated for
+  each of those builds, This will be placed in the resulting ``.spec``,
+  and is used for situations where fine-grained control is required.
+
+build_prepend_once
   Additional actions that should take place directly after ``%build``
-  and before the ``%configure`` macro or equivalent (``%cmake``,
-  etc.). If autospec is creating AVX2, AVX-512 or 32-bit, these
-  actions will be repeated for each of those builds, This will be
-  placed in the resulting ``.spec``, and is used for situations where
-  fine-grained control is required.
+  and before the ``%configure`` macro or equivalent (``%cmake``, etc.).
+  If autospec is creating AVX2, AVX-512 or 32-bit, these action will
+  not be repeated for each of those builds, This will be placed in the
+  resulting ``.spec``, and is used for situations where fine-grained
+  control is required.
 
 make_prepend
   Additional actions that should take place directly after the

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -90,6 +90,7 @@ class Config(object):
         self.disable_static = "--disable-static"
         self.prep_prepend = []
         self.build_prepend = []
+        self.build_prepend_once = []
         self.build_append = []
         self.make_prepend = []
         self.install_prepend = []
@@ -997,6 +998,7 @@ class Config(object):
             os.rename(os.path.join(self.download_path, "prep_append"), os.path.join(self.download_path, "build_prepend"))
         self.make_prepend = self.read_script_file(os.path.join(self.download_path, "make_prepend"))
         self.build_prepend = self.read_script_file(os.path.join(self.download_path, "build_prepend"))
+        self.build_prepend_once = self.read_script_file(os.path.join(self.download_path, "build_prepend_once"))
         self.build_append = self.read_script_file(os.path.join(self.download_path, "build_append"))
         self.install_prepend = self.read_script_file(os.path.join(self.download_path, "install_prepend"))
         if os.path.isfile(os.path.join(self.download_path, "make_install_append")):

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -357,6 +357,7 @@ class Specfile(object):
     def write_lang_c(self, export_epoch=False):
         """Write C language pattern."""
         self._write_strip("%build")
+        self.write_build_prepend_once()
         self.write_build_prepend()
         self.write_proxy_exports()
         self._write_strip("export LANG=C.UTF-8")
@@ -892,12 +893,20 @@ class Specfile(object):
             self._write_strip("## prep_prepend end")
 
     def write_build_prepend(self):
-        """Write out any custom supplied commands at the start of the %build section."""
+        """Write out any custom supplied commands at the start of the %build section and every build type."""
         if self.config.build_prepend:
             self._write_strip("## build_prepend content")
             for line in self.config.build_prepend:
                 self._write_strip("{}\n".format(line))
             self._write_strip("## build_prepend end")
+
+    def write_build_prepend_once(self):
+        """Write out any custom supplied commands once at the start of the %build section."""
+        if self.config.build_prepend_once:
+            self._write_strip("## build_prepend_once content")
+            for line in self.config.build_prepend_once:
+                self._write_strip("{}\n".format(line))
+            self._write_strip("## build_prepend_once end")
 
     def write_build_append(self):
         """Write out any custom supplied commands at the end of the %build section."""


### PR DESCRIPTION
Include the ability to have a build_append_once configuration that is
only run once at the top of the build section (before the
build_append, which has gotten a documentation update).

This is motivated by some packages wanting their base build to be
slightly different than the alternate builds.

It is possible instead of this change to instead move to having these
special builds be handled entirely with configuration files or using
another package.

Modified-by: William Douglas <william.douglas@intel.com>