### PR TITLE
Ignore extraction failures on absolute symlinks

### DIFF
--- a/autospec/tarball.py
+++ b/autospec/tarball.py
@@ -120,7 +120,10 @@ class Source():
             extraction_path = base_path
 
         extract_method = getattr(self, 'extract_{}'.format(self.type))
-        extract_method(extraction_path)
+        try:
+            extract_method(extraction_path)
+        except tarfile.AbsoluteLinkError:
+            pass
 
     def extract_tar(self, extraction_path):
         """Extract tar in path."""


### PR DESCRIPTION
Don't attempt to extract these but let the build continue when source archives have absolute symlinks.