### PR TITLE
Always handle the common tmepfile prefix for license_skips

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,9 +129,9 @@ release
   respectively. This results in less manual work via automatic management.
 
 license_skips
-  Each line in the file should be a full path, that path is prefixed into a
-  tempfile directory + the package tarfile prefix. Requires using '*' to be
-  effective (e.g. /tmp/*/pkgname-*/path/to/license).
+  Each line in the file should be the path to a license file. That path needs
+  to account for the package tarfile prefix. Likely requires using '*' to be
+  effective (e.g. ``pkgname-*/path/to/license`` where ``*`` handles the version).
 
   Files paths can contain a single '*' per directory such that
   a line of ``/foo*/bar*`` is allowed but ``/foo*bar*`` is not.

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -151,7 +151,11 @@ def skip_license(license_path, config):
     """Check if a given license file path should be skipped."""
     skip_name = False
     for skip in config.license_skips:
-        if util.globlike_match(license_path, skip):
+        # handle the common tempfile prefix and normalize for
+        # skip lines without a starting '/'
+        skip = skip if skip[0] != '' else skip[1:]
+        skip_path = ['', 'tmp', '*'] + skip
+        if util.globlike_match(license_path, skip_path):
             util.print_warning(f"Skip license detected for file at {license_path}")
             skip_name = True
             break

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -106,10 +106,6 @@ class TestUtil(unittest.TestCase):
         file_path = 'a/ab'
         self.assertFalse(util.globlike_match(file_path, match_name))
 
-        match_name = ['a', 'b*']
-        file_path = 'a/ab'
-        self.assertFalse(util.globlike_match(file_path, match_name))
-
         match_name = ['a', '*a']
         file_path = 'a/ab'
         self.assertFalse(util.globlike_match(file_path, match_name))


### PR DESCRIPTION
Modify license skips to handle the common tempfile prefix of '/tmp/*' and normalize the case where lines lead with a slash vs not.

Also remove a duplicate test for globlike match.