### PR TITLE
Stop redirecting libproxy dep to pacrunner-dev

### DIFF
--- a/autospec/failed_commands
+++ b/autospec/failed_commands
@@ -96,7 +96,6 @@
 -lpcap, libpcap-dev
 -lpcre, pcre-dev
 -lpopt, popt-dev
--lproxy, pacrunner-dev
 -lrdmacm, rdma-core-dev
 -lreadline, readline-dev
 -lsecret, libsecret-dev
@@ -1036,8 +1035,6 @@ libpng, pkgconfig(libpng)
 libpng-config, pkgconfig(libpng)
 libpng/png.h, pkgconfig(libpng)
 libportal, libportal-dev
-libproxy-1.0 pkg-config data, pacrunner-dev
-libproxy-1.0, pacrunner-dev
 libpsl, libpsl-dev
 libqhull/libqhull.h, qhull-dev
 library ldap, openldap-dev


### PR DESCRIPTION
We fixed the real libproxy a while back to query pacrunner itself via dbus, so pacrunner no longer provides a libproxy shim, nor the pacrunner-dev package.