### PR TITLE
Enforce services subpackages to require systemd

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -239,6 +239,11 @@ class Specfile(object):
         deps["lib32"] = ["data", "license"]
         deps["python"] = ["python3"]
         deps["python3"] = ["filemap"]
+        if "services" in self.packages:
+            if service_reqs := self.requirements.requires.get("services"):
+                service_reqs.add("systemd")
+            else:
+                self.requirements.requires["services"] = set(["systemd"])
         if self.config.config_opts.get('dev_requires_extras'):
             deps["dev"].append("extras")
         if self.config.config_opts.get('openmpi'):


### PR DESCRIPTION
More of a tidy up change as most images outside of docker will always have systemd but package checks are happier with it being explicit.