### PR TITLE
Add support for non-tarball bz2 archives

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -442,6 +442,8 @@ class Specfile(object):
                 extract_cmd = 'tar xf {}'
                 if archive.endswith('.zip'):
                     extract_cmd = 'unzip -q {}'
+                if archive.endswith('.bz2') and not archive.endswith('.tar.bz2'):
+                    extract_cmd = 'bzcat {0} > $(basename "{0}" .bz2)'
                 self._write_strip('cd %{_builddir}')
                 archive_file = os.path.basename(archive)
                 if self.config.archive_details.get(archive + "prefix"):

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import bz2
 import configparser
 import os
 import re
@@ -50,6 +51,8 @@ class Source():
         """Determine compression type."""
         if self.url.lower().endswith(('.zip', 'jar')):
             self.type = 'zip'
+        elif self.url.lower().endswith(('.bz2')) and not self.url.lower().endswith(('.tar.bz2')):
+            self.type = 'bz2'
         else:
             self.type = 'tar'
 
@@ -77,6 +80,9 @@ class Source():
         else:
             print_fatal("Not a valid tar file.")
             sys.exit(1)
+
+    def set_bz2_prefix(self):
+        """No prefix for plain bz2 archives."""
 
     def set_zip_prefix(self):
         """Determine prefix folder name of zip file."""
@@ -107,6 +113,15 @@ class Source():
         """Extract tar in path."""
         with tarfile.open(self.path) as content:
             content.extractall(path=extraction_path)
+
+    def extract_bz2(self, extraction_path):
+        """Extract plain bz2 file in path."""
+        with bz2.BZ2File(self.path, 'rb') as content:
+            data = content.read()
+            newfile = self.path.rsplit('/', 1)[1]
+            newfile = newfile.rsplit('.bz2', 1)[0]
+            with open(os.path.join(extraction_path), mode='wb') as f:
+                f.write(data)
 
     def extract_zip(self, extraction_path):
         """Extract zip in path."""


### PR DESCRIPTION
Some projects require additional bz2 downloads that are single compressed files, not tar archives. Detect and extract those with appropriate bz2 tools instead of tar.

For a given entry like this:
`ARCHIVES = https://example.com/download/foo.dat.bz2 src/data`

...upstream file is downloaded to:
`builddir/build/SOURCES/foo.dat.bz2`

...initially extracted as:
`builddir/build/BUILD/foo.dat/foo.dat`

...and finally copied to
`builddir/build/BUILD/<pkg>/src/data/foo.dat`
