### PR TITLE
Make ModuleNotFoundError return pypi() deps

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -274,7 +274,7 @@ class Config(object):
             (r"ImportError:.* No module named '?([a-zA-Z0-9\-\._]+)'?", 0, 'pypi'),
             (r"ImportError\: ([a-zA-Z]+) module missing", 0, None),
             (r"ImportError\: (?:No module|cannot import) named? (.*)", 0, None),
-            (r"ModuleNotFoundError.*No module named (.*)", 0, None),
+            (r"ModuleNotFoundError.*No module named '?(.*)'?", 0, 'pypi'),
             (r"Native dependency '(.*)' not found", 0, "pkgconfig"),
             (r"No library found for -l([a-zA-Z\-])", 0, None),
             (r"No (?:matching distribution|local packages or working download links) found for ([a-zA-Z0-9\-\.\_]+)", 0, 'pypi'),

--- a/tests/builderrors
+++ b/tests/builderrors
@@ -50,7 +50,8 @@ ImportError: No module named swig|pypi(swig)
 ImportError: cannot import name swig|swig
 ImportError: swig module missing|swig
 ImportError:..*: No module named swig|pypi(swig)
-ModuleNotFoundError: No module named swig|swig
+ModuleNotFoundError: No module named swig|pypi(swig)
+ModuleNotFoundError: No module named 'foo-bar'|pypi(foo_bar)
 Native dependency 'swig' not found|pkgconfig(swig)
 No local packages or working download links found for swig|pypi(swig)
 No matching distribution found for swig|pypi(swig)


### PR DESCRIPTION
ModuleNotFoundError: No module named 'pyqtbuild' should add the dep pypi(pyqtbuild)