### PR TITLE
buildreq: Fix typo

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -587,7 +587,7 @@ class Requirements(object):
             if 'pytest' in line:
                 continue
             if clean_line:
-                if self.add_buildreq(f"pypi({clean_line})", packages):
+                if self.add_buildreq(f"pypi({clean_line})"):
                     self.add_requires(f"pypi({clean_line})", packages, override=True, subpkg="python3")
 
     def add_pyproject_requires(self, filename):


### PR DESCRIPTION
add_buildreq doesn't take a packages argument and this was causing
junk to be added to the buildreq_cache.

Signed-off-by: William Douglas <william.douglas@intel.com>