### PR TITLE
Use the glob filename for push_file

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -234,7 +234,7 @@ class FileManager(object):
                     # the match name may be 1 longer due to a glob
                     # being able to match an empty string
                     if self.globlike_match(filename, match_name):
-                        self.push_package_file(filename, k)
+                        self.push_package_file(os.path.join('/', *match_name), k)
                         return
 
         if filename in self.setuid:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -184,7 +184,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*rightglob']]}}
         self.fm.push_file('leftglobrightglob', '')
-        calls = [call('leftglobrightglob', 'foobar-extras')]
+        calls = [call('/leftglob*rightglob', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_package_file_glob_left_match(self):
@@ -195,7 +195,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*']]}}
         self.fm.push_file('leftglobrightglob', '')
-        calls = [call('leftglobrightglob', 'foobar-extras')]
+        calls = [call('/leftglob*', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_package_file_glob_right_match(self):
@@ -206,7 +206,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.file_maps = {'foobar-extras': {'files': [['*rightglob']]}}
         self.fm.push_file('leftglobrightglob', '')
-        calls = [call('leftglobrightglob', 'foobar-extras')]
+        calls = [call('/*rightglob', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_package_file_glob_leftright_match(self):
@@ -217,7 +217,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*rightglob']]}}
         self.fm.push_file('leftglobstuffrightglob', '')
-        calls = [call('leftglobstuffrightglob', 'foobar-extras')]
+        calls = [call('/leftglob*rightglob', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_package_file_glob_multi_match(self):
@@ -228,7 +228,7 @@ class TestFiles(unittest.TestCase):
         self.fm.push_package_file = MagicMock()
         self.fm.file_maps = {'foobar-extras': {'files': [['leftglob*', '*rightglob']]}}
         self.fm.push_file('leftglobstuff/stuffrightglob', '')
-        calls = [call('leftglobstuff/stuffrightglob', 'foobar-extras')]
+        calls = [call('/leftglob*/*rightglob', 'foobar-extras')]
         self.fm.push_package_file.assert_has_calls(calls)
 
     def test_push_file_setuid(self):


### PR DESCRIPTION
Instead of pushing the filename that is matched, use the glob for the files section as in some cases it is required (rustc) in order to avoid build failures as the filenames may not be static.

Signed-off-by: William Douglas <william.douglas@intel.com>