### PR TITLE
Revamp autospec python dependency management

### DIFF
--- a/autospec/pypidata.py
+++ b/autospec/pypidata.py
@@ -26,21 +26,23 @@ def pkg_search(name):
         return False
 
 
-def get_pypi_name(name):
+def get_pypi_name(name, miss=False):
     """Try and verify the pypi name for a given package name."""
     # normalize the name for matching as pypi is case insensitve for search
-    name = name.lower()
+    name = name.lower().replace('-', '_')
     # Common case is the name and the pypi name match
     if pkg_search(name):
         return name
-    # Maybe we have a python- prefix
-    prefix = "python-"
+    # Maybe we have a python_ prefix
+    prefix = "python_"
     if name.startswith(prefix):
         name = name[len(prefix):]
         if pkg_search(name):
             return name
     # Some cases where search fails (Sphinx)
     # Just try the name we were given
+    if miss:
+        return ""
     return name
 
 

--- a/autospec/translate.dic
+++ b/autospec/translate.dic
@@ -37,7 +37,6 @@ keystonemiddleware-python=keystonemiddleware
 lazy_object_proxy=lazy-object-proxy
 manilaclient-python=python-manilaclient
 mistralclient.api.v2-python=python-mistralclient
-mock=python-mock
 netaddr-python=netaddr
 Opcodes=opcodes
 openstackclient.tests-python=python-openstackclient


### PR DESCRIPTION
This migrates python dependencies (both build and runtime) to use
'pypi()' where possible (when detecting dependencies from setup.py,
setup.cfg, pyproject.toml, requires.txt and requirements.txt).

It also adds a few little cleanups to python detection in order to
make the above work more evenly and removes some python2 cruft.

Signed-off-by: William Douglas <william.douglas@intel.com>