### PR TITLE
Enable working with Jinja2 spec templates

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -269,9 +269,13 @@ def package(args, url, name, archives, workingdir):
         pkg_integrity.check(url, conf, interactive=interactive_mode)
         pkg_integrity.load_specfile(specfile)
 
-    specfile.write_spec()
+    spec_type = specfile.write_spec()
+
     while 1:
         package.package(filemanager, args.mock_config, args.mock_opts, conf, requirements, content, args.cleanup)
+        if spec_type == "template":
+            # specfile template is assumed "correct" and any failures need to be manually addressed
+            break
         filemanager.load_specfile(specfile)
         specfile.write_spec()
         filemanager.newfiles_printed = 0
@@ -304,7 +308,8 @@ def package(args, url, name, archives, workingdir):
         except Exception:
             pass
 
-    check.check_regression(conf.download_path, conf.config_opts['skip_tests'], package.round - 1)
+    if spec_type == "generate":
+        check.check_regression(conf.download_path, conf.config_opts['skip_tests'], package.round - 1)
 
     examine_abi(conf.download_path, content.name)
     if os.path.exists("/var/lib/rpm"):

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -47,7 +47,7 @@ class TestSpecfileWrite(unittest.TestCase):
         self.WRITES = self.WRITES[:4] + self.WRITES[6:]
         self.assertEqual(expect, self.WRITES)
 
-    def test_write_nvr_no_urlban(self):
+    def test_write_nvr(self):
         """
         test Specfile.write_nvr with no urlban set
         """
@@ -57,19 +57,6 @@ class TestSpecfileWrite(unittest.TestCase):
                   "Release  : 2\n",
                   "URL      : http://www.testpkg.com/testpkg/pkg-1.0.tar.gz\n",
                   "Source0  : http://www.testpkg.com/testpkg/pkg-1.0.tar.gz\n"]
-        self.assertEqual(expect, self.WRITES)
-
-    def test_write_nvr_urlban(self):
-        """
-        test Specfile.write_nvr with urlban set
-        """
-        self.specfile.config.urlban = "www.testpkg.com"
-        self.specfile.write_nvr()
-        expect = ["Name     : pkg\n",
-                  "Version  : 1.0\n",
-                  "Release  : 2\n",
-                  "URL      : http://localhost/testpkg/pkg-1.0.tar.gz\n",
-                  "Source0  : http://localhost/testpkg/pkg-1.0.tar.gz\n"]
         self.assertEqual(expect, self.WRITES)
 
     def test_write_sources(self):


### PR DESCRIPTION
Allow autospec to handle building packages that use a Jinja2 formatted *.spec.template file. Currently only package_name, package_version, package_release and package_url fields are supported but others can be added as needed (patches and archives are good next steps).