### PR TITLE
Extend key ID matching to expired keys

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -444,7 +444,7 @@ class Specfile(object):
             self._write_strip("chmod 700 .gnupg")
             self._write_strip(f"gpg --homedir .gnupg --import {self.config.pkey_macro}")
             self._write_strip(f"gpg --homedir .gnupg --status-fd 1 --verify {self.config.signature_macro} %{{SOURCE0}} > gpg.status")
-            self._write_strip(f"grep '^\\[GNUPG:\\] GOODSIG {self.keyid}' gpg.status")
+            self._write_strip(f"grep -E '^\\[GNUPG:\\] (GOODSIG|EXPKEYSIG) {self.keyid}' gpg.status")
         self.write_prep_prepend()
         prefix = self.content.prefixes[self.url]
         if self.config.default_pattern == 'R':


### PR DESCRIPTION
gpg accepts signatures with expired keys as long as the signature was made prior to key expiration. But it also changes the status-fd output format that we grep for the expected key ID. Make sure we look for the alternate EXPKEYSIG line in the output in that case to find the key ID.