### PR TITLE
Add cargo vendor drop in style file

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -68,6 +68,7 @@ class Config(object):
 
     def __init__(self, download_path):
         """Initialize Default configuration settings."""
+        self.cargo_vendors = ""
         self.content = None  # hack to avoid circular init dependency
         self.extra_configure = ""
         self.extra_configure32 = ""
@@ -990,6 +991,11 @@ class Config(object):
                 if word.find(":") < 0:
                     if not license.add_license(word, self.license_translations, self.license_blacklist):
                         print_warning("{}: blacklisted license {} ignored.".format(self.content.name + ".license", word))
+
+        # cargo_vendors is the output of 'cargo vendor' and should be read as is
+        content = self.read_file(os.path.join(self.download_path, "cargo_vendors"), track=True)
+        if content:
+            self.cargo_vendors = "".join(content)
 
         if self.config_opts['use_clang']:
             self.config_opts['funroll-loops'] = False

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -509,14 +509,11 @@ class Specfile(object):
         self.apply_patches()
 
         # setup cargo.toml vendoring if needed
-        if self.config.config_opts['cargo_vendor']:
+        if self.config.cargo_vendors:
             if self.config.subdir:
                 self._write_strip("pushd " + self.config.subdir)
             self._write_strip("mkdir -p .cargo")
-            self._write_strip("echo '[source.crates-io]' >> .cargo/config.toml")
-            self._write_strip("""echo 'replace-with = "vendored-sources"' >> .cargo/config.toml""")
-            self._write_strip("echo '[source.vendored-sources]' >> .cargo/config.toml")
-            self._write_strip("""echo 'directory = "vendor"' >> .cargo/config.toml""")
+            self._write_strip(f"echo '{self.config.cargo_vendors}' >> .cargo/config.toml")
             if self.config.subdir:
                 self._write_strip("popd")
 


### PR DESCRIPTION
Add support for cargo_vendors which should be pretty much the output of a 'cargo vendor' run. This will be appended to any existing .cargo/config.toml file in the sources. It is intended to mostly come from the vendor.py in common but useful for other builds as well which don't need to enable cargo_vendor in options.conf.