### PR TITLE
Glob the perl module path

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -340,7 +340,7 @@ class FileManager(object):
             (r"^/usr/lib/sysusers.d", "config"),
             (r"^/usr/lib/sysctl.d", "config"),
             (r"^/usr/share/", "data"),
-            (r"^/usr/lib/perl5/", "perl"),
+            (r"^/usr/lib/perl5/", "perl", "/usr/lib/perl5/*"),
             # finally move any dynamically loadable plugins (not
             # perl/python/ruby/etc.. extensions) into lib package
             (r"^/usr/lib/.*/[a-zA-Z0-9._+-]*\.so", "lib"),


### PR DESCRIPTION
Rather than listing all the files in the perl module path (which
includes a minor version that causes updates to be a reautospec rather
than a bump) move to a glob to simplify the update workflow.

Signed-off-by: William Douglas <william.douglas@intel.com>