### PR TITLE
Update ld path and add new failure pattern

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -293,7 +293,7 @@ class Config(object):
             (r"You need ([a-zA-Z0-9\-\_]*) to build this program.", 1, None),
             (r"[Dd]ependency (.*) found: NO \(tried pkgconfig(?: and cmake)?\)", 0, 'pkgconfig'),
             (r"[Dd]ependency (.*) found: NO", 0, None),
-            (r"\/bin\/ld: cannot find (-l[a-zA-Z0-9\_]+)", 0, None),
+            (r"(?:\/usr)?\/bin\/ld: cannot find (-l[a-zA-Z0-9\_]+)", 0, None),
             (r"^.*By not providing \"Find(.*).cmake\" in CMAKE_MODULE_PATH this.*$", 0, None),
             (r"^.*Could not find a package configuration file provided by \"(.*)\".*$", 0, None),
             (r"^.*\"(.*)\" with any of the following names.*$", 0, None),

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -105,6 +105,7 @@
 -lsqlite3, sqlite-autoconf-dev
 -lssh, libssh-dev
 -lssl, openssl-dev
+-lTerminfo, ncurses-dev
 -ltermcap, ncurses-dev
 -ltinfo, ncurses-dev
 -ltinfow, ncurses-dev


### PR DESCRIPTION
The ld path will show /usr/bin/ld in some cases so account for that in the regex match pattern.

Also include a new style for a missing terminfo lib from trying to build bcc.