### PR TITLE
Ensure content separation for cargo's config.toml

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -548,7 +548,7 @@ class Specfile(object):
             if self.config.subdir:
                 self._write_strip("pushd " + self.config.subdir)
             self._write_strip("mkdir -p .cargo")
-            self._write_strip(f"echo '{self.config.cargo_vendors}' >> .cargo/config.toml")
+            self._write_strip(f"echo '\n{self.config.cargo_vendors}' >> .cargo/config.toml")
             if self.config.subdir:
                 self._write_strip("popd")
 


### PR DESCRIPTION
The .cargo/config.toml file may exist for a project and the source content configuration that we append needs to have a newline separating it from the existing content.