### PR TITLE
Fix build loop

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -299,9 +299,10 @@ class Build(object):
             util.print_fatal("Mock command failed, results log does not exist. User may not have correct permissions.")
             exit(1)
 
-        is_clean = self.parse_buildroot_log(config.download_path + "/results/root.log", ret)
-        if is_clean:
-            self.parse_build_results(config.download_path + "/results/build.log", ret, filemanager, config, requirements, content)
+        if not self.parse_buildroot_log(config.download_path + "/results/root.log", ret):
+            exit(1)
+
+        self.parse_build_results(config.download_path + "/results/build.log", ret, filemanager, config, requirements, content)
         if filemanager.has_banned:
             util.print_fatal("Content in banned paths found, aborting build")
             exit(1)

--- a/autospec/build.py
+++ b/autospec/build.py
@@ -160,6 +160,7 @@ class Build(object):
         if returncode == 0:
             return True
         self.must_restart = 0
+        self.file_restart = 0
         is_clean = True
         util.call("sync")
         with util.open_auto(filename, "r") as rootlog:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -268,6 +268,8 @@ class TestBuildpattern(unittest.TestCase):
         content = "line1\nDEBUG util.py:399:  No matching package to install: 'foobar'\nDEBUG util.py:399:  No matching package to install: 'foobarbaz'\nline 4"
         m_open = mock_open(read_data=content)
         pkg = build.Build()
+        pkg.must_restart = 1
+        pkg.file_restart = 1
 
         result = True
         with patch(open_name, m_open, create=True):
@@ -277,6 +279,7 @@ class TestBuildpattern(unittest.TestCase):
 
         self.assertFalse(result)
         self.assertEqual(pkg.must_restart, 0)
+        self.assertEqual(pkg.file_restart, 0)
 
     def test_parse_buildroot_log_pass(self):
         """


### PR DESCRIPTION
This is a bit of a double fix for the same issue. Maybe the *_restarts should be reset somewhere else (`build.py`'s `package` perhaps). Either way, the exit on missing package seems like what should be done regardless of any other state.