### PR TITLE
allow us to ship with debuginfo on the default filesystem

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -1,5 +1,4 @@
 #!/bin/true
-#
 # config.py - part of autospec
 # Copyright (C) 2015 Intel Corporation
 #
@@ -168,6 +167,7 @@ class Config(object):
             "no_autostart": "do not require autostart subpackage",
             "optimize_size": "optimize build for size over speed",
             "funroll-loops": "optimize build for speed over size",
+            "full-debug-info": "compile full (traditional) debug info",
             "fast-math": "pass -ffast-math to compiler",
             "insecure_build": "set flags to smallest -02 flags possible",
             "conservative_flags": "set conservative build flags",

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -193,7 +193,7 @@ class Specfile(object):
 
     def write_strip_command(self):
         """Write commands to prevent stripping binary if requested."""
-        if self.config.config_opts['nostrip']:
+        if self.config.config_opts['nostrip'] or not self.config.config_opts['full-debug-info']:
             self._write("# Suppress stripping binaries\n")
             self._write("%define __strip /bin/true\n%define debug_package %{nil}\n")
 
@@ -604,6 +604,8 @@ class Specfile(object):
                 flags.extend(["-O3"])
             else:
                 flags.extend(["-Ofast", "-fno-semantic-interposition", "-falign-functions=32"])
+        if not self.config.config_opts['full-debug-info'] and not self.config.config_opts['use_clang']:
+            flags.extend(["-gno-variable-location-views", "-gno-column-info", "-femit-struct-debug-baseonly", "-fdebug-types-section", "-gz", "-g1"])
         if self.config.default_pattern != 'qmake':
             if self.config.config_opts['use_lto']:
                 flags.extend(["-O3", lto, "-ffat-lto-objects"])


### PR DESCRIPTION
... while providing an opt-out options.conf setting

this changes the size of binaries moderately (25% range) but makes backtracing and profiling a ton more pleasant