### PR TITLE
Add etc_files log

### DIFF
--- a/autospec/git.py
+++ b/autospec/git.py
@@ -109,6 +109,7 @@ def commit_to_git(config, name, success):
     call("git add profile_payload", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add options.conf", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add configure_misses", check=False, stderr=subprocess.DEVNULL, cwd=path)
+    call("git add etc_files", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add whatrequires", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add description", check=False, stderr=subprocess.DEVNULL, cwd=path)
     call("git add attrs", check=False, stderr=subprocess.DEVNULL, cwd=path)


### PR DESCRIPTION
When a package has content in /etc, it is removed silently, this change adds an etc_files log file in git that shows what files were in /etc that weren't packaged.