### PR TITLE
Enable short-circuit with excludes

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -293,7 +293,7 @@ class Build(object):
             mockopts,
         ]
 
-        if not cleanup and self.must_restart == 0 and self.file_restart > 0 and len(filemanager.excludes) == 0:
+        if not cleanup and self.must_restart == 0 and self.file_restart > 0 and set(filemanager.excludes) == set(filemanager.manual_excludes):
             cmd_args.append("--no-clean")
             cmd_args.append("--short-circuit=binary")
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -874,6 +874,7 @@ class Config(object):
         content = self.read_conf_file(os.path.join(self.download_path, "excludes"))
         for exclude in content:
             print("%%exclude for: %s." % exclude)
+        filemanager.manual_excludes += content
         filemanager.excludes += content
 
         content = self.read_conf_file(os.path.join(self.download_path, "setuid"))

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -37,6 +37,7 @@ class FileManager(object):
         self.files = set()  # global file set to weed out dupes
         self.files_blacklist = set()
         self.excludes = []
+        self.manual_excludes = []
         self.file_maps = {}  # Filename-to-package mapping
         self.setuid = []
         self.attrs = {}
@@ -110,7 +111,7 @@ class FileManager(object):
         """Search for pattern in filename.
 
         Attempt to find pattern in filename, if pattern matches push package file.
-        If that file is also in the excludes list, prepend "%exclude " before pushing the filename.
+        If that file is also in the excludes list, don't push the file.
         Returns True if a file was pushed, False otherwise.
         """
         if not replacement:


### PR DESCRIPTION
When packages have excludes previously we would full build because
there was no method to determine if the excludes list had items
dynamically added to it.

This change adds a new list that is the original exlcudes list
manually configured and is used to compare against the excludes list
that is generated during processing the files list. If the two
lists (compared as sets) are the identical, then short-circuiting is
still possible.

Also fixup some out of date documentation.

Signed-off-by: William Douglas <william.douglas@intel.com>