### PR TITLE
Fix type mismatch

### DIFF
--- a/autospec/util.py
+++ b/autospec/util.py
@@ -112,7 +112,7 @@ def _process_build_log(filename):
         lines = lfile.readlines()
 
     prev_line = ''
-    current_patch = ''
+    current_patch = ['']
     reported_patches = {}
     error = False
     for line in lines:


### PR DESCRIPTION
current_patch is modified in the called as an array so make sure it is created as one.