### PR TITLE
Update failed command mapping for `nc`

### DIFF
--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -1094,7 +1094,7 @@ mutter-clutter-4, mutter-dev
 mysql_config, mariadb-dev
 nasm, nasm-bin
 nasmw, nasm
-nc, netcat
+nc, nmap-extras
 ncurses.h, ncurses-dev
 ncurses.h, pkgconfig(ncursesw)
 ncurses/curses.h, ncurses-dev


### PR DESCRIPTION
In Clear Linux OS, `nmap-extras` (subpackage of `nmap`) has provided an
`nc` symlink to `ncat` since Sep 2018, so this mapping should be
updated...