### PR TITLE
Don't use beignet for opencl

### DIFF
--- a/autospec/cmake_modules
+++ b/autospec/cmake_modules
@@ -298,7 +298,6 @@ OktetaKastenGui, okteta-dev
 Okular5, okular-dev
 OpenAL, openal-soft-dev
 OpenBLAS, openblas-dev
-OpenCL, beignet-dev
 OpenCV, opencv-dev
 OpenColorIO, OpenColorIO-data
 OpenEXR, extra-cmake-modules pkgconfig(OpenEXR)


### PR DESCRIPTION
beignet is not used for the latest opencl hardware so stop auto adding
it as a dependency.

Signed-off-by: William Douglas <william.douglas@intel.com>