### PR TITLE
Update elf-move.py targetpath

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -822,9 +822,9 @@ class Specfile(object):
         for setuid in self.setuid:
             skips = f"{skips} --skip-path {setuid}"
         if self.config.config_opts['use_avx2'] or self.config.default_pattern == "distutils3" or self.config.default_pattern == "pyproject":
-            self._write_strip('/usr/bin/elf-move.py avx2 %{buildroot}-v3 %{buildroot}/usr/share/clear/optimized-elf/ %{buildroot}/usr/share/clear/filemap/filemap-%{name}' + skips)
+            self._write_strip('/usr/bin/elf-move.py avx2 %{buildroot}-v3 %{buildroot} %{buildroot}/usr/share/clear/filemap/filemap-%{name}' + skips)
         if self.config.config_opts['use_avx512']:
-            self._write_strip('/usr/bin/elf-move.py avx512 %{buildroot}-v4 %{buildroot}/usr/share/clear/optimized-elf/ %{buildroot}/usr/share/clear/filemap/filemap-%{name}' + skips)
+            self._write_strip('/usr/bin/elf-move.py avx512 %{buildroot}-v4 %{buildroot} %{buildroot}/usr/share/clear/filemap/filemap-%{name}' + skips)
 
     def write_exclude_deletes(self):
         """Write out deletes for excluded files."""


### PR DESCRIPTION
The targetpath for elf-move.py now needs to be the %{buildroot} base
as the full path to the optimized-elf directory is now hardcoded into
the elf-move.py tooling.

This change was made for the library files being autoinstalled to the
glibc-hwcaps directory without making use of clr-elf-replace (making
swupd a little happier about missing files). Full details of the
change are in the clr-avx-tools repo
commit (415a400edd05e6fa405b0682f7c5c9895d039e09).

Signed-off-by: William Douglas <william.douglas@intel.com>