### PR TITLE
zstd support

### DIFF
--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -532,6 +532,7 @@ VERIFIER_TYPES = {
     '.bz2': GPGVerifier,
     '.xz': GPGVerifier,
     '.zip': GPGVerifier,
+    '.zst': GPGVerifier,
 }
 
 

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -465,6 +465,11 @@ class Specfile(object):
                     extract_cmd = 'unzip -q {}'
                 if archive.endswith('.bz2') and not archive.endswith('.tar.bz2'):
                     extract_cmd = 'bzcat {0} > $(basename "{0}" .bz2)'
+                if archive.endswith('.zst'):
+                    if archive.endswith('.tar.zst'):
+                        extract_cmd = 'tar -I zstd xf {}'
+                    else:
+                        extract_cmd = 'zstd -dqc {0} > $(basename "{0}" .zst)'
                 self._write_strip('cd %{_builddir}')
                 archive_file = os.path.basename(archive)
                 if self.config.archive_details.get(archive + "prefix"):

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -25,8 +25,8 @@ import sys
 import tarfile
 import zipfile
 
-import zstandard as zstd
 import download
+import zstandard as zstd
 from util import do_regex, get_sha1sum, print_fatal, write_out
 
 

--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -24,8 +24,8 @@ import re
 import sys
 import tarfile
 import zipfile
-import zstandard as zstd
 
+import zstandard as zstd
 import download
 from util import do_regex, get_sha1sum, print_fatal, write_out
 
@@ -83,7 +83,7 @@ class Source():
         else:
             print_fatal("Not a valid tar file.")
             sys.exit(1)
-    
+
     def set_zst_prefix(self):
         """Determine prefix folder name of tar.zst file."""
         with tarfile.open(fileobj=zstd.open(self.path, 'rb'), mode='r|') as content:
@@ -145,6 +145,7 @@ class Source():
         """Extract zst in path."""
         with tarfile.open(fileobj=zstd.open(self.path, 'rb'), mode='r|') as content:
             content.extractall(path=extraction_path)
+
 
 def convert_version(ver_str, name):
     """Remove disallowed characters from the version."""


### PR DESCRIPTION
With reference to https://github.com/clearlinux/distribution/issues/3114
bcachefs.org provides .tar.zst files in their releases repository https://evilpiepirate.org/bcachefs-tools/. As such, attempting to use their [vendored tarball](https://evilpiepirate.org/bcachefs-tools/bcachefs-tools-vendored-1.7.0.tar.zst) on autospec currently fails with 
`"Tar file doesn't appear to have any content"`

This PR hopes to address this issue.