### PR TITLE
Fix version parsing for libopenmpt

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -153,7 +153,7 @@ def convert_version(ver_str, name):
     # them out with expensive regular expressions
     banned_subs = ["x86.64", "source", "src", "all", "bin", "release", "rh",
                    "ga", ".ce", "lcms", "onig", "linux", "gc", "sdk", "orig",
-                   "jurko", "%2f", "%2F", "%20", "x265"]
+                   "jurko", "%2f", "%2F", "%20", "x265", "autotools"]
 
     # package names may be modified in the version string by adding "lib" for
     # example. Remove these from the name before trying to remove the name from
@@ -169,7 +169,7 @@ def convert_version(ver_str, name):
         ver_str = ver_str.replace(name.replace(mod, ""), "")
 
     # replace illegal characters
-    ver_str = ver_str.strip().replace('-', '.').replace('_', '.')
+    ver_str = ver_str.strip().replace('-', '.').replace('_', '.').replace('+', '.')
 
     # remove banned substrings
     for sub in banned_subs:

--- a/tests/packageurls
+++ b/tests/packageurls
@@ -1613,3 +1613,4 @@ https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3.11-pigeonhole-0.5.11.tar
 https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.20.tar.gz,pigeonhole,0.5.20
 https://www.ezix.org/software/files/lshw-B.02.19.2.tar.gz,lshw,02.19.2
 https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz,vectorscan,5.4.11
+https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.7.13+release.autotools.tar.gz,libopenmpt,0.7.13


### PR DESCRIPTION
Given tarball libopenmpt-0.7.13+release.autotools.tar.gz, ban 'autotools' from the version number, and replace '+' with '.', so instead of 0.7.13+.autotools, generate simply 0.7.13.