### PR TITLE
Have setuid content honor attrs

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -202,7 +202,13 @@ class FileManager(object):
                 return
 
         if filename in self.setuid:
-            newfn = "%attr(4755, root, root) " + filename
+            if filename in self.attrs:
+                mod = self.attrs[filename][0]
+                u = self.attrs[filename][1]
+                g = self.attrs[filename][2]
+                newfn = "%attr({0},{1},{2}) {3}".format(mod, u, g, filename)
+            else:
+                newfn = "%attr(4755, root, root) " + filename
             self.push_package_file(newfn, "setuid")
             return
 


### PR DESCRIPTION
Previously setuid files would only set ownership to root,root (and no
other attrs). In cases where content should be setuid with different
ownership, the configuration was only set in the attrs file for a
path. Unfortunately filemaps only look at the setuid file to know
which paths to skip over for calling elf-move and so setuid files were
not being accounted for.

This change allows attrs for setuid files to be set, enabling checking
for content with setuid bits more readily in the process.

Signed-off-by: William Douglas <william.douglas@intel.com>