### PR TITLE
config: fix value for default dnf conf

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -759,7 +759,7 @@ class Config(object):
             print("Warning: Set [autospec][license_show] uri for license link check support")
         if not self.yum_conf:
             print("Warning: Set [autospec][yum_conf] path to yum.conf file for whatrequires validation")
-            self.yum_conf = os.path.join(os.path.dirname(self.config_file), "image-creator/yum.conf")
+            self.yum_conf = os.path.join(os.path.dirname(self.config_file), "dnf.conf")
 
         if packages_file:
             self.os_packages = set(self.read_conf_file(packages_file, track=False))


### PR DESCRIPTION
If unset, the `yum_conf` autospec config variable (representing a dnf.conf in modern times) should reference the dnf.conf from `conf/dnf.conf` in the `common` repo.