### PR TITLE
Make Perl builds find included inc

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -1557,7 +1557,7 @@ class Specfile(object):
         self.write_proxy_exports()
         self._write_strip("export LANG=C.UTF-8")
         self._write_strip("if test -f Makefile.PL; then")
-        self._write_strip("%{__perl} Makefile.PL")
+        self._write_strip("%{__perl} -I. Makefile.PL")
         self.write_make_line()
         self._write_strip("else")
         self._write_strip("%{__perl} Build.PL")


### PR DESCRIPTION
Some Perl modules include custom build libraries under inc -- make sure they'll be able to find them by adding the source directory to the include path when processing Makefile.PL