### PR TITLE
Split packages from cmake_modules when adding them as buildreqs

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -508,7 +508,7 @@ class Requirements(object):
         """Scan a .cmake or CMakeLists.txt file for what's it's actually looking for."""
         findpackage = re.compile(r"^[^#]*find_package\((\w+)\b.*\)", re.I)
         findpackage_multiline = re.compile(r"^[^#]*find_package\((\w+)\b.*", re.I)
-        pkgconfig = re.compile(r"^[^#]*pkg_check_modules\s*\(\w+ (.*)\)", re.I)
+        pkgconfig = re.compile(r"^[^#]*pkg_check_modules\s*\([\w\-]+ (.*)\)", re.I)
         pkg_search_modifiers = {'REQUIRED', 'QUIET', 'NO_CMAKE_PATH',
                                 'NO_CMAKE_ENVIRONMENT_PATH', 'IMPORTED_TARGET'}
         extractword = re.compile(r'(?:"([^"]+)"|(\S+))(.*)')

--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -518,8 +518,13 @@ class Requirements(object):
         for line in lines:
             if match := findpackage.search(line):
                 module = match.group(1)
-                if pkg := cmake_modules.get(module):
-                    self.add_buildreq(pkg)
+                if pkgs := cmake_modules.get(module):
+                    # Some of the entries in cmake_modules list multiple packages, space-separated, so we need to split.
+                    # Otherwise, anything in buildreq_ban would have to match the entire string, not just a single package name.
+                    # For example: Png2Ico, extra-cmake-modules png2ico
+                    # buildreq_ban would have to contain "extra-cmake-modules png2ico" to match, instead of just "png2ico"
+                    for pkg in pkgs.split():
+                        self.add_buildreq(pkg)
             elif findpackage_multiline.search(line):
                 self.findpackage_parse_lines(line, lines, cmake_modules)
 


### PR DESCRIPTION
When parsing cmake files for find_package dependencies, we match against entries in cmake_modules. Many of the entries of this file list multiple packages, separated by space. Split on whitespace so we actually feed only individual package names to each add_buildreq call.

Otherwise, if cmake_modules provides "extra-cmake-modules png2ico", for example, and you have "png2ico" in buildreq_ban, the specfile would still list both extra-cmake-modules and png2ico as build dependencies, because add_buildreq only compared exact matches.