### PR TITLE
Make autoupdate default for new packages

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -448,6 +448,8 @@ class Config(object):
 
         # default lto to true for new things
         config_f['autospec']['use_lto'] = 'true'
+        # default autoupdate to true for new things
+        config_f['autospec']['autoupdate'] = 'true'
 
         # renamed options need special care
         skip_path = os.path.join(self.download_path, "skip_test_suite")


### PR DESCRIPTION
Things should be autoupdating by default for new content at this point as being held back for no reason isn't helpful.