### PR TITLE
Allow requires_ban to override defaults

### DIFF
--- a/autospec/specfiles.py
+++ b/autospec/specfiles.py
@@ -326,6 +326,9 @@ class Specfile(object):
                 self._write("Group: Default\n")
 
             for dep in deps.get(pkg, []):
+                # honor requires_ban for manual overrides
+                if f"{self.name}-{dep}" in self.requirements.banned_requires.get(pkg, []):
+                    continue
                 if dep in self.packages:
                     self._write("Requires: {}-{} = %{{version}}-%{{release}}\n".format(self.name, dep))
 


### PR DESCRIPTION
In cases where a built-in default for a requirement exists (bin requires conf for example) the bin_requires_ban was not honored. This change enables the ban to go into effect.