### PR TITLE
Add a config option for skipping file replacement

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -184,7 +184,8 @@ class Config(object):
             "compat": "this package is a library compatibility package and only ships versioned library files",
             "nodebug": "do not generate debuginfo for this package",
             "openmpi": "configure build also for openmpi",
-            "server": "Package is only used by servers"
+            "server": "Package is only used by servers",
+            "no_glob": "Do not use the replacement pattern for file matching"
         }
         # simple_pattern_pkgconfig patterns
         # contains patterns for parsing build.log for missing dependencies

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -114,7 +114,7 @@ class FileManager(object):
         If that file is also in the excludes list, don't push the file.
         Returns True if a file was pushed, False otherwise.
         """
-        if not replacement:
+        if not replacement or self.config.config_opts.get("no_glob"):
             replacement = prefix + filename
 
         # compat files should always be excluded

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -113,6 +113,15 @@ class TestFiles(unittest.TestCase):
         self.assertTrue(self.fm.file_pat_match('test-fn', r'test-fn', 'main', 'testfn'))
         self.fm.push_package_file.assert_called_with('testfn', 'main')
 
+    def test_file_pat_match_replacement_no_glob(self):
+        """
+        Test file_pat_match with replacement provided but no glob set
+        """
+        self.fm.push_package_file = MagicMock()
+        self.fm.config.config_opts['no_glob'] = True
+        self.assertTrue(self.fm.file_pat_match('test-fn', r'test-fn', 'main', 'testfn'))
+        self.fm.push_package_file.assert_called_with('test-fn', 'main')
+
     def test_file_pat_match_no_match(self):
         """
         Test file_pat_match with no match


### PR DESCRIPTION
Some packages have a files section replacement in place that uses globs instead of listing all files in the section. This doesn't work well with extras. Add an option to config to turn off the replacement so extras are able to function as normal.

Signed-off-by: William Douglas <william.douglas@intel.com>