### PR TITLE
Ignore python requirements with max python version

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -36,6 +36,18 @@ def is_qmake_pro(f):
     return f.endswith(".pro") and not f.startswith(".")
 
 
+def old_python_module(req):
+    """Check if the req is only for old python versions."""
+    # Format for the line is expected to be:
+    #  'module_name >= x.y.z; python_version<"x.y"'
+    for block in req.split(';'):
+        if 'python_version' in block:
+            loc = block.find('python_version')
+            if '<' in block[loc:]:
+                return True
+    return False
+
+
 def clean_python_req(req):
     """Strip version information from req."""
     if not req:
@@ -45,7 +57,10 @@ def clean_python_req(req):
     ret = req.rstrip("\n\r").strip()
     i = ret.find(";")
     if i >= 0:
-        ret = ret[:i]
+        if old_python_module(ret):
+            return ""
+        else:
+            ret = ret[:i]
     i = ret.find("<")
     if i >= 0:
         ret = ret[:i]

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -278,6 +278,8 @@ class TestBuildreq(unittest.TestCase):
                          'requirement')
         self.assertEqual(buildreq.clean_python_req('requirement ; python_version > 1.1.2'),
                          'requirement')
+        self.assertEqual(buildreq.clean_python_req('requirement ; python_version < 1.1.2'),
+                         '')
         self.assertEqual(buildreq.clean_python_req('requirement <= 1.1.2'),
                          'requirement')
         self.assertEqual(buildreq.clean_python_req('requirement = 1.1.2'),


### PR DESCRIPTION
If a python requirement has a python_version bounded by a maximum
(python_version < 3.8) than ignore it. The reasoning for this change
is to avoid dependencies that no longer apply with the most recent
python version.

Signed-off-by: William Douglas <william.douglas@intel.com>