### PR TITLE
Run pypi dependency version override fix over the buildroot too

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1387,6 +1387,8 @@ class Specfile(object):
         self._write_strip("python3 -tt setup.py build  install --root=%{buildroot}")
         if self.config.subdir:
             self._write_strip("popd")
+        for module in self.config.pypi_overrides:
+            self._write_strip(f"pypi-dep-fix.py %{{buildroot}} {module}")
         self._write_strip("echo ----[ mark ]----")
         self._write_strip("cat %{buildroot}/usr/lib/python3*/site-packages/*/requires.txt || :")
         self._write_strip("echo ----[ mark ]----")


### PR DESCRIPTION
In cases where the requires.txt is generated, the dependency version
override will need to be run over the buildroot and not just the
source root.

Signed-off-by: William Douglas <william.douglas@intel.com>