### PR TITLE
Add file to skip verification for a single version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,12 @@ ${custom}_provides_ban
 Controlling the build process
 ------------------------------
 
+invalid_release_sig
+  This file contains the current version that will **not** have its package
+  file be processed for signature verification (overriding the config_opt).
+  This file will be automatically deleted after a new release and is intended
+  to override a single bad signed release.
+
 extra_sources
   This file contains a list of extra files to be added to the ``.spec`` and
   optionally installed as well. Each non-blank and non-comment line should start

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -837,6 +837,18 @@ class Config(object):
             except Exception as e:
                 print_warning(f"Unable to remove buildreq_cache file: {e}")
 
+        invalid_release_sig_file = os.path.join(self.download_path, "invalid_release_sig")
+        content = self.read_conf_file(invalid_release_sig_file)
+        if content and content[0] == version:
+            self.config_opts['verify_required'] = False
+        else:
+            try:
+                os.unlink(invalid_release_sig_file)
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                print_warning(f"Unable to remove invalid_release_sig file: {e}")
+
         content = self.read_conf_file(os.path.join(self.download_path, "pkgconfig_add"))
         for extra in content:
             extra = pkgconfig_re.sub(r'\1', extra)


### PR DESCRIPTION
Sometimes a package will make a release without verification we support, in these cases it is nice to be able to toggle off verification just for that release. Add a new configuration file that contains the version to not validate.

This file could be extended in the future to support adding specific keys not to use in the verification process in cases where that key has problems (though this might be better left to another configuration file).