### PR TITLE
Fix test processing

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -290,8 +290,6 @@ def package(args, url, name, archives, workingdir):
 
         save_mock_logs(conf.download_path, package.round)
 
-    check.check_regression(conf.download_path, conf.config_opts['skip_tests'])
-
     if package.success == 0:
         conf.create_buildreq_cache(content.version, requirements.buildreqs_cache)
         print_fatal("Build failed, aborting")
@@ -306,6 +304,8 @@ def package(args, url, name, archives, workingdir):
             print("*********************\n")
         except Exception:
             pass
+
+    check.check_regression(conf.download_path, conf.config_opts['skip_tests'], package.round - 1)
 
     examine_abi(conf.download_path, content.name)
     if os.path.exists("/var/lib/rpm"):

--- a/autospec/check.py
+++ b/autospec/check.py
@@ -28,12 +28,17 @@ import util
 tests_config = ""
 
 
-def check_regression(pkg_dir, skip_tests):
+def check_regression(pkg_dir, skip_tests, test_round):
     """Check the build log for test regressions using the count module."""
     if skip_tests:
         return
 
-    result = count.parse_log(os.path.join(pkg_dir, "results/build.log"))
+    log_path = os.path.join(pkg_dir, 'results', 'build.log')
+    result = count.parse_log(log_path)
+    if len(result) == 0:
+        log_path = os.path.join(pkg_dir, 'results', f"round{test_round}-build.log")
+        result = count.parse_log(log_path)
+
     titles = [('Package', 'package name', 1),
               ('Total', 'total tests', 1),
               ('Pass', 'total passing', 1),

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -42,7 +42,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open()
         open_name = 'util.open'
         with patch(open_name, m_open, create=True):
-            check.check_regression('pkgdir', False)
+            check.check_regression('pkgdir', False, -1)
 
         check.count.parse_log = parse_log_backup
 
@@ -65,7 +65,7 @@ class TestTest(unittest.TestCase):
         m_open = mock_open()
         open_name = 'util.open'
         with patch(open_name, m_open, create=True):
-            check.check_regression('pkgdir', False)
+            check.check_regression('pkgdir', False, -1)
 
         check.count.parse_log = parse_log_backup
 


### PR DESCRIPTION
If a file addition only failure happens and a quick rebuilt is done,
the build log will be missing test results. Check the previous build
log in that case.

Signed-off-by: William Douglas <william.douglas@intel.com>