### PR TITLE
Add configure_ac parsing to configure pattern

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -801,6 +801,8 @@ class Requirements(object):
             for cfile in cmake_files:
                 self.parse_cmake(cfile, config.cmake_modules, config.config_opts.get('32bit'))
         elif config.default_pattern == "configure":
+            for cfile in configure_ac_files:
+                self.parse_configure_ac(cfile, config)
             self.add_buildreq("buildreq-configure")
         elif config.default_pattern in ("autogen", "configure_ac"):
             for cfile in configure_ac_files:


### PR DESCRIPTION
When the configure pattern is detected, also try to parse any configure_ac files found. Too many buildreqs are in configure_ac but we don't usually want to set the build_pattern as configure_ac when configure is around as it is fragile.