### PR TITLE
Don't exit on missing dependencies

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -300,7 +300,7 @@ class Build(object):
             exit(1)
 
         if not self.parse_buildroot_log(config.download_path + "/results/root.log", ret):
-            exit(1)
+            return
 
         self.parse_build_results(config.download_path + "/results/build.log", ret, filemanager, config, requirements, content)
         if filemanager.has_banned:


### PR DESCRIPTION
Previous change made missing build dependendies fatal, and while
correct, causing the buildreq_cache file to not be updated when
missing dependencies cause the build to exit.

Move back to previous obvserved behavior but change the logic to
return if the buildroot log is not successful.

Fixes #729 

Signed-off-by: William Douglas <william.douglas@intel.com>