### PR TITLE
Rust library pattern

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -281,6 +281,8 @@ class FileManager(object):
             (r"^/usr/share/omf", "main", "/usr/share/omf/*"),
             (r"^/usr/share/installed-tests/", "tests"),
             (r"^/usr/libexec/installed-tests/", "tests"),
+            (r"^/usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/[a-zA-Z0-9._+-]+\.rlib", "lib", "/usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.rlib"),
+            (r"^/usr/lib/rustlib/x86_64-unknown-linux-gnu/analysis/[a-zA-Z0-9._+-]+\.json", "lib", "/usr/lib/rustlib/x86_64-unknown-linux-gnu/analysis/*.json"),
             (r"^/usr/share/clear/optimized-elf/bin", "bin", "/usr/share/clear/optimized-elf/bin*"),
             (r"^/usr/share/clear/optimized-elf/exec", "libexec", "/usr/share/clear/optimized-elf/exec*"),
             (r"^/usr/share/clear/optimized-elf/lib", "lib", "/usr/share/clear/optimized-elf/lib*"),

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -130,8 +130,8 @@ class FileManager(object):
 
             self.push_package_file(replacement, package)
             return True
-        else:
-            return False
+
+        return False
 
     def file_is_locale(self, filename):
         """If a file is a locale, appends to self.locales and returns True, returns False otherwise."""


### PR DESCRIPTION
Worth taking a look at the rust package for what this looks like in practice. Still had to special case `/usr/lib/libfoo-$hash.so` though in a somewhat awkward way that might need a rethink.