### PR TITLE
pip install without 'pypi_' prefix

### DIFF
--- a/autospec/pypidata.py
+++ b/autospec/pypidata.py
@@ -65,13 +65,13 @@ def get_pypi_metadata(name):
         if proc.returncode != 0:
             _print_command_error(cmd, proc)
             return ""
-        cmd = f"source bin/activate && pip install {name}"
+        cmd = f"source bin/activate && pip install {name.removeprefix('pypi_')}"
         proc = subprocess.run(cmd, cwd=tdir, shell=True, capture_output=True,
                               env=pip_env())
         if proc.returncode != 0:
             _print_command_error(cmd, proc)
             return ""
-        cmd = f"source bin/activate &> /dev/null && pip show {name}"
+        cmd = f"source bin/activate &> /dev/null && pip show {name.removeprefix('pypi_')}"
         proc = subprocess.run(cmd, cwd=tdir, shell=True, capture_output=True,
                               env=pip_env())
         if proc.returncode != 0:


### PR DESCRIPTION
The 'pypi_' prefix seems to have more issues than without when doing a pip install so switch to removing the prefix.