### PR TITLE
Add a mechanism to automatically exclude Windows executables

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -181,7 +181,8 @@ class Config(object):
             "nodebug": "do not generate debuginfo for this package",
             "openmpi": "configure build also for openmpi",
             "server": "Package is only used by servers",
-            "no_glob": "Do not use the replacement pattern for file matching"
+            "no_glob": "Do not use the replacement pattern for file matching",
+            "allow_exe": "Allow Windows executables (*.exe, *.dll) to be packaged",
         }
         # simple_pattern_pkgconfig patterns
         # contains patterns for parsing build.log for missing dependencies

--- a/autospec/files.py
+++ b/autospec/files.py
@@ -272,6 +272,16 @@ class FileManager(object):
         if self.want_dev_split and self.file_pat_match(filename, r"^/usr/.*/include/.*\.h$", "dev"):
             return
 
+        # Exclude Windows executables and DLLs unless otherwise configured
+        # Can't just skip them because they could be swept up in a python lib wildcard, for example
+        if re.search(r"[^/]+\.(exe|dll)$", filename):
+            if self.config.config_opts.get('allow_exe'):
+                util.print_warning("Allowing {} because allow_exe is true".format(filename))
+            else:
+                util.print_warning("Blocking {} because allow_exe is false".format(filename))
+                self.excludes.append(filename)
+                return
+
         # if configured to do so, add .so files to the lib package instead of
         # the dev package. THis is useful for packages with a plugin
         # architecture like elfutils and mesa.


### PR DESCRIPTION
Some packages, especially PIP wheels, install Windows executables. Introduce an option, allow_exe, with which to permit installing those executables. Otherwise, explicitly delete them so they're not inadvertently installed via wildcards later.