### PR TITLE
Rework cargo pattern use

### DIFF
--- a/autospec/buildreq.py
+++ b/autospec/buildreq.py
@@ -763,7 +763,7 @@ class Requirements(object):
         for dirpath, _, files in os.walk(dirn):
             default_score = 2 if dirpath == dirn else 1
 
-            if "Cargo.toml" in files:
+            if "Cargo.toml" in files and 'Makefile' not in files:
                 config.set_build_pattern('cargo', default_score)
 
             if "CMakeLists.txt" in files and "configure.ac" not in files:

--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -2067,14 +2067,11 @@ class Specfile(object):
         self.write_license_files()
         if self.config.subdir:
             self._write_strip("pushd " + self.config.subdir)
-        if self.config.install_macro:
-            self._write_strip(self.config.install_macro)
-        else:
-            self._write_strip("cargo install --path .")
-            self._write_strip("mkdir -p %{buildroot}/usr/bin")
-            self._write_strip('pushd "${HOME}/.cargo/bin/"')
-            self._write_strip("mv * %{buildroot}/usr/bin/")
-            self._write_strip("popd")
+        self._write_strip("cargo install --path .")
+        self._write_strip("mkdir -p %{buildroot}/usr/bin")
+        self._write_strip('pushd "${HOME}/.cargo/bin/"')
+        self._write_strip("mv * %{buildroot}/usr/bin/")
+        self._write_strip("popd")
         if self.config.subdir:
             self._write_strip("popd")
         self.write_install_append()


### PR DESCRIPTION
In cases where a package has both a Makefile and a Cargo.toml try and use the make pattern (the options.conf flag for cargo vendor still needs to be changed). When the cargo pattern is being used, use cargo install as well. More complex cases likely should just be patched into a Makefile and perhaps submitted upstream.