### PR TITLE
Reject /usr and /usr/ as possible rpm files

### DIFF
--- a/autospec/build.py
+++ b/autospec/build.py
@@ -215,6 +215,8 @@ class Build(object):
             elif infiles == 1 and "not matching the package arch" not in line:
                 # exclude blank lines from consideration...
                 file = line.strip()
+                if file in ("/usr", "/usr/"):
+                    self.must_restart += 1
                 if file and file[0] == "/":
                     filemanager.push_file(file, content.name)
 

--- a/autospec/count.py
+++ b/autospec/count.py
@@ -71,14 +71,8 @@ def sanitize_counts():
     """Validate test counts are within sane bounds."""
     global total_tests
     global total_pass
-    global total_fail
-    global total_xfail
-    global total_skip
     global counted_tests
     global counted_pass
-    global counted_fail
-    global counted_xfail
-    global counted_skip
     if total_tests > 0 and total_pass == 0:
         total_pass = total_tests - total_fail - total_skip - total_xfail
 
@@ -170,7 +164,6 @@ def parse_log(log, pkgname=''):
     global total_fail
     global total_xfail
     global total_skip
-    global counted_tests
     global counted_pass
     global counted_fail
     global counted_xfail

--- a/autospec/license.py
+++ b/autospec/license.py
@@ -55,8 +55,6 @@ def add_license(lic, translations, blacklist):
     presence in the blacklist. Returns False if no license were added, True
     otherwise.
     """
-    global licenses
-    global license_files
     lic = lic.strip().strip(',')
     result = False
 
@@ -208,9 +206,6 @@ def scan_for_licenses(srcdir, config, pkg_name):
 
 def load_specfile(specfile):
     """Get licenses from the specfile content."""
-    global licenses
-    global license_files
-    global hashes
     specfile.licenses = licenses if licenses else [default_license]
     specfile.license_files = sorted(license_files)
     specfile.hashes = hashes

--- a/autospec/pkg_integrity.py
+++ b/autospec/pkg_integrity.py
@@ -96,7 +96,7 @@ class GPGCli(object):
         util.write_out(os.path.join(_gpghome, 'gpg.conf'), GNUPGCONF)
         if pubkey is not None:
             args = self.args + ['--import', pubkey]
-            output, err, code = self.exec_cmd(args)
+            _, err, code = self.exec_cmd(args)
             if code == -9:
                 raise Exception('Command {} timeout after {} seconds'.format(' '.join(args), CMD_TIMEOUT))
             elif code != 0:
@@ -212,16 +212,15 @@ class Verifier(object):
     @staticmethod
     def calc_sum(filepath, digest_algo):
         """Use digest_algo to calculate block sum of a file."""
-        BLOCK_SIZE = 4096
+        block_size = 4096
         with open(filepath, 'rb') as fp:
             digest = digest_algo()
-            for block in iter(lambda: fp.read(BLOCK_SIZE), b''):
+            for block in iter(lambda: fp.read(block_size), b''):
                 digest.update(block)
             return digest.hexdigest()
 
     def print_result(self, result, err_msg=''):
         """Display verification results."""
-        global EMAIL
         package_name = ''
         if self.url is not None:
             package_name = os.path.basename(self.url)

--- a/autospec/util.py
+++ b/autospec/util.py
@@ -156,7 +156,6 @@ def _file_write(self, s):
 
 def translate(package):
     """Convert terms to their alternate definition."""
-    global dictionary
     for item in dictionary:
         if item.startswith(package + "="):
             return item.split("=")[1]


### PR DESCRIPTION
These should not be handled paths for autospec. This is a bit of a hack to work around the rpm build logs being incomplete however and might be worth reverting if the log issue is fixed.