### PR TITLE
Fix name/version parsing for ezix tarballs

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -346,6 +346,12 @@ class Content():
                 name = m.group(1).strip()
                 version = convert_version(m.group(2), name)
 
+        if ".ezix.org" in self.url:
+            # https://www.ezix.org/software/files/lshw-B.02.19.2.tar.gz
+            if m := re.search(r"(\w+)-[A-Z]\.(\d+(?:\.\d+)+)", self.url):
+                name = m.group(1).strip()
+                version = convert_version(m.group(2), name)
+
         # override name and version from commandline
         self.name = self.name if self.name else name
         self.version = self.version if self.version else version

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1611,3 +1611,4 @@ https://pypi.debian.net/zope.testrunner/zope.testrunner-4.7.0.zip,zope.testrunne
 http://sourceforge.net/projects/zsh/files/zsh/5.4.2/zsh-5.4.2.tar.gz,zsh,5.4.2
 https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3.11-pigeonhole-0.5.11.tar.gz,pigeonhole,0.5.11
 https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz,pigeonhole,0.5.20
+https://www.ezix.org/software/files/lshw-B.02.19.2.tar.gz,lshw,02.19.2


### PR DESCRIPTION
Package names look like this:
```
- lshw-A.01.09.tar.gz
- lshw-B.02.18.tar.gz
- lshw-B.02.19.2.tar.gz
- lshw-T.00.01.tar.gz
- lshw-T.00.02.tar.gz
```
I'm not sure what the significance of the leading letter/dot is. For now, we'll just strip it off. Later, we might rework tools to incorporate it in version numbers, but there are surprising pitfalls.