### PR TITLE
Add github url handling for tags with slashes

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -295,7 +295,8 @@ class Content():
         if "github.com" in self.url:
             # define regex accepted for valid packages, important for specific
             # patterns to come before general ones
-            github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/refs/tags/[vVrR]?(.*)\.tar",
+            github_patterns = [r"https?://github.com/(.*)/(.*?)/archive/refs/tags/.*/(.*).tar",
+                               r"https?://github.com/(.*)/(.*?)/archive/refs/tags/[vVrR]?(.*)\.tar",
                                r"https?://github.com/(.*)/(.*?)/archive/[v|r]?.*/(.*).tar",
                                r"https?://github.com/(.*)/(.*?)/archive/[-a-zA-Z_]*-(.*).tar",
                                r"https?://github.com/(.*)/(.*?)/archive/[vVrR]?(.*).tar",

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1612,3 +1612,4 @@ http://sourceforge.net/projects/zsh/files/zsh/5.4.2/zsh-5.4.2.tar.gz,zsh,5.4.2
 https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3.11-pigeonhole-0.5.11.tar.gz,pigeonhole,0.5.11
 https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz,pigeonhole,0.5.20
 https://www.ezix.org/software/files/lshw-B.02.19.2.tar.gz,lshw,02.19.2
+https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz,vectorscan,5.4.11


### PR DESCRIPTION
vectorscan uses 'vectorscan/' as a tag prefix which confuses our version parsing (even more so with v being the tag prefix). Add support for matching any '*/version' tag names as the top priority.