### PR TITLE
Enable shell like glob matching for *extras files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,6 +395,9 @@ extras
   one to keep the main package slim and split out optional functionality or
   files.
 
+  Files paths can contain a single '*' per directory such that
+  a line of ``/foo*/bar*`` is allowed but ``/foo*bar*`` is not.
+
 dev_extras
   Same as "extras" above, but instead of the files being placed in an
   ``-extras`` subpackage, they will be placed in the ``-dev`` one. Use this

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -558,10 +558,30 @@ class Config(object):
         lines = self.read_file(path, track=track)
         return [line.strip() for line in lines if not line.strip().startswith("#") and line.split()]
 
+    def validate_extras_content(self, lines, fname):
+        """Verify extras file contents are valid match strings."""
+        newlines = []
+        for line in lines:
+            if '*' not in line:
+                newlines.append(line)
+                continue
+            nline = line.split('/')
+            invalid = False
+            for itm in nline:
+                if itm.count('*') > 1:
+                    invalid = True
+                    break
+            if invalid:
+                print_warning(f"Ignoring '{line}' from {fname} (can only use a single '*' between each '/')")
+            else:
+                newlines.append(nline)
+        return newlines
+
     def process_extras_file(self, fname, name, filemanager):
         """Process extras type subpackages configuration."""
         content = {}
-        content['files'] = self.read_conf_file(os.path.join(self.download_path, fname))
+        data = self.read_conf_file(os.path.join(self.download_path, fname))
+        content['files'] = self.validate_extras_content(data, fname)
         req_file = os.path.join(self.download_path, f'{fname}_requires')
         if os.path.isfile(req_file):
             content['requires'] = self.read_conf_file(req_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,33 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(conf.default_pattern, "make")
         self.assertEqual(conf.pattern_strength, 2)
 
+    def test_validate_extras_content_bad_glob(self):
+        """
+        Test validate_extras_content with more than one glob in a directory
+        """
+        conf = config.Config("")
+        lines = ['/bad*path*/file']
+        new_lines = conf.validate_extras_content(lines, 'bad_glob')
+        self.assertEqual(len(new_lines), 0)
+
+    def test_validate_extras_content_good_single_glob(self):
+        """
+        Test validate_extras_content with a single glob in a directory
+        """
+        conf = config.Config("")
+        lines = ['/good*/file']
+        new_lines = conf.validate_extras_content(lines, 'good_single_glob')
+        self.assertEqual(new_lines, [lines[0].split('/')])
+
+    def test_validate_extras_content_good_multi_glob(self):
+        """
+        Test validate_extras_content with a multiple valid globs
+        """
+        conf = config.Config("")
+        lines = ['/path1', '/good*/glob*/file', '/path3']
+        new_lines = conf.validate_extras_content(lines, 'good_multi_glob')
+        self.assertEqual(new_lines, ['/path1', lines[1].split('/'), '/path3'])
+
 # Create dynamic tests
 create_dynamic_tests()
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -176,6 +176,60 @@ class TestFiles(unittest.TestCase):
         calls = [call('foobar', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
+    def test_push_package_file_glob_empty(self):
+        """
+        Test push_file with glob extras empty match
+        """
+        self.fm.file_is_locale = MagicMock(return_value=False)
+        self.fm.push_package_file = MagicMock()
+        self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*rightglob']]}}
+        self.fm.push_file('leftglobrightglob', '')
+        calls = [call('leftglobrightglob', 'foobar-extras')]
+        self.fm.push_package_file.assert_has_calls(calls)
+
+    def test_push_package_file_glob_left_match(self):
+        """
+        Test push_file with glob extras left content matching
+        """
+        self.fm.file_is_locale = MagicMock(return_value=False)
+        self.fm.push_package_file = MagicMock()
+        self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*']]}}
+        self.fm.push_file('leftglobrightglob', '')
+        calls = [call('leftglobrightglob', 'foobar-extras')]
+        self.fm.push_package_file.assert_has_calls(calls)
+
+    def test_push_package_file_glob_right_match(self):
+        """
+        Test push_file with glob extras right content matching
+        """
+        self.fm.file_is_locale = MagicMock(return_value=False)
+        self.fm.push_package_file = MagicMock()
+        self.fm.file_maps = {'foobar-extras': {'files': [['*rightglob']]}}
+        self.fm.push_file('leftglobrightglob', '')
+        calls = [call('leftglobrightglob', 'foobar-extras')]
+        self.fm.push_package_file.assert_has_calls(calls)
+
+    def test_push_package_file_glob_leftright_match(self):
+        """
+        Test push_file with glob extras leftright content matching
+        """
+        self.fm.file_is_locale = MagicMock(return_value=False)
+        self.fm.push_package_file = MagicMock()
+        self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*rightglob']]}}
+        self.fm.push_file('leftglobstuffrightglob', '')
+        calls = [call('leftglobstuffrightglob', 'foobar-extras')]
+        self.fm.push_package_file.assert_has_calls(calls)
+
+    def test_push_package_file_glob_multi_match(self):
+        """
+        Test push_file with multiple globs extras content matching
+        """
+        self.fm.file_is_locale = MagicMock(return_value=False)
+        self.fm.push_package_file = MagicMock()
+        self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*', '*rightglob']]}}
+        self.fm.push_file('leftglobstuff/stuffrightglob', '')
+        calls = [call('leftglobstuff/stuffrightglob', 'foobar-extras')]
+        self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_file_setuid(self):
         """


### PR DESCRIPTION
This change allows *extras files to contain '*' matches. This somewhat emulates the shell glob match in that '/foo*bar' will match '/foobar' and '/foobazbar' but not '/foo/bar'. The globs are only allowed one per directory such that '/foo*/bar*' is allowed but '/foo*bar*' is not.

Signed-off-by: William Douglas <william.douglas@intel.com>