### PR TITLE
Rework cargo vendor config location

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -381,12 +381,6 @@ class Specfile(object):
 
     def write_make_line(self, build32=False):
         """Write make line to spec file."""
-        if self.config.config_opts['cargo_vendor']:
-            self._write_strip("mkdir -p .cargo")
-            self._write_strip("echo '[source.crates-io]' >> .cargo/config.toml")
-            self._write_strip("""echo 'replace-with = "vendored-sources"' >> .cargo/config.toml""")
-            self._write_strip("echo '[source.vendored-sources]' >> .cargo/config.toml")
-            self._write_strip("""echo 'directory = "vendor"' >> .cargo/config.toml""")
         if self.config.make_prepend:
             self._write_strip("## make_prepend content")
             for line in self.config.make_prepend:
@@ -468,6 +462,19 @@ class Specfile(object):
                                           self.content.tarball_prefix,
                                           destination))
         self.apply_patches()
+
+        # setup cargo.toml vendoring if needed
+        if self.config.config_opts['cargo_vendor']:
+            if self.config.subdir:
+                self._write_strip("pushd " + self.config.subdir)
+            self._write_strip("mkdir -p .cargo")
+            self._write_strip("echo '[source.crates-io]' >> .cargo/config.toml")
+            self._write_strip("""echo 'replace-with = "vendored-sources"' >> .cargo/config.toml""")
+            self._write_strip("echo '[source.vendored-sources]' >> .cargo/config.toml")
+            self._write_strip("""echo 'directory = "vendor"' >> .cargo/config.toml""")
+            if self.config.subdir:
+                self._write_strip("popd")
+
         if self.config.default_pattern == "distutils3" or self.config.default_pattern == "pyproject":
             self._write_strip("pushd ..")
             self._write_strip("cp -a {} buildavx2".format(self.content.tarball_prefix))


### PR DESCRIPTION
Move addition of vendor config to non-pattern dependent location which is copied for different builds (avx2/avx512).