### PR TITLE
Add config for using ninja instead of make

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -751,6 +751,10 @@ class Requirements(object):
         configure_ac_files = []
         qmake_profiles = []
         cmake_files = []
+
+        if config.config_opts['use_ninja']:
+            self.add_buildreq('ninja')
+
         for dirpath, _, files in os.walk(dirn):
             default_score = 2 if dirpath == dirn else 1
 

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -187,6 +187,7 @@ class Config(object):
             "server": "Package is only used by servers",
             "no_glob": "Do not use the replacement pattern for file matching",
             "allow_exe": "Allow Windows executables (*.exe, *.dll) to be packaged",
+            "use_ninja": "Use ninja build files",
         }
         # simple_pattern_pkgconfig patterns
         # contains patterns for parsing build.log for missing dependencies

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -414,6 +414,8 @@ class Specfile(object):
             self._write_strip("## make_prepend end")
         if self.config.make_command:
             make = self.config.make_command
+        elif self.config.config_opts['use_ninja']:
+            make = "ninja"
         else:
             make = "make"
         if build32:
@@ -430,7 +432,11 @@ class Specfile(object):
 
     def write_cmake_line_openmpi(self):
         """Write cmake line (openmpi) to spec file."""
-        cmake_string = 'cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$MPI_ROOT -DCMAKE_INSTALL_SBINDIR=$MPI_BIN \\\n' \
+        if self.config.config_opts['use_ninja']:
+            cmake_type = "Ninja"
+        else:
+            cmake_type = "Unix Makefiles"
+        cmake_string = f"cmake -G {cmake_type} -DCMAKE_INSTALL_PREFIX=$MPI_ROOT -DCMAKE_INSTALL_SBINDIR=$MPI_BIN \\\n" \
                        '-DCMAKE_INSTALL_LIBDIR=$MPI_LIB -DCMAKE_INSTALL_INCLUDEDIR=$MPI_INCLUDE -DLIB_INSTALL_DIR=$MPI_LIB \\\n' \
                        '-DBUILD_SHARED_LIBS:BOOL=ON -DLIB_SUFFIX=64 \\\n' \
                        '-DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_RANLIB=/usr/bin/gcc-ranlib \\\n'
@@ -1631,7 +1637,11 @@ class Specfile(object):
         self._write_strip("pushd clr-build")
         self.write_variables()
         self._write_strip("export GOAMD64=v2")
-        self._write_strip("%cmake {} {}".format(self.config.cmake_srcdir, self.extra_cmake))
+        if self.config.config_opts['use_ninja']:
+            cmake_type = "-G Ninja"
+        else:
+            cmake_type = "-G 'Unix Makefiles'"
+        self._write_strip(f"%cmake {self.config.cmake_srcdir} {self.extra_cmake} {cmake_type}")
 
         self.write_profile_payload("cmake")
 
@@ -1648,7 +1658,7 @@ class Specfile(object):
             self._write_strip(f'CXXFLAGS="$CLEAR_INTERMEDIATE_CXXFLAGS {AVX2_CFLAGS} {AVX2_LFLAGS} "')
             self._write_strip(f'FFLAGS="$CLEAR_INTERMEDIATE_FFLAGS {AVX2_CFLAGS} {AVX2_LFLAGS} "')
             self._write_strip(f'FCFLAGS="$CLEAR_INTERMEDIATE_FCFLAGS {AVX2_CFLAGS} "')
-            self._write_strip("%cmake {} {}".format(self.config.cmake_srcdir, self.extra_cmake))
+            self._write_strip(f"%cmake {self.config.cmake_srcdir} {self.extra_cmake} {cmake_type}")
             self.write_make_line()
             self._write_strip("popd")
 
@@ -1662,7 +1672,7 @@ class Specfile(object):
             self._write_strip(f'CXXFLAGS="$CLEAR_INTERMEDIATE_CXXFLAGS {AVX512_CFLAGS} {AVX512_LFLAGS} "')
             self._write_strip(f'FFLAGS="$CLEAR_INTERMEDIATE_FFLAGS {AVX512_CFLAGS} {AVX512_LFLAGS} "')
             self._write_strip(f'FCFLAGS="$CLEAR_INTERMEDIATE_FCFLAGS {AVX512_CFLAGS} "')
-            self._write_strip("%cmake {} {}".format(self.config.cmake_srcdir, self.extra_cmake))
+            self._write_strip(f"%cmake {self.config.cmake_srcdir} {self.extra_cmake} {cmake_type}")
             self.write_make_line()
             self._write_strip("popd")
 
@@ -1676,7 +1686,7 @@ class Specfile(object):
             self._write_strip(f'CXXFLAGS="$CLEAR_INTERMEDIATE_CXXFLAGS {AVX2_CFLAGS} {AVX2_LFLAGS} "')
             self._write_strip(f'FFLAGS="$CLEAR_INTERMEDIATE_FFLAGS {APX_CFLAGS} {APX_LFLAGS} "')
             self._write_strip(f'FCFLAGS="$CLEAR_INTERMEDIATE_FCFLAGS {APX_CFLAGS} "')
-            self._write_strip("%cmake {} {}".format(self.config.cmake_srcdir, self.extra_cmake))
+            self._write_strip(f"%cmake {self.config.cmake_srcdir} {self.extra_cmake} {cmake_type}")
             self.write_make_line()
             self._write_strip("popd")
 
@@ -1689,7 +1699,7 @@ class Specfile(object):
             self._write_strip("%cmake -DLIB_INSTALL_DIR:PATH=/usr/lib32 "
                               "-DCMAKE_INSTALL_LIBDIR=/usr/lib32 "
                               "-DLIB_SUFFIX=32 "
-                              "{} {} ".format(self.config.cmake_srcdir, self.extra_cmake))
+                              f"{self.config.cmake_srcdir} {self.extra_cmake} {cmake_type}")
             self.write_make_line()
             self._write_strip("unset PKG_CONFIG_PATH")
             self._write_strip("popd")

--- a/tests/test_buildreq.py
+++ b/tests/test_buildreq.py
@@ -402,6 +402,7 @@ class TestBuildreq(unittest.TestCase):
         should be sufficient.
         """
         conf = config.Config("")
+        conf.config_opts['use_ninja'] = False
         with tempfile.TemporaryDirectory() as tmpd:
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'setup.py'), 'w').close()
@@ -418,6 +419,7 @@ class TestBuildreq(unittest.TestCase):
         should be sufficient.
         """
         conf = config.Config("")
+        conf.config_opts['use_ninja'] = False
         with tempfile.TemporaryDirectory() as tmpd:
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'CMakeLists.txt'), 'w').close()
@@ -434,6 +436,7 @@ class TestBuildreq(unittest.TestCase):
         should be sufficient.
         """
         conf = config.Config("")
+        conf.config_opts['use_ninja'] = False
         with tempfile.TemporaryDirectory() as tmpd:
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'SConstruct'), 'w').close()
@@ -450,6 +453,7 @@ class TestBuildreq(unittest.TestCase):
         should be sufficient.
         """
         conf = config.Config("")
+        conf.config_opts['use_ninja'] = False
         with tempfile.TemporaryDirectory() as tmpd:
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'meson.build'), 'w').close()
@@ -480,6 +484,7 @@ class TestBuildreq(unittest.TestCase):
         buildreq.pypidata.get_pypi_metadata = MagicMock(return_value=content)
         with tempfile.TemporaryDirectory() as tmpd:
             conf = config.Config(tmpd)
+            conf.config_opts['use_ninja'] = False
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'subdir', 'pyproject.toml'), 'w').close()
             self.reqs.scan_for_configure(os.path.join(tmpd, 'subdir'), "", conf)
@@ -512,6 +517,7 @@ class TestBuildreq(unittest.TestCase):
         m_open = mock_open(read_data=content)
         with tempfile.TemporaryDirectory() as tmpd:
             conf = config.Config(tmpd)
+            conf.config_opts['use_ninja'] = False
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'subdir', 'pyproject.toml'), 'w').close()
             open(os.path.join(tmpd, 'pypi.json'), 'w').close()
@@ -537,6 +543,7 @@ class TestBuildreq(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpd:
             conf = config.Config(tmpd)
+            conf.config_opts['use_ninja'] = False
             os.mkdir(os.path.join(tmpd, 'subdir'))
             open(os.path.join(tmpd, 'subdir', 'setup.py'), 'w').close()
             open(os.path.join(tmpd, 'subdir', 'requires.txt'), 'w').close()
@@ -545,6 +552,21 @@ class TestBuildreq(unittest.TestCase):
         self.reqs.add_pyproject_requires.assert_not_called()
         self.reqs.add_setup_py_requires.assert_called_once()
         self.reqs.grab_python_requirements.assert_called_once()
+
+    def test_scan_for_configure_ninja(self):
+        """
+        Test scan_for_configure when ninja is enabled.
+        """
+        conf = config.Config("")
+        conf.config_opts['use_ninja'] = True
+        with tempfile.TemporaryDirectory() as tmpd:
+            os.mkdir(os.path.join(tmpd, 'subdir'))
+            open(os.path.join(tmpd, 'setup.py'), 'w').close()
+
+            self.reqs.scan_for_configure(tmpd, "", conf)
+
+        self.assertEqual(self.reqs.buildreqs,
+                         set(['buildreq-distutils3', 'ninja']))
 
     def test_parse_cmake_pkg_check_modules(self):
         """


### PR DESCRIPTION
Given more packages are using ninja as the build system of choice instead of make, add flag to enable ninja usage.