### PR TITLE
check: Add handling for empty testcount key

### DIFF
--- a/autospec/check.py
+++ b/autospec/check.py
@@ -35,7 +35,7 @@ def check_regression(pkg_dir, skip_tests, test_round):
 
     log_path = os.path.join(pkg_dir, 'results', 'build.log')
     result = count.parse_log(log_path)
-    if len(result) == 0:
+    if len(result) == 0 or result[0:2] == ',0':
         log_path = os.path.join(pkg_dir, 'results', f"round{test_round}-build.log")
         result = count.parse_log(log_path)
 


### PR DESCRIPTION
In some packages (kubernetes) builds that skip the final round may
have content in the build.log interpreted as test results. For these
cases try and use the empty test count key as a signal that the
previous build should be used for test results instead.

In some cases this will cause packages that had no tests for an empty
key to use the previous build round for reporting test results but
hopefully that won't cause test reporting failures.

Signed-off-by: William Douglas <william.douglas@intel.com>