### PR TITLE
Avoid rebuilding the package after only file adds

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -285,7 +285,7 @@ def package(args, url, name, archives, workingdir):
             # directories added to the blacklist, need to re-run
             package.must_restart += 1
 
-        if package.round > 20 or package.must_restart == 0:
+        if package.round > 20 or (package.must_restart == 0 and package.file_restart == 0):
             break
 
         save_mock_logs(conf.download_path, package.round)

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -88,6 +88,7 @@ class Build(object):
         self.success = 0
         self.round = 0
         self.must_restart = 0
+        self.file_restart = 0
         self.uniqueext = ''
         self.warned_about = set()
 
@@ -175,6 +176,7 @@ class Build(object):
         """Handle build log contents."""
         requirements.verbose = 1
         self.must_restart = 0
+        self.file_restart = 0
         infiles = 0
 
         # Flush the build-log to disk, before reading it
@@ -255,11 +257,12 @@ class Build(object):
             "--buildsrpm",
             "--sources=./",
             f"--spec={content.name}.spec",
-            f"--uniqueext={self.uniqueext}",
+            f"--uniqueext={self.uniqueext}-src",
             "--result=results/",
             cleanup_flag,
             mockopts,
         ]
+
         util.call(" ".join(cmd_args),
                   logfile=f"{config.download_path}/results/mock_srpm.log",
                   cwd=config.download_path)
@@ -280,6 +283,11 @@ class Build(object):
             cleanup_flag,
             mockopts,
         ]
+
+        if not cleanup and self.must_restart == 0 and self.file_restart > 0:
+            cmd_args.append("--no-clean")
+            cmd_args.append("--short-circuit=binary")
+
         ret = util.call(" ".join(cmd_args),
                         logfile=f"{config.download_path}/results/mock_build.log",
                         check=False,

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -79,7 +79,7 @@ class FileManager(object):
             g = self.attrs[filename][2]
             filename = "%attr({0},{1},{2}) {3}".format(mod, u, g, filename)
         self.packages[package].add(filename)
-        self.package.must_restart += 1
+        self.package.file_restart += 1
         if not self.newfiles_printed:
             print("  New %files content found")
             self.newfiles_printed = True
@@ -141,6 +141,7 @@ class FileManager(object):
             if lang not in self.locales:
                 self.locales.append(lang)
                 print("  New locale:", lang)
+                self.package.must_restart += 1
                 if "locales" not in self.packages:
                     self.packages["locales"] = set()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -453,7 +453,8 @@ class TestBuildpattern(unittest.TestCase):
                               '/usr/testdir/file1',
                               '/usr/testdir/file2']))
         # one for each file added
-        self.assertEqual(pkg.must_restart, 3)
+        self.assertEqual(pkg.must_restart, 0)
+        self.assertEqual(pkg.file_restart, 3)
 
     def test_parse_build_results_banned_files(self):
         """


### PR DESCRIPTION
Try to avoid doing a full rebuild when the build.log only has new
files in it.

This has a two downsides. The source buildroot needs to be distinct
from the binary buildroot. The built rpms are no longer installable as
rpmbuild flags them.

The upside is packages that take forever to build or don't have
build times improved by ccache will not need a duplicate round for
just adding the files.

The rpms can still be generated in an installable fashion with 'make
build' and the autospec generated rpms can be installed by force
installing if need be.

Signed-off-by: William Douglas <william.douglas@intel.com>