### PR TITLE
Support minimal escaping in pattern conf files

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -53,6 +53,8 @@ def read_pattern_conf(filename, dest, list_format=False, path=None):
             for line in patfile:
                 if line.startswith("#"):
                     continue
+                if line.startswith(r"\#"):
+                    line = line[1:]
                 # Make list format a dict for faster lookup times
                 if list_format:
                     dest[line.strip()] = True

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -2,6 +2,7 @@
 # in the form: <pattern>, <package>
 # This file is sorted with LC_COLLATE=C
 # Lines beginning with '#' are ignored.
+# For patterns that start with '#', escape the '#' as '\#'.
 'nose', pypi(nose)
 'numpy', pypi(numpy)
 'pexpect', pypi(pexpect)

--- a/autospec/ignored_commands
+++ b/autospec/ignored_commands
@@ -2,6 +2,7 @@
 # in the form: <configure line>
 # This file is sorted with LC_COLLATE=C
 # Lines beginning with '#' are ignored.
+# For patterns that start with '#', escape the '#' as '\#'.
 -Wmissing-braces
 -Wparentheses-equality
 -Wtypedef-redefinition

--- a/autospec/license_blacklist
+++ b/autospec/license_blacklist
@@ -2,6 +2,7 @@
 # in the form: <blacklisted string>
 # This file is sorted with LC_COLLATE=C
 # Lines beginning with '#' are ignored.
+# For strings that start with '#', escape the '#' as '\#'.
 %
 %license
 (LGPL)

--- a/autospec/license_translations
+++ b/autospec/license_translations
@@ -2,6 +2,7 @@
 # with in the form: <license string>: <license>
 # This file is sorted with LC_COLLATE=C
 # Lines beginning with '#' are ignored.
+# For strings that start with '#', escape the '#' as '\#'.
 2-clause, BSD-2-Clause
 AGPL-3, AGPL-3.0
 APL-2.0, Apache-2.0


### PR DESCRIPTION
Add support to escape a leading `#` character in pattern conf file
patterns by interpreting `\#` as a pattern starting with `#`.

Also add documentation for this feature to the existing pattern conf
files where this support might be needed.