### PR TITLE
Add handling for emacs jit files

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -303,6 +303,7 @@ class FileManager(object):
             (r"^/usr/lib32/lib(asm|dw|elf)-[0-9.]+\.so", "lib32"),
             (r"^/usr/lib64/haswell/[a-zA-Z0-9._+-]*\.so\.", "lib"),
             (r"^/usr/lib64/gobject-introspection/", "lib"),
+            (r"^/usr/libexec/emacs/", "libexec", "/usr/libexec/emacs/*"),
             (r"^/usr/libexec/", "libexec"),
             (r"^/usr/bin/", "bin"),
             (r"^/usr/sbin/", "bin"),


### PR DESCRIPTION
emacs jit files are dynamically generated names that are under a path like /usr/libexec/emacs/$version/$arch/emacs-$hash.pdmp. Collect these (though there is only 1 per build at this time) files under a single glob to avoid needing to account for the filename changing between builds.