### PR TITLE
Add has_license config

### DIFF
--- a/autospec/autospec.py
+++ b/autospec/autospec.py
@@ -277,6 +277,9 @@ def package(args, url, name, archives, workingdir):
             # specfile template is assumed "correct" and any failures need to be manually addressed
             break
         filemanager.load_specfile(specfile)
+        if 'license' in specfile.packages and not conf.config_opts['has_license']:
+            conf.config_opts['has_license'] = True
+            conf.rewrite_config_opts()
         specfile.write_spec()
         filemanager.newfiles_printed = 0
         mock_chroot = "/var/lib/mock/clear-{}/root/builddir/build/BUILDROOT/" \
@@ -296,6 +299,10 @@ def package(args, url, name, archives, workingdir):
     if package.success == 0:
         conf.create_buildreq_cache(content.version, requirements.buildreqs_cache)
         print_build_failed()
+        sys.exit(1)
+    elif 'license' not in specfile.packages and conf.config_opts['has_license']:
+        print_fatal("package -license subpackage deleted")
+        conf.create_buildreq_cache(content.version, requirements.buildreqs_cache)
         sys.exit(1)
     elif os.path.isfile("README.clear"):
         try:

--- a/autospec/config.py
+++ b/autospec/config.py
@@ -193,6 +193,7 @@ class Config(object):
             "no_glob": "Do not use the replacement pattern for file matching",
             "allow_exe": "Allow Windows executables (*.exe, *.dll) to be packaged",
             "use_ninja": "Use ninja build files",
+            "has_license": "Require license subpackage for successful build",
         }
         # simple_pattern_pkgconfig patterns
         # contains patterns for parsing build.log for missing dependencies


### PR DESCRIPTION
In cases where a package's license subpackage disappears, prefer failing the build as it should have some manual investigation.