### PR TITLE
Ban pypi-nose related packages

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -268,10 +268,13 @@ class Requirements(object):
 
     def __init__(self, url):
         """Initialize Default requirements settings."""
-        self.banned_requires = {None: set(["futures",
-                                           "configparser",
-                                           "typing",
-                                           "ipaddress"])}
+        self.banned_anywhere_requires = set(["futures",
+                                             "configparser",
+                                             "typing",
+                                             "ipaddress",
+                                             "pypi-nose",
+                                             "pypi(nose)"])
+        self.banned_requires = {None: set()}
         self.buildreqs = set()
         self.buildreqs_cache = set()
         self.requires = {None: set(), "pypi": set()}
@@ -294,7 +297,10 @@ class Requirements(object):
                                      "setuptools_scm[toml]",
                                      "typing",
                                      "ipaddress",
-                                     "pypi(setuptools_scm_git_archive)"])
+                                     "pypi-nose",
+                                     "pypi(setuptools_scm_git_archive)",
+                                     "pypi(setuptools_changelog_shortener)",
+                                     "pypi(nose)"])
         self.autoreconf_reqs = ["gettext-bin",
                                 "automake-dev",
                                 "automake",
@@ -346,6 +352,8 @@ class Requirements(object):
         if (banned_requires := self.banned_requires.get(subpkg)) is None:
             banned_requires = self.banned_requires[subpkg] = set()
         if req in banned_requires:
+            return False
+        if req in self.banned_anywhere_requires:
             return False
 
         if req not in self.buildreqs and req not in packages and not override:

--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -3,7 +3,6 @@
 # This file is sorted with LC_COLLATE=C
 # Lines beginning with '#' are ignored.
 # For patterns that start with '#', escape the '#' as '\#'.
-'nose', pypi(nose)
 'numpy', pypi(numpy)
 'pexpect', pypi(pexpect)
 -lEGL, mesa-dev
@@ -1132,7 +1131,6 @@ nfsidmap.h, libnfsidmap-dev
 nghttp, nghttp2-dev
 nl_handle_alloc, libnl-dev
 node, nodejs
-nose, pypi-nose
 nosexcover, nosexcover
 notmuch.h, notmuch-dev
 nroff, groff

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -80,6 +80,13 @@ class TestBuildreq(unittest.TestCase):
         self.assertFalse(self.reqs.add_requires('testreq', []))
         self.assertNotIn('testreq', self.reqs.requires[None])
 
+    def test_add_banned_requires(self):
+        """
+        Test add_requires with banned new req (override buildreq).
+        """
+        self.assertFalse(self.reqs.add_requires('pypi(nose)', [], override=True))
+        self.assertNotIn('testreq', self.reqs.requires[None])
+
     def test_ban_provides(self):
         """
         Test ban_provides with prov already present in provides


### PR DESCRIPTION
pypi-nose is no longer usable so ban it from being added as a dependency.