### PR TITLE
Add name/version parser for dovecot pigeonhole packages

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -388,6 +388,12 @@ class Content(object):
                 name = m.group(1).strip()
                 version = convert_version(m.group(2), name)
 
+        if "pigeonhole.dovecot.org" in self.url:
+            # https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz
+            if m := re.search(r"pigeonhole\.dovecot\.org/releases/.*/dovecot-[\d\.]+-(\w+)-([\d\.]+)\.[^\d]", self.url):
+                name = m.group(1).strip()
+                version = convert_version(m.group(2), name)
+
         # override name and version from commandline
         self.name = self.name if self.name else name
         self.version = self.version if self.version else version

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1915,3 +1915,5 @@ https://pypi.debian.net/zope.security/zope.security-4.1.1.tar.gz,zope.security,4
 https://pypi.debian.net/zope.testing/zope.testing-4.6.2.tar.gz,zope.testing,4.6.2
 https://pypi.debian.net/zope.testrunner/zope.testrunner-4.7.0.zip,zope.testrunner,4.7.0
 http://sourceforge.net/projects/zsh/files/zsh/5.4.2/zsh-5.4.2.tar.gz,zsh,5.4.2
+https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3.11-pigeonhole-0.5.11.tar.gz,pigeonhole,0.5.11
+https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz,pigeonhole,0.5.20


### PR DESCRIPTION
Example:
https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz

Parse as name=pigeonhole, version=0.5.20