### PR TITLE
Add R-project mirror domain for build pattern detection

### DIFF
--- a/autospec/config.py
+++ b/autospec/config.py
@@ -347,7 +347,7 @@ class Config(object):
     def detect_build_from_url(self, url):
         """Detect build patterns and build requirements from the patterns detected in the url."""
         # R package
-        if "cran.r-project.org" in url or "cran.rstudio.com" in url:
+        if "cran.r-project.org" in url or "cran.rstudio.com" in url or "/pub/cran/" in url:
             self.set_build_pattern("R", 10)
 
         # python

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import config
 # Structure: (url, build_pattern)
 BUILD_PAT_URL = [
     ("https://cran.r-project.org/src/contrib/raster_3.0-12.tar.gz", "R"),
+    ("https://ftp.osuosl.org/pub/cran/src/contrib/hexbin_1.28.5.tar.gz", "R"),
     ("http://pypi.debian.net/argparse/argparse-1.4.0.tar.gz", "distutils3"),
     ("https://pypi.python.org/packages/source/T/Tempita/Tempita-0.5.2.tar.gz", "distutils3"),
     ("https://cpan.metacpan.org/authors/id/T/TO/TODDR/IO-Tty-1.14.tar.gz", "cpan"),


### PR DESCRIPTION
We use ftp.osuosl.org/pub/cran/ as a CRAN mirror, and autospec uses the URL to select the R build pattern, so make sure that URL is also included.