### PR TITLE
Add use_apx flag to options.conf

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -153,6 +153,7 @@ class Config(object):
             "broken_c++": "extend flags with '-std=gnu++98",
             "cargo_vendor": "create vendor archive with cargo",
             "use_lto": "configure build for lto",
+            "use_apx": "configure build for APX",
             "use_avx2": "configure build for avx2",
             "use_avx512": "configure build for avx512",
             "keepstatic": "do not remove static libraries",
@@ -411,7 +412,10 @@ class Config(object):
         # (in case of a user-created options.conf)
         missing = set(self.config_options.keys()).difference(set(self.config_opts.keys()))
         for option in missing:
-            self.config_opts[option] = False
+            if option in ['use_apx']:
+                self.config_opts[option] = True
+            else:
+                self.config_opts[option] = False
 
         for fname, comment in sorted(self.config_options.items()):
             config_f.set('autospec', '# {}'.format(comment))


### PR DESCRIPTION
New options default to false, except use_apx, which will default to true.

No handlers for use_apx at this time.

```diff
diff --git a/options.conf b/options.conf
index ed481d682825..127ec6e6ffaa 100644
--- a/options.conf
+++ b/options.conf
@@ -59,6 +59,16 @@ server = false
 skip_tests = false
 # add .so files to the lib package instead of dev
 so_to_lib = false
+# configure build for apx
+use_apx = true
+# configure build for avx2
+use_avx2 = false
+# configure build for avx512
+use_avx512 = false
+# add clang flags
+use_clang = false
+# configure build for lto
+use_lto = false
 # require package verification for build
 verify_required = false
```