### PR TITLE
Add more bits to the blacklist

### DIFF
--- a/autospec/license_blacklist
+++ b/autospec/license_blacklist
@@ -160,3 +160,13 @@ with
 your
 |
 ~
+Permission
+a
+charge
+copy
+granted
+hereby
+obtaining
+of
+person
+to


### PR DESCRIPTION
A poorly parsed license file caused these to need to be added.