### PR TITLE
Enable provides configuration overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,14 @@ ${custom}_requires_add
   Same as "requires_add" above, but instead of the Requires being placed on the
   ``main`` subpackage, they will be placed on the ``-${custom}`` subpackage.
 
+provides_add
+  Each line in the file provides the name of a identifier to add as a Provides
+  to the ``.spec``.
+
+${custom}_provides_add
+  Same as "provides_add" above, but instead of the Provides being placed on the
+  ``main`` subpackage, they will be placed on the ``-${custom}`` subpackage.
+
 buildreq_ban
   Each line in the file is a build dependency that under no circumstance should
   be automatically added to the build dependencies. This is useful to block
@@ -174,6 +182,16 @@ requires_ban
 
 ${custom}_requires_ban
   Same as "requires_ban" above, but instead of the Requires being removed from
+  the ``main`` subpackage, they will be removed from the ``-${custom}``
+  subpackage.
+
+provides_ban
+  Each line in the file is an identifier that under no circumstance should be
+  automatically added as a Provides. This is useful to block automatic
+  configuration routines adding undesired identifiers.
+
+${custom}_provides_ban
+  Same as "provides_ban" above, but instead of the Provides being removed from
   the ``main`` subpackage, they will be removed from the ``-${custom}``
   subpackage.
 

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -319,6 +319,7 @@ class Requirements(object):
         self.buildreqs = set()
         self.buildreqs_cache = set()
         self.requires = {None: set(), "pypi": set()}
+        self.banned_provides = {None: set()}
         self.provides = {None: set(), "pypi": set()}
         self.extra_cmake = set()
         self.extra_cmake_openmpi = set()
@@ -398,6 +399,32 @@ class Requirements(object):
         if new:
             # print("Adding requirement:", req)
             requires.add(req)
+        return new
+
+    def ban_provides(self, ban, subpkg=None):
+        """Add ban to the banned set (and remove it from provides if it was added)."""
+        ban = ban.strip()
+        if (provides := self.provides.get(subpkg)) is None:
+            provides = self.provides[subpkg] = set()
+        if (banned_provides := self.banned_provides.get(subpkg)) is None:
+            banned_provides = self.banned_provides[subpkg] = set()
+        provides.discard(ban)
+        banned_provides.add(ban)
+
+    def add_provides(self, prov, subpkg=None):
+        """Add prov to the provides set if it is not banned."""
+        new = True
+        prov = prov.strip()
+        if (provides := self.provides.get(subpkg)) is None:
+            provides = self.provides[subpkg] = set()
+        if prov in provides:
+            new = False
+        if (banned_provides := self.banned_provides.get(subpkg)) is None:
+            banned_provides = self.banned_provides[subpkg] = set()
+        if prov in banned_provides:
+            return False
+        if new:
+            provides.add(prov)
         return new
 
     def add_pkgconfig_buildreq(self, preq, conf32, cache=False):

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -576,6 +576,15 @@ class Config(object):
             else:
                 requirements.ban_requires(pkg, subpkg=subpkg)
 
+    def process_provides_file(self, fname, requirements, prov_type, subpkg=None):
+        """Process manual subpackage provides file."""
+        content = self.read_conf_file(os.path.join(self.download_path, fname))
+        for pkg in content:
+            if prov_type == 'add':
+                requirements.add_provides(pkg, subpkg=subpkg)
+            else:
+                requirements.ban_provides(pkg, subpkg=subpkg)
+
     def read_script_file(self, path, track=True):
         """Read RPM script snippet file at path.
 
@@ -864,6 +873,16 @@ class Config(object):
                 self.process_requires_file(fname, requirements, 'add')
             elif fname == 'requires_ban':
                 self.process_requires_file(fname, requirements, 'ban')
+            elif fname == 'provides_add':
+                self.process_provides_file(fname, requirements, 'add')
+            elif fname == 'provides_ban':
+                self.process_provides_file(fname, requirements, 'ban')
+            elif re.search(r'.+_provides_add$', fname):
+                subpkg = fname[:-len("_requires_add")]
+                self.process_provides_file(fname, requirements, 'add', subpkg)
+            elif re.search(r'.+_provides_ban$', fname):
+                subpkg = fname[:-len("_provides_ban")]
+                self.process_provides_file(fname, requirements, 'ban', subpkg)
             elif re.search(r'.+_extras$', fname):
                 # Prefix all but blessed names with extras-
                 name = fname[:-len("_extras")]

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -295,6 +295,9 @@ class Specfile(object):
             for req in sorted(self.requirements.requires.get(pkg, [])):
                 self._write(f"Requires: {req}\n")
 
+            for prov in sorted(self.requirements.provides.get(pkg, [])):
+                self._write(f"Provides: {prov}\n")
+
             self._write("\n%description {}\n".format(pkg))
             self._write("{} components for the {} package.\n".format(pkg, self.name))
             self._write("\n")

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -80,6 +80,36 @@ class TestBuildreq(unittest.TestCase):
         self.assertFalse(self.reqs.add_requires('testreq', []))
         self.assertNotIn('testreq', self.reqs.requires[None])
 
+    def test_ban_provides(self):
+        """
+        Test ban_provides with prov already present in provides
+        """
+        self.reqs.provides[None] = set(['testreq'])
+        self.reqs.ban_provides('testreq')
+        self.assertNotIn('testreq', self.reqs.provides[None])
+
+    def test_ban_provides_subpkg(self):
+        """
+        Test ban_provides on a subpkg with prov already present in provides
+        """
+        self.reqs.provides['subpkg'] = set(['testreq'])
+        self.reqs.ban_provides('testreq', subpkg='subpkg')
+        self.assertNotIn('testreq', self.reqs.provides['subpkg'])
+
+    def test_add_provides(self):
+        """
+        Test add_provides with unbanned new prov
+        """
+        self.assertTrue(self.reqs.add_provides('testreq'))
+        self.assertIn('testreq', self.reqs.provides[None])
+
+    def test_add_provides_subpkg(self):
+        """
+        Test add_provides on a subpkg with unbanned new prov
+        """
+        self.assertTrue(self.reqs.add_provides('testreq', subpkg='subpkg'))
+        self.assertIn('testreq', self.reqs.provides['subpkg'])
+
     def test_add_pkgconfig_buildreq(self):
         """
         Test add_pkgconfig_buildreq with config_opts['32bit'] set to False


### PR DESCRIPTION
Add support for (*_)provides_{add,ban} configuration files.

This is occasionally useful for cases where a pypi() provide isn't
picked up as the packages isn't a python package but does provide a
python library. It also can be handy when doing some renames to
prevent mass rebuilds.

Signed-off-by: William Douglas <william.douglas@intel.com>