### PR TITLE
Create a new object for multi_version

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -243,8 +243,9 @@ class Content(object):
         elif not self.multi_version:
             # Fall back to ensure a version is always set
             # (otherwise the last known version will be used)
-            self.multi_version["1"] = ""
+            self.multi_version = {"1": ""}
         latest = sorted(self.multi_version.keys())[-1]
+
         return latest
 
     def name_and_version(self, filemanager):

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import unittest
+from collections import OrderedDict
 from unittest.mock import MagicMock, Mock, patch
 import build
 import config
@@ -210,6 +211,22 @@ class TestTarball(unittest.TestCase):
         self.content.name = 'test'
         self.content.set_gcov()
         self.assertEqual(self.content.gcov_file, 'test.gcov')
+
+    def test_set_multi_version_no_ver(self):
+        versions = OrderedDict()
+        self.content.config.parse_config_versions = lambda: versions
+        self.content.config.default_pattern = ""
+        latest = self.content.set_multi_version("")
+        self.assertEqual(latest, "1")
+        self.assertNotEqual(id(self.content.multi_version), id(versions))
+
+    def test_set_multi_version_with_ver(self):
+        versions = OrderedDict()
+        self.content.config.parse_config_versions = lambda: versions
+        self.content.config.default_pattern = ""
+        latest = self.content.set_multi_version("3")
+        self.assertEqual(latest, "3")
+        self.assertNotEqual(id(self.content.multi_version), id(versions))
 
     def test_process_go_archives(self):
         """Test for tarball.process_go_archives method."""


### PR DESCRIPTION
When not handling a multiple version package, there was a case where if
the version wasn't set the multi_version map would be the
config.versions map and that's not intended to outside of multiple
version use case.

So to fix this, make a new map when setting a default version for the
multi_version map and keep config.versions as its own map.

Fixes #727 

Signed-off-by: William Douglas <william.douglas@intel.com>