### PR TITLE
Move hwdb.d files to -config subpackage

### DIFF
--- a/autospec/files.py
+++ b/autospec/files.py
@@ -377,6 +377,7 @@ class FileManager(object):
             (r"^/lib/systemd/user/", "services"),
             (r"^/usr/lib/systemd/system/", "services"),
             (r"^/usr/lib/systemd/user/", "services"),
+            (r"^/usr/lib/udev/hwdb.d", "config"),
             (r"^/usr/lib/udev/rules.d", "config"),
             (r"^/usr/lib/modules-load.d", "config"),
             (r"^/usr/lib/tmpfiles.d", "config"),


### PR DESCRIPTION
These are udev files that really belong with the rules.d files so put them in config as well.