### PR TITLE
Handle the new pypi- prefix

### DIFF
--- a/autospec/pypidata.py
+++ b/autospec/pypidata.py
@@ -33,12 +33,12 @@ def get_pypi_name(name, miss=False):
     # Common case is the name and the pypi name match
     if pkg_search(name):
         return name
-    # Maybe we have a python_ prefix
-    prefix = "python_"
-    if name.startswith(prefix):
-        name = name[len(prefix):]
-        if pkg_search(name):
-            return name
+    # Maybe we have a prefix
+    for prefix in ["pypi_", "python_"]:
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            if pkg_search(name):
+                return name
     # Some cases where search fails (Sphinx)
     # Just try the name we were given
     if miss:


### PR DESCRIPTION
The pypi automation has learned to add a pypi- prefix to packages from
that ecosystem so make autospec look for that as well. Note the pypi_
being looked for is just our lowercase of pypi-.

Signed-off-by: William Douglas <william.douglas@intel.com>