### PR TITLE
Add make_command override file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,11 @@ cmake_args_openmpi
   This file contains arguments that should be passed to the ``%cmake`` macro for
   CMake based tarballs for openmpi builds.
 
+make_command
+  The contents of this file will be used instead of the ``make``
+  command, i.e. use this if ``make`` should be replace with another build tool
+  like ``ninja``.
+
 make_args
   The contents of this file are appended to the ``make`` invocation. This may be
   useful for passing arguments to ``make``, i.e. ``make TOOLDIR=/usr``

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -78,6 +78,7 @@ class Config(object):
         self.config_files = set()
         self.parallel_build = " %{?_smp_mflags} "
         self.urlban = ""
+        self.make_command = ""
         self.extra_make = ""
         self.extra32_make = ""
         self.extra_make_install = ""
@@ -917,6 +918,10 @@ class Config(object):
             self.disable_static = ""
         if self.config_opts['broken_parallel_build']:
             self.parallel_build = ""
+
+        content = self.read_conf_file(os.path.join(self.download_path, "make_command"))
+        if content and content[0]:
+            self.make_command = content[0]
 
         content = self.read_conf_file(os.path.join(self.download_path, "make_args"))
         if content:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -380,10 +380,14 @@ class Specfile(object):
             for line in self.config.make_prepend:
                 self._write_strip("{}\n".format(line))
             self._write_strip("## make_prepend end")
-        if build32:
-            self._write_strip("make {} {} {}".format(self.config.parallel_build, self.config.extra_make, self.config.extra32_make))
+        if self.config.make_command:
+            make = self.config.make_command
         else:
-            self._write_strip("make {} {}".format(self.config.parallel_build, self.config.extra_make))
+            make = "make"
+        if build32:
+            self._write_strip("{} {} {} {}".format(make, self.config.parallel_build, self.config.extra_make, self.config.extra32_make))
+        else:
+            self._write_strip("{} {} {}".format(make, self.config.parallel_build, self.config.extra_make))
 
     def write_install_openmpi(self):
         """Write make install line (openmpi) to spec file."""
@@ -697,7 +701,8 @@ class Specfile(object):
             self._write_strip("popd")
         self._write_strip("\n")
         self._write_strip("\n".join(self.config.profile_payload))
-        self._write_strip("\nmake clean\n")
+        if not self.config.make_command:
+            self._write_strip("\nmake clean\n")
         if post:
             self._write_strip(post)
 


### PR DESCRIPTION
Enable using an alternate command instead of make. This is useful as
some projects are enabling the use of ninja with cmake for instance.

Signed-off-by: William Douglas <william.douglas@intel.com>